### PR TITLE
fix(frontend): beperk corpus-indexfout tot de bibliotheek

### DIFF
--- a/frontend/src/LibraryView.indexErrorTakeover.repro.test.js
+++ b/frontend/src/LibraryView.indexErrorTakeover.repro.test.js
@@ -34,13 +34,22 @@ vi.mock('./composables/useAuth.js', () => ({
   useAuth: () => ({ authenticated: ref(true), login: vi.fn() }),
 }));
 
-vi.mock('./composables/useTrajects.js', () => ({
-  useTrajects: () => ({
-    activeTrajectRef: ref('traject-abcd1234'),
-    activeTraject: ref({ name: 'Afgeschermde test Kandidaatstellingsprocedure Kieswet' }),
-  }),
-  refreshTrajects: vi.fn(),
-}));
+// Held in a hoisted box so a test can switch traject in-place: the traject
+// switcher leaves LibraryView mounted and only swaps the route param, which is
+// what LibraryView's `watch(activeTrajectRef)` reacts to. (`vi.mock` factories
+// are hoisted above module-level consts, hence `vi.hoisted`.)
+const { trajectScope } = vi.hoisted(() => ({ trajectScope: {} }));
+
+vi.mock('./composables/useTrajects.js', () => {
+  trajectScope.activeTrajectRef = ref('traject-abcd1234');
+  return {
+    useTrajects: () => ({
+      activeTrajectRef: trajectScope.activeTrajectRef,
+      activeTraject: ref({ name: 'Afgeschermde test Kandidaatstellingsprocedure Kieswet' }),
+    }),
+    refreshTrajects: vi.fn(),
+  };
+});
 
 // The 502 body below is the backend's own text for a traject whose
 // writable-own (private) repo could not be scanned - see
@@ -159,6 +168,7 @@ beforeEach(() => {
   routeState.name = 'taken-traject';
   routeState.params = { trajectRef: 'traject-abcd1234', categorie: 'alle' };
   routeState.query = {};
+  trajectScope.activeTrajectRef.value = 'traject-abcd1234';
 });
 
 // The warning banner LibraryView now raises over the non-library modes.
@@ -221,6 +231,55 @@ describe('LibraryView index-error scoping', () => {
     const wrapper = await mountAfterFailedIndex();
     expect(wrapper.findComponent({ name: 'TrajectDetailsPane' }).exists()).toBe(true);
     expect(wrapper.html()).toContain(BANNER_TEXT);
+    routeState.name = 'taken-traject';
+    routeState.params = { trajectRef: 'traject-abcd1234', categorie: 'alle' };
+  });
+
+  it('keeps the WERKDOCUMENTEN route standing under a corpus 502', async () => {
+    routeState.name = 'werkdocumenten-traject';
+    routeState.params = { trajectRef: 'traject-abcd1234' };
+    const wrapper = await mountAfterFailedIndex();
+    // Werkdocumenten live in the traject repo's docs tree, not in the
+    // wettenindex, so the document list has to survive the corpus 502 too.
+    expect(wrapper.find('nldd-navigation-split-view').exists()).toBe(true);
+    expect(wrapper.html()).not.toContain(FULLSCREEN_TEXT);
+    expect(wrapper.html()).toContain(BANNER_TEXT);
+    routeState.name = 'taken-traject';
+    routeState.params = { trajectRef: 'traject-abcd1234', categorie: 'alle' };
+  });
+
+  // The banner/takeover must track the scope it belongs to. `retryLoadCorpus`
+  // clears the error itself, but the traject switcher reaches `loadIndex()`
+  // through `watch(activeTrajectRef)` - if only the retry path cleared the
+  // error, switching away from a broken traject would carry its error onto a
+  // perfectly healthy one.
+  it('drops the error when switching to a healthy traject (banner does not stick)', async () => {
+    const wrapper = await mountAfterFailedIndex();
+    expect(wrapper.html()).toContain(BANNER_TEXT);
+
+    // Same view, other traject - and this one indexes fine.
+    apiFetch.mockImplementation(async () => ({ ok: true, status: 200, json: async () => [] }));
+    routeState.params = { trajectRef: 'traject-99998888', categorie: 'alle' };
+    trajectScope.activeTrajectRef.value = 'traject-99998888';
+    for (let i = 0; i < 6; i++) await nextTick();
+
+    expect(wrapper.html()).not.toContain(BANNER_TEXT);
+    expect(wrapper.find('nldd-banner.corpus-warning').exists()).toBe(false);
+    expect(wrapper.findComponent({ name: 'TasksCategoriesPane' }).exists()).toBe(true);
+  });
+
+  it('drops the fullscreen takeover when switching to a healthy traject', async () => {
+    routeState.name = 'library-traject';
+    routeState.params = { trajectRef: 'traject-abcd1234' };
+    const wrapper = await mountAfterFailedIndex();
+    expect(wrapper.html()).toContain(FULLSCREEN_TEXT);
+
+    apiFetch.mockImplementation(async () => ({ ok: true, status: 200, json: async () => [] }));
+    routeState.params = { trajectRef: 'traject-99998888' };
+    trajectScope.activeTrajectRef.value = 'traject-99998888';
+    for (let i = 0; i < 6; i++) await nextTick();
+
+    expect(wrapper.html()).not.toContain(FULLSCREEN_TEXT);
     routeState.name = 'taken-traject';
     routeState.params = { trajectRef: 'traject-abcd1234', categorie: 'alle' };
   });

--- a/frontend/src/LibraryView.indexErrorTakeover.repro.test.js
+++ b/frontend/src/LibraryView.indexErrorTakeover.repro.test.js
@@ -1,0 +1,270 @@
+// Guards the fix for the 2026-07-29 bug report "taakmenu crasht na ophalen
+// wetgeving in private repo": when the traject-scoped corpus listing fails
+// (502 because the traject's writable-own repo could not be scanned),
+// LibraryView's top-level index-error pane used to take over the WHOLE route -
+// including /taken and /instellingen/details, which do not read the corpus
+// index at all. After the fix the takeover is gated to library mode; the
+// non-library modes keep their panes and get a non-blocking warning banner,
+// and the backend's own explanation is surfaced instead of a generic fallback.
+//
+// Harness copied from LibraryView.conversionJobs.test.js: shallow-mount with
+// every composable stubbed, deliberately narrow to this one surface.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref, nextTick } from 'vue';
+
+const routeState = {
+  name: 'taken-traject',
+  params: { trajectRef: 'traject-abcd1234', categorie: 'alle' },
+  query: {},
+  fullPath: '/trajecten/traject-abcd1234/taken',
+};
+vi.mock('vue-router', () => ({
+  useRoute: () => routeState,
+  useRouter: () => ({
+    replace: vi.fn().mockResolvedValue(undefined),
+    push: vi.fn(),
+    resolve: () => ({ href: '#' }),
+  }),
+  onBeforeRouteUpdate: vi.fn(),
+  onBeforeRouteLeave: vi.fn(),
+}));
+
+vi.mock('./composables/useAuth.js', () => ({
+  useAuth: () => ({ authenticated: ref(true), login: vi.fn() }),
+}));
+
+vi.mock('./composables/useTrajects.js', () => ({
+  useTrajects: () => ({
+    activeTrajectRef: ref('traject-abcd1234'),
+    activeTraject: ref({ name: 'Afgeschermde test Kandidaatstellingsprocedure Kieswet' }),
+  }),
+  refreshTrajects: vi.fn(),
+}));
+
+// The 502 body below is the backend's own text for a traject whose
+// writable-own (private) repo could not be scanned - see
+// `require_traject_index` in corpus_handlers.rs.
+//
+// `vi.mock` factories are hoisted above module-level consts, so the shared
+// stubs have to be hoisted too.
+const { ApiErrorStub, apiFetch, apiFetchJson } = vi.hoisted(() => {
+  class ApiErrorStub extends Error {
+    constructor(message, { status, body = '' } = {}) {
+      super(message);
+      this.name = 'ApiError';
+      this.status = status;
+      this.body = body;
+    }
+  }
+  const BODY =
+    'De bibliotheek van dit traject is niet beschikbaar: de traject-repo kon niet ' +
+    'worden gescand (Trees API for org/afgeschermd-traject@main: 409)';
+  const fail = () => {
+    throw new ApiErrorStub('Failed to load corpus: 502', { status: 502, body: BODY });
+  };
+  // Every traject-scoped corpus call fails; favorites/changed-laws resolve
+  // (they swallow their own errors anyway, so failing them would prove nothing
+  // about the takeover).
+  return {
+    ApiErrorStub,
+    apiFetch: vi.fn(async (url) => {
+      if (String(url).includes('/corpus/laws')) fail();
+      return { ok: true, status: 200, json: async () => [] };
+    }),
+    apiFetchJson: vi.fn(async (url) => {
+      if (String(url).includes('/corpus/laws')) fail();
+      return [];
+    }),
+  };
+});
+
+vi.mock('./lib/apiFetch.js', () => ({
+  apiFetch: (...a) => apiFetch(...a),
+  apiFetchJson: (...a) => apiFetchJson(...a),
+  ApiError: ApiErrorStub,
+}));
+
+vi.mock('./composables/useFeatureFlags.js', () => ({
+  useFeatureFlags: () => ({ isEnabled: () => true }),
+}));
+
+vi.mock('./composables/useDocumentsManager.js', () => ({
+  useDocumentsManager: () => ({
+    documents: ref([]),
+    listLoading: ref(false),
+    listError: ref(null),
+    currentPath: ref(null),
+    currentBody: ref(''),
+    hasChanges: ref(false),
+    docLoading: ref(false),
+    docError: ref(null),
+    saving: ref(false),
+    open: vi.fn(),
+    startNew: vi.fn(),
+    close: vi.fn(),
+    uploadDocument: vi.fn(),
+    displayTitle: (p) => String(p ?? '').replace(/\.md$/, ''),
+    dropDraft: vi.fn(),
+    refreshList: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock('./composables/useTrajectDocumentJobs.js', () => ({
+  useTrajectDocumentJobs: () => ({
+    jobs: ref([]),
+    cancelJob: vi.fn(),
+    refresh: vi.fn(),
+    startPolling: vi.fn(),
+    stopPolling: vi.fn(),
+  }),
+}));
+
+vi.mock('./composables/useDocumentUpload.js', () => ({
+  useDocumentUpload: () => ({
+    fileInput: ref(null),
+    uploadError: ref(null),
+    uploadRetryable: ref(false),
+    onUpload: vi.fn(),
+    onFileChange: vi.fn(),
+  }),
+}));
+
+vi.mock('./composables/useDocumentTaskReview.js', () => ({
+  useDocumentTaskReview: () => ({
+    reviewTask: ref(null),
+    proposedContent: ref(null),
+    loadError: ref(null),
+    loadReview: vi.fn().mockResolvedValue(undefined),
+    approveAfterSave: vi.fn(),
+    reject: vi.fn(),
+  }),
+}));
+
+import LibraryView from './LibraryView.vue';
+
+async function mountAfterFailedIndex() {
+  const wrapper = shallowMount(LibraryView, { global: { stubs: { teleport: true } } });
+  await nextTick();
+  await nextTick();
+  await nextTick();
+  return wrapper;
+}
+
+const defaultApiFetch = apiFetch.getMockImplementation();
+
+beforeEach(() => {
+  apiFetch.mockClear().mockImplementation(defaultApiFetch);
+  apiFetchJson.mockClear();
+  routeState.name = 'taken-traject';
+  routeState.params = { trajectRef: 'traject-abcd1234', categorie: 'alle' };
+  routeState.query = {};
+});
+
+// The warning banner LibraryView now raises over the non-library modes.
+const BANNER_TEXT = 'Wetten en regels van dit traject zijn niet geladen';
+// The fullscreen takeover that still owns the library routes themselves.
+const FULLSCREEN_TEXT = 'Wetten en regels zijn niet geladen';
+
+describe('LibraryView index-error scoping', () => {
+  it('probes the traject corpus even with nothing curated (fresh private repo)', async () => {
+    await mountAfterFailedIndex();
+    // No favorites, no changed laws => the ids set is empty, but LibraryView
+    // still probes `?limit=1` so a broken traject repo is not shown as a
+    // normal-looking empty library.
+    expect(apiFetch).toHaveBeenCalledWith(
+      '/api/trajects/traject-abcd1234/corpus/laws?limit=1',
+      expect.anything(),
+    );
+  });
+
+  it('keeps the TAKEN route standing and shows a non-blocking warning banner', async () => {
+    const wrapper = await mountAfterFailedIndex();
+    // The task panes survive the unrelated 502 - the user can still work.
+    expect(wrapper.findComponent({ name: 'TasksCategoriesPane' }).exists()).toBe(true);
+    expect(wrapper.findComponent({ name: 'TasksListPane' }).exists()).toBe(true);
+    const html = wrapper.html();
+    // ...with a warning banner instead of the fullscreen takeover.
+    expect(html).toContain(BANNER_TEXT);
+    const banner = wrapper.find('nldd-banner.corpus-warning');
+    expect(banner.exists()).toBe(true);
+    expect(banner.attributes('variant')).toBe('warning');
+  });
+
+  it('keeps the taken panes even when the corpus call fails mid-flight (no flash)', async () => {
+    let rejectCorpus;
+    apiFetch.mockImplementation(async (url) => {
+      if (String(url).includes('/corpus/laws')) {
+        return new Promise((_, rej) => {
+          rejectCorpus = () =>
+            rej(new ApiErrorStub('Failed to load corpus: 502', { status: 502, body: 'kapot' }));
+        });
+      }
+      return { ok: true, status: 200, json: async () => [] };
+    });
+    const wrapper = shallowMount(LibraryView, { global: { stubs: { teleport: true } } });
+    await nextTick();
+    await nextTick();
+    // The task list is on screen while the corpus probe is still in flight...
+    expect(wrapper.findComponent({ name: 'TasksCategoriesPane' }).exists()).toBe(true);
+    rejectCorpus();
+    for (let i = 0; i < 5; i++) await nextTick();
+    // ...and it stays put once the unrelated corpus call fails - only the
+    // warning banner appears on top.
+    expect(wrapper.findComponent({ name: 'TasksCategoriesPane' }).exists()).toBe(true);
+    expect(wrapper.html()).toContain(BANNER_TEXT);
+  });
+
+  it('keeps the INSTELLINGEN route standing under a corpus 502', async () => {
+    routeState.name = 'instellingen-traject';
+    routeState.params = { trajectRef: 'traject-abcd1234', tab: 'details' };
+    const wrapper = await mountAfterFailedIndex();
+    expect(wrapper.findComponent({ name: 'TrajectDetailsPane' }).exists()).toBe(true);
+    expect(wrapper.html()).toContain(BANNER_TEXT);
+    routeState.name = 'taken-traject';
+    routeState.params = { trajectRef: 'traject-abcd1234', categorie: 'alle' };
+  });
+
+  it('still shows the fullscreen index-error page on the library route itself', async () => {
+    routeState.name = 'library-traject';
+    routeState.params = { trajectRef: 'traject-abcd1234' };
+    const wrapper = await mountAfterFailedIndex();
+    const html = wrapper.html();
+    // The library route DOES depend on the index, so it keeps the fullscreen
+    // takeover (unchanged) - and does not fall back to the warning banner.
+    expect(html).toContain(FULLSCREEN_TEXT);
+    expect(wrapper.find('nldd-banner.corpus-warning').exists()).toBe(false);
+    routeState.name = 'taken-traject';
+    routeState.params = { trajectRef: 'traject-abcd1234', categorie: 'alle' };
+  });
+
+  it('surfaces the backend explanation while it fits the cap', async () => {
+    const wrapper = await mountAfterFailedIndex();
+    expect(wrapper.html()).toContain('traject-repo kon niet worden gescand');
+  });
+
+  it('still surfaces the backend reason once GitHub\'s JSON body pushes it long', async () => {
+    // What a real 409 "Git Repository is empty" looks like once the Trees
+    // error body is interpolated into the 502 message. The old 300-char cap
+    // dropped this whole sentence to the useless generic fallback (the bug
+    // report's screenshots); it must now come through, clamped.
+    const githubBody =
+      '{"message":"Git Repository is empty.","documentation_url":' +
+      '"https://docs.github.com/rest/git/trees/trees#get-a-tree","status":"409"}';
+    const long =
+      'De bibliotheek van dit traject is niet beschikbaar: de traject-repo kon niet ' +
+      `worden gescand (GitHub API error 409: Trees API for example-org/regelrecht-corpus-example@main: ${githubBody})`;
+    expect(long.length).toBeGreaterThan(300);
+    apiFetch.mockImplementation(async (url) => {
+      if (String(url).includes('/corpus/laws')) {
+        throw new ApiErrorStub('Failed to load corpus: 502', { status: 502, body: long });
+      }
+      return { ok: true, status: 200, json: async () => [] };
+    });
+    const wrapper = await mountAfterFailedIndex();
+    const html = wrapper.html();
+    // The reason reaches the user instead of "De gegevens konden niet worden opgehaald."
+    expect(html).toContain('traject-repo kon niet worden gescand');
+    expect(html).not.toContain('De gegevens konden niet worden opgehaald');
+  });
+});

--- a/frontend/src/LibraryView.vue
+++ b/frontend/src/LibraryView.vue
@@ -436,6 +436,16 @@ const takenTitle = computed(() => {
 // --- Instellingen (traject details + leden, folded into Home) ---------------
 const isInstellingenMode = computed(() => route.name === 'instellingen-traject');
 const instellingenTab = computed(() => route.params.tab || null);
+
+// True on the library routes proper (/trajecten/{ref} and /corpus/…) - i.e.
+// none of the sibling non-corpus modes that LibraryView also hosts. Kept as one
+// computed so the "no usable content" states below (initial-loading,
+// empty-library and, crucially, the index-error takeover) can't drift apart:
+// a failed corpus index must only take over the library itself, never /taken,
+// /instellingen or /werkdocumenten, which don't read the wettenindex at all.
+const isLibraryMode = computed(
+  () => !isWerkdocMode.value && !isInstellingenMode.value && !isTakenMode.value,
+);
 function goToInstellingen(tab) {
   if (!activeTrajectRef.value) return;
   router.push({ name: 'instellingen-traject', params: { trajectRef: activeTrajectRef.value, tab } });
@@ -918,23 +928,35 @@ const sidebarSections = computed(() => {
 // width rather than the narrow sidebar. isInitialLoading covers the first load
 // before anything resolves; indexError is handled at the same top level.
 const isInitialLoading = computed(
-  () => loading.value && !selectedLawId.value && sidebarSections.value.length === 0 && !isWerkdocMode.value && !isInstellingenMode.value && !isTakenMode.value,
+  () => loading.value && !selectedLawId.value && sidebarSections.value.length === 0 && isLibraryMode.value,
 );
 const isEmptyLibrary = computed(
-  () => !loading.value && !indexError.value && !selectedLawId.value && sidebarSections.value.length === 0 && !isWerkdocMode.value && !isInstellingenMode.value && !isTakenMode.value,
+  () => !loading.value && !indexError.value && !selectedLawId.value && sidebarSections.value.length === 0 && isLibraryMode.value,
 );
 
-// Supporting text for the index-error pane: prefer the backend's own
-// (Dutch) explanation — e.g. "De bibliotheek van dit traject is niet
-// beschikbaar: de traject-repo kon niet worden gescand (…)" — over the
-// generic fallback. Length-capped so an unexpected HTML/stack body from
-// an intermediary never floods the dialog.
+// Longest backend explanation we'll surface verbatim before clamping. The real
+// 502 body is the backend's own Dutch sentence ("De bibliotheek van dit traject
+// is niet beschikbaar: de traject-repo kon niet worden gescand (…)") with
+// GitHub's Trees error interpolated, which comfortably exceeds a few hundred
+// chars; the old 300 cap silently dropped the whole thing to the useless
+// generic fallback. Clamp-with-ellipsis instead so the reason still reaches the
+// user while a runaway body can't flood the dialog.
+const INDEX_ERROR_MAX_CHARS = 600;
+
+// Supporting text for the index-error surfaces (fullscreen pane + non-library
+// warning banner): prefer the backend's own (Dutch) explanation over the
+// generic fallback. The `<`/`{` guard still rejects an HTML/JSON body from an
+// intermediary proxy (those start with those chars) so a raw proxy dump never
+// leaks; a human-readable sentence with JSON interpolated *inside* it does not
+// start with either and comes through, clamped to a clean length.
 const indexErrorSupportingText = computed(() => {
   const body = indexError.value?.body;
   if (typeof body === 'string') {
     const text = body.trim();
-    if (text && text.length <= 300 && !text.startsWith('<') && !text.startsWith('{')) {
-      return text;
+    if (text && !text.startsWith('<') && !text.startsWith('{')) {
+      return text.length <= INDEX_ERROR_MAX_CHARS
+        ? text
+        : `${text.slice(0, INDEX_ERROR_MAX_CHARS).trimEnd()}…`;
     }
   }
   return 'De gegevens konden niet worden opgehaald.';
@@ -1770,10 +1792,32 @@ watch(activeTrajectRef, () => {
              back as a reviewable markdown werkdocument. -->
         <input ref="docFileInput" type="file" hidden @change="onDocFileChange" />
 
+        <!-- Non-blocking corpus warning for the non-library modes (/taken,
+             /instellingen, /werkdocumenten): those don't read the wettenindex,
+             so a corpus 502 leaves their panes standing (the fullscreen page
+             below is gated to library mode) and they get this banner instead.
+             Rendered as a sibling above the split-view so it spans all panes
+             rather than sitting in the narrow sidebar; the .corpus-warning rule
+             keeps it auto-height (the app main pane slots its children flex:1).
+             It clears itself the moment a retry repopulates the index
+             (retryLoadCorpus → indexError becomes null). -->
+        <nldd-banner
+          v-if="indexError && !isLibraryMode"
+          class="corpus-warning"
+          variant="warning"
+          text="Wetten en regels van dit traject zijn niet geladen"
+          :supporting-text="indexErrorSupportingText"
+        >
+          <nldd-button slot="actions" variant="secondary" text="Probeer opnieuw" @click="retryLoadCorpus"></nldd-button>
+        </nldd-banner>
+
         <!-- Full-page "no usable content" states (matching EditorView): shown
              instead of the split-view so the error / CTA spans the full width,
-             not the narrow sidebar. -->
-        <nldd-page v-if="indexError">
+             not the narrow sidebar. The index-error takeover is gated to
+             library mode: /taken, /instellingen and /werkdocumenten don't read
+             the wettenindex, so a corpus 502 must leave them standing (they get
+             the non-blocking warning banner above instead). -->
+        <nldd-page v-if="indexError && isLibraryMode">
           <nldd-simple-section width="full">
             <nldd-inline-dialog
               variant="alert"
@@ -2487,5 +2531,15 @@ nldd-navigation-split-view:not(.full-stack) .article-not-found__back-button {
    :not([hidden]) yields to the toolbar's own overflow hiding. */
 .job-back:not([hidden]) {
   display: var(--context-back-button-display, inline-flex);
+}
+
+/* The corpus-warning banner is a light-DOM sibling of the navigation-split-view,
+   so it lands in AppShell's main split-view-pane, whose `::slotted(*)` sets
+   `flex: 1`. Left as-is the banner would grow to eat half the pane; pin it to
+   its content height so it reads as a thin bar above the panes and the
+   split-view keeps the remaining space. Unscoped for the same reason as the
+   rule above (the class is reflected from light-DOM space). */
+nldd-banner.corpus-warning {
+  flex: 0 0 auto;
 }
 </style>

--- a/frontend/src/LibraryView.vue
+++ b/frontend/src/LibraryView.vue
@@ -1257,6 +1257,14 @@ const claimLoadIndex = useLatest();
 
 async function loadIndex() {
   const isCurrent = claimLoadIndex();
+  // Drop any previous scope's failure before we start. The error describes one
+  // specific index load, so it must not outlive the run that produced it:
+  // besides `retryLoadCorpus`, `loadIndex` is also reached from the
+  // `activeTrajectRef` watcher, and without this a broken traject's error would
+  // ride along to the next traject the user switches to - warning about (or,
+  // on the library routes, blocking) a traject whose wetten loaded fine. The
+  // `catch` below re-raises it for this run if this load fails too.
+  indexError.value = null;
   // Snapshot the traject so the changed-laws fetch and its assignment below
   // both refer to the scope this run started in.
   const trajectRef = activeTrajectRef.value;
@@ -1358,11 +1366,11 @@ function retryLoadLaw() {
 }
 
 function retryLoadCorpus() {
-  indexError.value = null;
-  // loadIndex only flips loading back to false in its finally block -
-  // it never sets it to true. So after the first failure (loading is
-  // false, indexError is truthy) we have to flip the spinner back on
-  // here, otherwise the retry shows the error pane until the next
+  // Clearing indexError is loadIndex's job (it does so for every caller, not
+  // just this one). loading is not: loadIndex only flips it back to false in
+  // its finally block, it never sets it to true. So after the first failure
+  // (loading is false, indexError is truthy) we have to flip the spinner back
+  // on here, otherwise the retry shows the error pane until the next
   // round-trip resolves.
   loading.value = true;
   loadIndex();
@@ -1799,8 +1807,9 @@ watch(activeTrajectRef, () => {
              Rendered as a sibling above the split-view so it spans all panes
              rather than sitting in the narrow sidebar; the .corpus-warning rule
              keeps it auto-height (the app main pane slots its children flex:1).
-             It clears itself the moment a retry repopulates the index
-             (retryLoadCorpus → indexError becomes null). -->
+             It clears itself the moment any index load starts over - a retry
+             here, or a switch to another traject - and stays gone unless that
+             load fails too (loadIndex resets indexError up front). -->
         <nldd-banner
           v-if="indexError && !isLibraryMode"
           class="corpus-warning"
@@ -2534,11 +2543,13 @@ nldd-navigation-split-view:not(.full-stack) .article-not-found__back-button {
 }
 
 /* The corpus-warning banner is a light-DOM sibling of the navigation-split-view,
-   so it lands in AppShell's main split-view-pane, whose `::slotted(*)` sets
-   `flex: 1`. Left as-is the banner would grow to eat half the pane; pin it to
-   its content height so it reads as a thin bar above the panes and the
-   split-view keeps the remaining space. Unscoped for the same reason as the
-   rule above (the class is reflected from light-DOM space). */
+   so it is slotted straight into AppShell's main split-view-pane, whose
+   `::slotted(*)` sets `flex: 1` on every slotted child. Left as-is the banner
+   would grow to eat half the pane; pin it to its content height so it reads as
+   a thin bar above the panes and the split-view keeps the remaining space.
+   (Unlike the rules above this one would also work scoped - it targets an
+   element in this component's own template - but this whole block is global,
+   so it is stated plainly rather than singled out.) */
 nldd-banner.corpus-warning {
   flex: 0 0 auto;
 }

--- a/frontend/src/components/AddLawSheet.test.js
+++ b/frontend/src/components/AddLawSheet.test.js
@@ -155,6 +155,29 @@ describe('AddLawSheet', () => {
     expect(row.get('nldd-text-cell').attributes('text')).toBe('Voorbeeldwet extern');
   });
 
+  // De zoekopdracht gaat naar `/api/trajects/{ref}/corpus/laws`, dus een
+  // mislukte zoekopdracht gaat over de bibliotheek van dít traject - niet over
+  // het centrale corpus. De melding moet daar ook naar wijzen, ook wanneer de
+  // trajectenlijst (en dus de naam) nog niet binnen is: de scope hangt aan de
+  // ref uit de route, niet aan het opgehaalde traject-object.
+  it('wijst bij een mislukte zoekopdracht naar het traject, niet naar het centrale corpus', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url) => {
+        const u = String(url);
+        if (u.startsWith(`/api/trajects/${TRAJECT_REF}/corpus/laws`)) throw new Error('boom');
+        return { ok: true, json: async () => [] };
+      }),
+    );
+    const wrapper = mount(AddLawSheet);
+    await searchFor(wrapper, 'wet');
+
+    const dialog = wrapper.get('nldd-inline-dialog[text="Zoeken is mislukt"]');
+    const supporting = dialog.attributes('supporting-text');
+    expect(supporting).toContain('bibliotheek van dit traject');
+    expect(supporting).not.toContain('centrale corpus');
+  });
+
   it('start een traject-scoped harvest voor een BWB-resultaat en emit "harvest-requested"', async () => {
     const wrapper = mount(AddLawSheet);
     await wrapper.vm.requestTrajectHarvest('BWBR0002399', 'Voorbeeldwet extern');

--- a/frontend/src/components/AddLawSheet.vue
+++ b/frontend/src/components/AddLawSheet.vue
@@ -58,13 +58,23 @@ const searchFailed = ref(false);
 // The search is traject-scoped whenever a traject is active (see `runSearch`:
 // it hits `/api/trajects/{ref}/corpus/laws`), so a failure is about *this
 // traject's* library - its own repo could not be scanned - not the central
-// corpus. Name the traject so the user knows where to look; fall back to the
-// central-corpus wording only when there's no active traject.
-const searchFailedText = computed(() =>
-  activeTraject.value?.name
-    ? `De bibliotheek van ${activeTraject.value.name} kon niet worden doorzocht. Probeer het opnieuw.`
-    : 'Het centrale corpus kon niet worden doorzocht. Probeer het opnieuw.',
-);
+// corpus. What decides the scope is `activeTrajectRef` (read straight from the
+// route, so it is there from the first render), NOT `activeTraject`: that one
+// is looked up in the asynchronously loaded trajects list and is still null
+// while the list is in flight, or when the list request itself failed. Keying
+// the wording on the name alone would point the user at the central corpus for
+// a request that never went there. So: name the traject when we know it, say
+// "dit traject" when we only know there is one, and keep the central-corpus
+// wording strictly for the no-traject search.
+const searchFailedText = computed(() => {
+  if (!activeTrajectRef.value) {
+    return 'Het centrale corpus kon niet worden doorzocht. Probeer het opnieuw.';
+  }
+  const scope = activeTraject.value?.name
+    ? `van ${activeTraject.value.name}`
+    : 'van dit traject';
+  return `De bibliotheek ${scope} kon niet worden doorzocht. Probeer het opnieuw.`;
+});
 
 // Gedeelde promote-logica (ook gebruikt door de gewone zoekresultaten in
 // SearchPopover): per-wet busy-state, al-in-traject-set, 409-afhandeling.

--- a/frontend/src/components/AddLawSheet.vue
+++ b/frontend/src/components/AddLawSheet.vue
@@ -33,7 +33,7 @@ import { useLatest } from '../lib/useLatest.js';
 
 const emit = defineEmits(['promoted', 'harvest-requested', 'upload-requested']);
 
-const { activeTrajectRef } = useTrajects();
+const { activeTrajectRef, activeTraject } = useTrajects();
 const { results: bwbResults, loading: bwbLoading, search: searchBwb, clear: clearBwb } = useBwbSearch();
 
 const search = ref('');
@@ -54,6 +54,17 @@ function onModeChange(e) {
 const centralLaws = ref([]);
 const searching = ref(false);
 const searchFailed = ref(false);
+
+// The search is traject-scoped whenever a traject is active (see `runSearch`:
+// it hits `/api/trajects/{ref}/corpus/laws`), so a failure is about *this
+// traject's* library - its own repo could not be scanned - not the central
+// corpus. Name the traject so the user knows where to look; fall back to the
+// central-corpus wording only when there's no active traject.
+const searchFailedText = computed(() =>
+  activeTraject.value?.name
+    ? `De bibliotheek van ${activeTraject.value.name} kon niet worden doorzocht. Probeer het opnieuw.`
+    : 'Het centrale corpus kon niet worden doorzocht. Probeer het opnieuw.',
+);
 
 // Gedeelde promote-logica (ook gebruikt door de gewone zoekresultaten in
 // SearchPopover): per-wet busy-state, al-in-traject-set, 409-afhandeling.
@@ -378,7 +389,7 @@ defineExpose({ show });
               v-else-if="searchFailed"
               variant="alert"
               text="Zoeken is mislukt"
-              supporting-text="Het centrale corpus kon niet worden doorzocht. Probeer het opnieuw."
+              :supporting-text="searchFailedText"
             ></nldd-inline-dialog>
             <nldd-inline-dialog
               v-else-if="bwbLoading"


### PR DESCRIPTION
## Waarom

Een mislukte corpus-index (een 502 op de traject-wettenlijst, bijvoorbeeld
wanneer de eigen repo van een traject niet gescand kon worden) kaapte de hele
LibraryView-route. Ook `/taken`, `/instellingen` en `/werkdocumenten` — schermen
die de wettenindex helemaal niet gebruiken — werden overruled door de fullscreen
foutpagina. De gebruiker kon dan niets meer en zag alleen "De gegevens konden
niet worden opgehaald", zonder enige aanwijzing dat het om de traject-repo ging.

## Wat

- **Scope de indexfout tot de bibliotheek.** Eén computed `isLibraryMode` bundelt
  de drie "geen bruikbare inhoud"-states (initial-loading, empty-library en de
  index-fout) zodat ze niet meer uit elkaar kunnen lopen — dat was de eigenlijke
  oorzaak. De fullscreen index-foutpagina is nu gegated op library-modus.
- **Niet-blokkerende waarschuwing in de overige modi.** `/taken`,
  `/instellingen` en `/werkdocumenten` blijven bruikbaar en krijgen bovenaan een
  `nldd-banner` (variant `warning`) met een "Probeer opnieuw"-actie die de
  bestaande `retryLoadCorpus` hergebruikt. De banner verdwijnt zodra een retry
  slaagt.
- **De backendverklaring bereikt de gebruiker.** De harde grens van 300 tekens,
  die de echte reden liet vallen zodra de (Engelse) GitHub-errorbody erin
  geïnterpoleerd werd, is vervangen door een nette afkapping met ellipsis. De
  guard op een `<`- of `{`-begin blijft, zodat HTML/JSON-bodies van een
  tussenliggende proxy niet doorlekken.
- **Juiste melding in AddLawSheet.** Bij een actief traject benoemt de
  "Zoeken is mislukt"-melding nu de traject-bibliotheek in plaats van "het
  centrale corpus", passend bij het traject-scoped zoek-endpoint.

## Extra CSS

Eén regel toegevoegd (unscoped, gemotiveerd met commentaar): de waarschuwings-
banner is een light-DOM-sibling van de navigation-split-view en zou via
`::slotted(*) { flex: 1 }` de helft van de pane opeten. `nldd-banner.corpus-warning
{ flex: 0 0 auto }` pint hem op zijn eigen hoogte als een dunne balk boven de
panes.

## Tests

Een vitest-suite (`LibraryView.indexErrorTakeover.repro.test.js`) dekt: de
taken- en instellingen-routes overleven de 502, de waarschuwingsbanner is
zichtbaar in taken-modus, de bibliotheek-route toont nog steeds de fullscreen-
pagina, en de lange backendtekst komt door. Volledige frontend-suite groen
(710 tests; de enige rode file is een pre-existing omgevingsissue rond
niet-geïnstalleerde `echarts`/`jsdom`, los van deze wijziging).
