### PR TITLE
feat(frontend): ontwerpsysteem 0.8.72, met de UI-feedback die daarbij langskwam

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@astrojs/markdown-remark": "^7.2.1",
         "@astrojs/mdx": "^7.0.4",
-        "@nldd/design-system": "^0.8.71",
+        "@nldd/design-system": "^0.8.72",
         "astro": "^7.1.4",
         "astro-pagefind": "^2.0.1",
         "rehype-mermaid": "^3",
@@ -2009,9 +2009,9 @@
       }
     },
     "node_modules/@nldd/design-system": {
-      "version": "0.8.71",
-      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.71.tgz",
-      "integrity": "sha512-j7xrsmfEK9t/noHxkJVmI9+w1kwLNamOTP8ig2EJ2lPAUFrEEIqopJBpoaZ6rYMTqNIkJP/ePlvELo7RZVwPRg==",
+      "version": "0.8.72",
+      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.72.tgz",
+      "integrity": "sha512-FiToAvEyP3GhUmXARKW+qmhk8w48FUGfjTvRU29LYTZ/JyW+iZhVQ1h7bZrQnnl6htJZUqOBDmKt6g17gdtMcQ==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.3",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@astrojs/markdown-remark": "^7.2.1",
         "@astrojs/mdx": "^7.0.4",
-        "@nldd/design-system": "^0.8.69",
+        "@nldd/design-system": "^0.8.71",
         "astro": "^7.1.4",
         "astro-pagefind": "^2.0.1",
         "rehype-mermaid": "^3",
@@ -95,9 +95,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -113,9 +110,6 @@
       "integrity": "sha512-xqE8BVbDoBueK/B47w30PtkVofUWJKGkwoMVE+EOMLf11rnoANxIAdA9FPqY+rng4oNI5ndHGsri1yPj2k8vZQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -133,9 +127,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -151,9 +142,6 @@
       "integrity": "sha512-16q0fYf7kpbmdObZEeZJEup8hQv/whgNwVjrSvT8umrKwLDSnNIWiQpm09lQQu6bweZB0XyIvHwlPitvJhC+hg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2021,9 +2009,9 @@
       }
     },
     "node_modules/@nldd/design-system": {
-      "version": "0.8.69",
-      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.69.tgz",
-      "integrity": "sha512-6lhFdo21V6/VU8OBVl4gne1H3TUtfqn2AmpOyEenUYO5FNtmSEs0+hv3vKdBp5mSIGzmN1KRbFHchPFn8sxNEg==",
+      "version": "0.8.71",
+      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.71.tgz",
+      "integrity": "sha512-j7xrsmfEK9t/noHxkJVmI9+w1kwLNamOTP8ig2EJ2lPAUFrEEIqopJBpoaZ6rYMTqNIkJP/ePlvELo7RZVwPRg==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.3",

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@astrojs/markdown-remark": "^7.2.1",
     "@astrojs/mdx": "^7.0.4",
-    "@nldd/design-system": "^0.8.69",
+    "@nldd/design-system": "^0.8.71",
     "astro": "^7.1.4",
     "astro-pagefind": "^2.0.1",
     "rehype-mermaid": "^3",

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@astrojs/markdown-remark": "^7.2.1",
     "@astrojs/mdx": "^7.0.4",
-    "@nldd/design-system": "^0.8.71",
+    "@nldd/design-system": "^0.8.72",
     "astro": "^7.1.4",
     "astro-pagefind": "^2.0.1",
     "rehype-mermaid": "^3",

--- a/docs/src/components/DocsOutline.astro
+++ b/docs/src/components/DocsOutline.astro
@@ -24,7 +24,7 @@ const flat = headings.filter((h) => h.depth >= 2 && h.depth <= 3);
     <nldd-list type="navigation" variant="simple" aria-label="On this page">
       {flat.map((h) => (
         <nldd-list-item href={`#${h.slug}`}>
-          {h.depth === 3 && <nldd-spacer-cell slot="start" />}
+          {h.depth === 3 && <nldd-spacer-cell />}
           <nldd-text-cell text={h.text} />
         </nldd-list-item>
       ))}

--- a/docs/src/components/LandingSections.astro
+++ b/docs/src/components/LandingSections.astro
@@ -361,7 +361,7 @@ const toc = [
                 />
                 <nldd-spacer-cell size="16" />
                 <nldd-timeline-track-cell
-                  child={
+                  position={
                     i === 0 ? 'first' : i === arr.length - 1 ? 'last' : 'between'
                   }
                 />

--- a/frontend-lawmaking/package.json
+++ b/frontend-lawmaking/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@nldd/design-system": "^0.8.71",
+    "@nldd/design-system": "^0.8.72",
     "@regelrecht/frontend-shared": "*",
     "vue": "^3.5.38"
   },

--- a/frontend-lawmaking/package.json
+++ b/frontend-lawmaking/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@nldd/design-system": "^0.8.70",
+    "@nldd/design-system": "^0.8.71",
     "@regelrecht/frontend-shared": "*",
     "vue": "^3.5.38"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@cucumber/gherkin": "^41.0.0",
     "@cucumber/messages": "^34.2.0",
-    "@nldd/design-system": "^0.8.71",
+    "@nldd/design-system": "^0.8.72",
     "@regelrecht/frontend-shared": "*",
     "@vue-flow/background": "^1.3.2",
     "@vue-flow/controls": "^1.1.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@cucumber/gherkin": "^41.0.0",
     "@cucumber/messages": "^34.2.0",
-    "@nldd/design-system": "^0.8.70",
+    "@nldd/design-system": "^0.8.71",
     "@regelrecht/frontend-shared": "*",
     "@vue-flow/background": "^1.3.2",
     "@vue-flow/controls": "^1.1.3",

--- a/frontend/src/AppShell.vue
+++ b/frontend/src/AppShell.vue
@@ -353,7 +353,7 @@ function onTabDismiss(e) {
             <nldd-toolbar-item slot="end" v-if="trajectActive || (!authLoading && oidcConfigured && !authenticated)">
               <nldd-icon-button id="add-menu-btn-md" size="md" icon="plus-small" text="Nieuw" tooltip-timing="never" expandable popup-type="menu" popovertarget="add-menu-md"></nldd-icon-button>
               <nldd-menu v-if="trajectActive" id="add-menu-md" anchor="add-menu-btn-md">
-                <nldd-menu-item icon="book-badge-plus" text="Wet toevoegen…" @select="triggerAddLaw"></nldd-menu-item>
+                <nldd-menu-item icon="new-book" text="Wet toevoegen…" @select="triggerAddLaw"></nldd-menu-item>
                 <nldd-menu-item icon="new-text-document" text="Werkdocument toevoegen">
                   <nldd-menu>
                     <nldd-menu-item icon="new-text-document" text="Nieuw document" @select="triggerNewWerkdoc"></nldd-menu-item>
@@ -470,7 +470,7 @@ function onTabDismiss(e) {
             <nldd-toolbar-item slot="end" v-if="trajectActive || (!authLoading && oidcConfigured && !authenticated)">
               <nldd-icon-button id="add-menu-btn-lg" size="md" icon="plus-small" text="Nieuw" tooltip-timing="never" expandable popup-type="menu" popovertarget="add-menu-lg"></nldd-icon-button>
               <nldd-menu v-if="trajectActive" id="add-menu-lg" anchor="add-menu-btn-lg">
-                <nldd-menu-item icon="book-badge-plus" text="Wet toevoegen…" @select="triggerAddLaw"></nldd-menu-item>
+                <nldd-menu-item icon="new-book" text="Wet toevoegen…" @select="triggerAddLaw"></nldd-menu-item>
                 <nldd-menu-item icon="new-text-document" text="Werkdocument toevoegen">
                   <nldd-menu>
                     <nldd-menu-item icon="new-text-document" text="Nieuw document" @select="triggerNewWerkdoc"></nldd-menu-item>
@@ -719,7 +719,7 @@ function onTabDismiss(e) {
             <nldd-toolbar-item slot="end" v-if="trajectActive || (!authLoading && oidcConfigured && !authenticated)">
               <nldd-icon-button id="add-menu-btn-sm" size="lg" icon="plus-small" text="Nieuw" tooltip-timing="never" popup-type="menu" popovertarget="add-menu-sm"></nldd-icon-button>
               <nldd-menu v-if="trajectActive" id="add-menu-sm" anchor="add-menu-btn-sm">
-                <nldd-menu-item icon="book-badge-plus" text="Wet toevoegen…" @select="triggerAddLaw"></nldd-menu-item>
+                <nldd-menu-item icon="new-book" text="Wet toevoegen…" @select="triggerAddLaw"></nldd-menu-item>
                 <nldd-menu-item icon="new-text-document" text="Werkdocument toevoegen">
                   <nldd-menu>
                     <nldd-menu-item icon="new-text-document" text="Nieuw document" @select="triggerNewWerkdoc"></nldd-menu-item>

--- a/frontend/src/AppShell.vue
+++ b/frontend/src/AppShell.vue
@@ -353,7 +353,7 @@ function onTabDismiss(e) {
             <nldd-toolbar-item slot="end" v-if="trajectActive || (!authLoading && oidcConfigured && !authenticated)">
               <nldd-icon-button id="add-menu-btn-md" size="md" icon="plus-small" text="Nieuw" tooltip-timing="never" expandable popup-type="menu" popovertarget="add-menu-md"></nldd-icon-button>
               <nldd-menu v-if="trajectActive" id="add-menu-md" anchor="add-menu-btn-md">
-                <nldd-menu-item icon="book" text="Wet toevoegen…" @select="triggerAddLaw"></nldd-menu-item>
+                <nldd-menu-item icon="book-badge-plus" text="Wet toevoegen…" @select="triggerAddLaw"></nldd-menu-item>
                 <nldd-menu-item icon="new-text-document" text="Werkdocument toevoegen">
                   <nldd-menu>
                     <nldd-menu-item icon="new-text-document" text="Nieuw document" @select="triggerNewWerkdoc"></nldd-menu-item>
@@ -470,7 +470,7 @@ function onTabDismiss(e) {
             <nldd-toolbar-item slot="end" v-if="trajectActive || (!authLoading && oidcConfigured && !authenticated)">
               <nldd-icon-button id="add-menu-btn-lg" size="md" icon="plus-small" text="Nieuw" tooltip-timing="never" expandable popup-type="menu" popovertarget="add-menu-lg"></nldd-icon-button>
               <nldd-menu v-if="trajectActive" id="add-menu-lg" anchor="add-menu-btn-lg">
-                <nldd-menu-item icon="book" text="Wet toevoegen…" @select="triggerAddLaw"></nldd-menu-item>
+                <nldd-menu-item icon="book-badge-plus" text="Wet toevoegen…" @select="triggerAddLaw"></nldd-menu-item>
                 <nldd-menu-item icon="new-text-document" text="Werkdocument toevoegen">
                   <nldd-menu>
                     <nldd-menu-item icon="new-text-document" text="Nieuw document" @select="triggerNewWerkdoc"></nldd-menu-item>
@@ -719,7 +719,7 @@ function onTabDismiss(e) {
             <nldd-toolbar-item slot="end" v-if="trajectActive || (!authLoading && oidcConfigured && !authenticated)">
               <nldd-icon-button id="add-menu-btn-sm" size="lg" icon="plus-small" text="Nieuw" tooltip-timing="never" popup-type="menu" popovertarget="add-menu-sm"></nldd-icon-button>
               <nldd-menu v-if="trajectActive" id="add-menu-sm" anchor="add-menu-btn-sm">
-                <nldd-menu-item icon="book" text="Wet toevoegen…" @select="triggerAddLaw"></nldd-menu-item>
+                <nldd-menu-item icon="book-badge-plus" text="Wet toevoegen…" @select="triggerAddLaw"></nldd-menu-item>
                 <nldd-menu-item icon="new-text-document" text="Werkdocument toevoegen">
                   <nldd-menu>
                     <nldd-menu-item icon="new-text-document" text="Nieuw document" @select="triggerNewWerkdoc"></nldd-menu-item>

--- a/frontend/src/AppShell.vue
+++ b/frontend/src/AppShell.vue
@@ -71,7 +71,7 @@ function openAbout() {
   nextTick(() => aboutSheet.value?.show?.());
 }
 
-// "Ondersteuning" support sheet, opened from the account menu.
+// "Help" sheet, opened from the account menu.
 const supportSheet = ref(null);
 function openSupport() {
   // Let the account menu popover close first, then raise the sheet.
@@ -422,7 +422,7 @@ function onTabDismiss(e) {
                 </nldd-menu-item>
                 <nldd-menu-divider></nldd-menu-divider>
                 <nldd-menu-item text="Over RegelRecht" icon="info" @click="openAbout"></nldd-menu-item>
-                <nldd-menu-item text="Ondersteuning" icon="support" @click="openSupport"></nldd-menu-item>
+                <nldd-menu-item text="Help" icon="help" @click="openSupport"></nldd-menu-item>
                 <nldd-menu-item v-if="authenticated && githubStatus?.configured && isEnabled('github.user_oauth') && githubStatus?.connected" :text="'GitHub ontkoppelen (' + githubStatus.github_login + ')'" icon="dismiss" @click="disconnectGithub"></nldd-menu-item>
                 <nldd-menu-item v-else-if="authenticated && githubStatus?.configured && isEnabled('github.user_oauth')" text="Koppel GitHub-account" icon="external-link" @click="connectGithub()"></nldd-menu-item>
                 <template v-if="!authLoading && authenticated">
@@ -535,7 +535,7 @@ function onTabDismiss(e) {
                 </nldd-menu-item>
                 <nldd-menu-divider></nldd-menu-divider>
                 <nldd-menu-item text="Over RegelRecht" icon="info" @click="openAbout"></nldd-menu-item>
-                <nldd-menu-item text="Ondersteuning" icon="support" @click="openSupport"></nldd-menu-item>
+                <nldd-menu-item text="Help" icon="help" @click="openSupport"></nldd-menu-item>
                 <nldd-menu-item v-if="authenticated && githubStatus?.configured && isEnabled('github.user_oauth') && githubStatus?.connected" :text="'GitHub ontkoppelen (' + githubStatus.github_login + ')'" icon="dismiss" @click="disconnectGithub"></nldd-menu-item>
                 <nldd-menu-item v-else-if="authenticated && githubStatus?.configured && isEnabled('github.user_oauth')" text="Koppel GitHub-account" icon="external-link" @click="connectGithub()"></nldd-menu-item>
                 <template v-if="!authLoading && authenticated">
@@ -780,7 +780,7 @@ function onTabDismiss(e) {
                 </nldd-menu-item>
                 <nldd-menu-divider></nldd-menu-divider>
                 <nldd-menu-item text="Over RegelRecht" icon="info" @click="openAbout"></nldd-menu-item>
-                <nldd-menu-item text="Ondersteuning" icon="support" @click="openSupport"></nldd-menu-item>
+                <nldd-menu-item text="Help" icon="help" @click="openSupport"></nldd-menu-item>
                 <nldd-menu-item v-if="authenticated && githubStatus?.configured && isEnabled('github.user_oauth') && githubStatus?.connected" :text="'GitHub ontkoppelen (' + githubStatus.github_login + ')'" icon="dismiss" @click="disconnectGithub"></nldd-menu-item>
                 <nldd-menu-item v-else-if="authenticated && githubStatus?.configured && isEnabled('github.user_oauth')" text="Koppel GitHub-account" icon="external-link" @click="connectGithub()"></nldd-menu-item>
                 <template v-if="!authLoading && authenticated">

--- a/frontend/src/LibraryView.vue
+++ b/frontend/src/LibraryView.vue
@@ -1806,7 +1806,7 @@ watch(activeTrajectRef, () => {
                 <nldd-toolbar v-if="paneChromeVisible(selectedLawLoading)" label="Favorieten">
                   <nldd-toolbar-item slot="start">
                     <nldd-icon-button
-                      :icon="favorites?.has(selectedLawId) ? 'heart-filled' : 'heart'"
+                      :icon="favorites?.has(selectedLawId) ? 'star-filled' : 'star'"
                       :text="favorites?.has(selectedLawId) ? 'Verwijder uit favorieten' : 'Voeg toe aan favorieten'"
                       @click="onFavoriteClick"
                     ></nldd-icon-button>

--- a/frontend/src/LibraryView.vue
+++ b/frontend/src/LibraryView.vue
@@ -1040,7 +1040,7 @@ watchEffect(() => {
   } else if (isInstellingenMode.value) {
     detail.push(
       instellingenTab.value === 'leden' ? 'Leden'
-        : instellingenTab.value === 'details' ? 'Traject details'
+        : instellingenTab.value === 'details' ? 'Algemeen'
           : 'Instellingen',
     );
   } else {
@@ -1611,15 +1611,15 @@ watch(activeTrajectRef, () => {
                   <template v-if="activeTrajectRef">
                     <nldd-list variant="simple" arrow-navigation>
                       <nldd-list-item size="md" button :selected="isInstellingenMode || undefined" @click="goToInstellingen()">
-                        <nldd-icon-cell slot="start" size="20"><nldd-icon name="gear"></nldd-icon></nldd-icon-cell>
-                        <nldd-spacer-cell slot="start" size="8"></nldd-spacer-cell>
+                        <nldd-icon-cell size="20"><nldd-icon name="gear"></nldd-icon></nldd-icon-cell>
+                        <nldd-spacer-cell size="8"></nldd-spacer-cell>
                         <nldd-text-cell text="Instellingen"></nldd-text-cell>
                         <nldd-spacer-cell size="8"></nldd-spacer-cell>
                         <nldd-icon-cell size="20"><nldd-icon name="chevron-right"></nldd-icon></nldd-icon-cell>
                       </nldd-list-item>
                       <nldd-list-item size="md" button :selected="isWerkdocMode || undefined" @click="goToWerkdocumenten">
-                        <nldd-icon-cell slot="start" size="20"><nldd-icon name="documents"></nldd-icon></nldd-icon-cell>
-                        <nldd-spacer-cell slot="start" size="8"></nldd-spacer-cell>
+                        <nldd-icon-cell size="20"><nldd-icon name="documents"></nldd-icon></nldd-icon-cell>
+                        <nldd-spacer-cell size="8"></nldd-spacer-cell>
                         <nldd-text-cell text="Werkdocumenten"></nldd-text-cell>
                         <nldd-spacer-cell size="8"></nldd-spacer-cell>
                         <nldd-icon-cell size="20"><nldd-icon name="chevron-right"></nldd-icon></nldd-icon-cell>
@@ -1714,15 +1714,15 @@ watch(activeTrajectRef, () => {
                        twee openen dezelfde bestemmingen, dus ze horen er niet
                        anders uit te zien afhankelijk van waar je ze aanklikt. -->
                   <nldd-list-item size="md" button :selected="instellingenTab === 'details' || undefined" @click="goToInstellingen('details')">
-                    <nldd-icon-cell slot="start" size="20"><nldd-icon name="traject"></nldd-icon></nldd-icon-cell>
-                    <nldd-spacer-cell slot="start" size="8"></nldd-spacer-cell>
-                    <nldd-text-cell text="Traject details"></nldd-text-cell>
+                    <nldd-icon-cell size="20"><nldd-icon name="traject"></nldd-icon></nldd-icon-cell>
+                    <nldd-spacer-cell size="8"></nldd-spacer-cell>
+                    <nldd-text-cell text="Algemeen"></nldd-text-cell>
                     <nldd-spacer-cell size="8"></nldd-spacer-cell>
                     <nldd-icon-cell size="20"><nldd-icon name="chevron-right"></nldd-icon></nldd-icon-cell>
                   </nldd-list-item>
                   <nldd-list-item size="md" button :selected="instellingenTab === 'leden' || undefined" @click="goToInstellingen('leden')">
-                    <nldd-icon-cell slot="start" size="20"><nldd-icon name="person-2"></nldd-icon></nldd-icon-cell>
-                    <nldd-spacer-cell slot="start" size="8"></nldd-spacer-cell>
+                    <nldd-icon-cell size="20"><nldd-icon name="person-2"></nldd-icon></nldd-icon-cell>
+                    <nldd-spacer-cell size="8"></nldd-spacer-cell>
                     <nldd-text-cell text="Leden"></nldd-text-cell>
                     <nldd-spacer-cell size="8"></nldd-spacer-cell>
                     <nldd-icon-cell size="20"><nldd-icon name="chevron-right"></nldd-icon></nldd-icon-cell>
@@ -1853,7 +1853,7 @@ watch(activeTrajectRef, () => {
             <nldd-page sticky-header>
               <nldd-top-title-bar
                 slot="header"
-                :text="instellingenTab === 'leden' ? 'Leden' : (instellingenTab === 'details' ? 'Traject details' : undefined)"
+                :text="instellingenTab === 'leden' ? 'Leden' : (instellingenTab === 'details' ? 'Algemeen' : undefined)"
                 back-text="Instellingen"
                 :collapse-anchor="instellingenTab ? 'instellingen-pane-titel' : undefined"
               ></nldd-top-title-bar>

--- a/frontend/src/TrajectChooserView.vue
+++ b/frontend/src/TrajectChooserView.vue
@@ -118,9 +118,9 @@ function trajectSupportingText(t) {
             button
             @click="selectTraject(t)"
           >
-            <nldd-spacer-cell slot="start" size="12"></nldd-spacer-cell>
-            <nldd-icon-cell slot="start" size="20"><nldd-icon name="traject"></nldd-icon></nldd-icon-cell>
-            <nldd-spacer-cell slot="start" size="8"></nldd-spacer-cell>
+            <nldd-spacer-cell size="12"></nldd-spacer-cell>
+            <nldd-icon-cell size="20"><nldd-icon name="traject"></nldd-icon></nldd-icon-cell>
+            <nldd-spacer-cell size="8"></nldd-spacer-cell>
             <nldd-text-cell :text="t.name" :supporting-text="trajectSupportingText(t)"></nldd-text-cell>
             <nldd-spacer-cell size="8"></nldd-spacer-cell>
             <nldd-icon-cell size="20">
@@ -131,9 +131,9 @@ function trajectSupportingText(t) {
             button
             @click="openCreate"
           >
-            <nldd-spacer-cell slot="start" size="12"></nldd-spacer-cell>
-            <nldd-icon-cell slot="start" size="20"><nldd-icon name="plus"></nldd-icon></nldd-icon-cell>
-            <nldd-spacer-cell slot="start" size="8"></nldd-spacer-cell>
+            <nldd-spacer-cell size="12"></nldd-spacer-cell>
+            <nldd-icon-cell size="20"><nldd-icon name="plus"></nldd-icon></nldd-icon-cell>
+            <nldd-spacer-cell size="8"></nldd-spacer-cell>
             <nldd-text-cell text="Nieuw traject"></nldd-text-cell>
             <nldd-spacer-cell size="8"></nldd-spacer-cell>
             <nldd-icon-cell size="20">

--- a/frontend/src/components/DocumentList.vue
+++ b/frontend/src/components/DocumentList.vue
@@ -47,13 +47,13 @@ const rows = computed(() => {
         :selected="row.job.target_path === selectedPath || undefined"
         @click="$emit('select', row.job.target_path)"
       >
-        <nldd-cell v-if="row.job.status !== 'failed'" slot="start">
+        <nldd-cell v-if="row.job.status !== 'failed'">
           <nldd-activity-indicator size="20" timing="instant"></nldd-activity-indicator>
         </nldd-cell>
-        <nldd-icon-cell v-else slot="start" size="20">
+        <nldd-icon-cell v-else size="20">
           <nldd-icon name="alert"></nldd-icon>
         </nldd-icon-cell>
-        <nldd-spacer-cell slot="start" size="8"></nldd-spacer-cell>
+        <nldd-spacer-cell size="8"></nldd-spacer-cell>
         <nldd-text-cell
           :text="jobTitle(row.job)"
           :supporting-text="row.job.status === 'failed' ? 'Conversie mislukt' : undefined"
@@ -70,8 +70,8 @@ const rows = computed(() => {
         :selected="row.doc.path === selectedPath || undefined"
         @click="$emit('select', row.doc.path)"
       >
-        <nldd-icon-cell slot="start" size="20"><nldd-icon name="text-document"></nldd-icon></nldd-icon-cell>
-        <nldd-spacer-cell slot="start" size="8"></nldd-spacer-cell>
+        <nldd-icon-cell size="20"><nldd-icon name="text-document"></nldd-icon></nldd-icon-cell>
+        <nldd-spacer-cell size="8"></nldd-spacer-cell>
         <nldd-text-cell :text="title(row.doc.path)"></nldd-text-cell>
         <nldd-spacer-cell size="8"></nldd-spacer-cell>
         <nldd-icon-cell size="20"><nldd-icon name="chevron-right"></nldd-icon></nldd-icon-cell>

--- a/frontend/src/components/MobileTrajectSheet.vue
+++ b/frontend/src/components/MobileTrajectSheet.vue
@@ -259,15 +259,14 @@ onBeforeUnmount(() => {
               <nldd-spacer-cell size="8"></nldd-spacer-cell>
               <nldd-text-cell text="Taken"></nldd-text-cell>
             </nldd-list-item>
-            <nldd-list-item size="md" button @click="goToInstellingen('leden')">
-              <nldd-icon-cell size="20"><nldd-icon name="person-2"></nldd-icon></nldd-icon-cell>
+            <!-- Eén rij naar Instellingen, net als in de zijbalk: Algemeen en
+                 Leden staan daarbinnen, niet ernaast. -->
+            <nldd-list-item size="md" button @click="goToInstellingen()">
+              <nldd-icon-cell size="20"><nldd-icon name="settings"></nldd-icon></nldd-icon-cell>
               <nldd-spacer-cell size="8"></nldd-spacer-cell>
-              <nldd-text-cell text="Leden"></nldd-text-cell>
-            </nldd-list-item>
-            <nldd-list-item size="md" button @click="goToInstellingen('details')">
-              <nldd-icon-cell size="20"><nldd-icon name="traject"></nldd-icon></nldd-icon-cell>
+              <nldd-text-cell text="Instellingen"></nldd-text-cell>
               <nldd-spacer-cell size="8"></nldd-spacer-cell>
-              <nldd-text-cell text="Traject details"></nldd-text-cell>
+              <nldd-icon-cell size="20"><nldd-icon name="chevron-right"></nldd-icon></nldd-icon-cell>
             </nldd-list-item>
           </nldd-list>
 
@@ -289,10 +288,10 @@ onBeforeUnmount(() => {
               :selected="!activeTrajectRef || undefined"
               @click="goToCorpusJuris"
             >
-              <nldd-spacer-cell slot="start" size="12"></nldd-spacer-cell>
-              <nldd-icon-cell v-if="!activeTrajectRef" slot="start" size="20"><nldd-icon name="check-mark"></nldd-icon></nldd-icon-cell>
-              <nldd-spacer-cell v-else slot="start" size="20"></nldd-spacer-cell>
-              <nldd-spacer-cell slot="start" size="8"></nldd-spacer-cell>
+              <nldd-spacer-cell size="12"></nldd-spacer-cell>
+              <nldd-icon-cell v-if="!activeTrajectRef" size="20"><nldd-icon name="check-mark"></nldd-icon></nldd-icon-cell>
+              <nldd-spacer-cell v-else size="20"></nldd-spacer-cell>
+              <nldd-spacer-cell size="8"></nldd-spacer-cell>
               <nldd-text-cell text="Corpus juris"></nldd-text-cell>
             </nldd-list-item>
             <nldd-list-item
@@ -303,10 +302,10 @@ onBeforeUnmount(() => {
               :selected="t.ref === activeTrajectRef || undefined"
               @click="selectTraject(t)"
             >
-              <nldd-spacer-cell slot="start" size="12"></nldd-spacer-cell>
-              <nldd-icon-cell v-if="t.ref === activeTrajectRef" slot="start" size="20"><nldd-icon name="check-mark"></nldd-icon></nldd-icon-cell>
-              <nldd-spacer-cell v-else slot="start" size="20"></nldd-spacer-cell>
-              <nldd-spacer-cell slot="start" size="8"></nldd-spacer-cell>
+              <nldd-spacer-cell size="12"></nldd-spacer-cell>
+              <nldd-icon-cell v-if="t.ref === activeTrajectRef" size="20"><nldd-icon name="check-mark"></nldd-icon></nldd-icon-cell>
+              <nldd-spacer-cell v-else size="20"></nldd-spacer-cell>
+              <nldd-spacer-cell size="8"></nldd-spacer-cell>
               <nldd-text-cell :text="`${t.name}${t.status === 'afgerond' ? ' (afgerond)' : ''}`"></nldd-text-cell>
             </nldd-list-item>
             <nldd-list-item size="md" button @click="startCreate">
@@ -331,10 +330,10 @@ onBeforeUnmount(() => {
                 :selected="isActiveTab(tab) || undefined"
                 @click="selectTab(tab)"
               >
-                <nldd-spacer-cell slot="start" size="12"></nldd-spacer-cell>
-                <nldd-icon-cell v-if="isActiveTab(tab)" slot="start" size="20"><nldd-icon name="check-mark"></nldd-icon></nldd-icon-cell>
-                <nldd-spacer-cell v-else slot="start" size="20"></nldd-spacer-cell>
-                <nldd-spacer-cell slot="start" size="8"></nldd-spacer-cell>
+                <nldd-spacer-cell size="12"></nldd-spacer-cell>
+                <nldd-icon-cell v-if="isActiveTab(tab)" size="20"><nldd-icon name="check-mark"></nldd-icon></nldd-icon-cell>
+                <nldd-spacer-cell v-else size="20"></nldd-spacer-cell>
+                <nldd-spacer-cell size="8"></nldd-spacer-cell>
                 <nldd-text-cell :text="tabText(tab)" :supporting-text="tabSupporting(tab)"></nldd-text-cell>
                 <nldd-spacer-cell size="8"></nldd-spacer-cell>
                 <nldd-cell>

--- a/frontend/src/components/SupportSheet.vue
+++ b/frontend/src/components/SupportSheet.vue
@@ -1,5 +1,5 @@
 <script setup>
-// "Ondersteuning" — a short support sheet opened from the account menu. Points
+// "Help" — a short support sheet opened from the account menu. Points
 // users at the support inbox when they run into something. Exposes show()/hide()
 // so the shell can drive it from the menu item.
 import { ref } from 'vue';
@@ -21,7 +21,7 @@ defineExpose({ show, hide });
   <Teleport to="body">
     <nldd-sheet ref="sheetEl" placement="right" width="480px" full-height @close="hide">
       <nldd-page sticky-header>
-        <nldd-top-title-bar slot="header" text="Ondersteuning" dismiss-text="Sluit" @dismiss="hide"></nldd-top-title-bar>
+        <nldd-top-title-bar slot="header" text="Help" dismiss-text="Sluit" @dismiss="hide"></nldd-top-title-bar>
         <nldd-simple-section width="full">
           <nldd-rich-text>
             <p>

--- a/frontend/src/components/TasksCategoriesPane.vue
+++ b/frontend/src/components/TasksCategoriesPane.vue
@@ -88,8 +88,8 @@ function select(categorie, lawId = null) {
       :selected="isSelected(PRIORITEIT) || undefined"
       @click="select(PRIORITEIT)"
     >
-      <nldd-icon-cell slot="start" size="20"><nldd-icon name="exclamation-circle"></nldd-icon></nldd-icon-cell>
-      <nldd-spacer-cell slot="start" size="8"></nldd-spacer-cell>
+      <nldd-icon-cell size="20"><nldd-icon name="exclamation-circle"></nldd-icon></nldd-icon-cell>
+      <nldd-spacer-cell size="8"></nldd-spacer-cell>
       <nldd-text-cell text="Prioriteit"></nldd-text-cell>
       <nldd-spacer-cell size="8"></nldd-spacer-cell>
       <nldd-text-cell
@@ -109,8 +109,8 @@ function select(categorie, lawId = null) {
       :selected="isSelected(WACHTEN) || undefined"
       @click="select(WACHTEN)"
     >
-      <nldd-icon-cell slot="start" size="20"><nldd-icon name="clock"></nldd-icon></nldd-icon-cell>
-      <nldd-spacer-cell slot="start" size="8"></nldd-spacer-cell>
+      <nldd-icon-cell size="20"><nldd-icon name="clock"></nldd-icon></nldd-icon-cell>
+      <nldd-spacer-cell size="8"></nldd-spacer-cell>
       <nldd-text-cell text="Wachten op"></nldd-text-cell>
       <nldd-spacer-cell size="8"></nldd-spacer-cell>
       <nldd-text-cell
@@ -129,8 +129,8 @@ function select(categorie, lawId = null) {
       :selected="isSelected(ALLE) || undefined"
       @click="select(ALLE)"
     >
-      <nldd-icon-cell slot="start" size="20"><nldd-icon name="circle-grid-2x2-top-left-check-mark"></nldd-icon></nldd-icon-cell>
-      <nldd-spacer-cell slot="start" size="8"></nldd-spacer-cell>
+      <nldd-icon-cell size="20"><nldd-icon name="circle-grid-2x2-top-left-check-mark"></nldd-icon></nldd-icon-cell>
+      <nldd-spacer-cell size="8"></nldd-spacer-cell>
       <nldd-text-cell text="Alle taken"></nldd-text-cell>
       <nldd-spacer-cell size="8"></nldd-spacer-cell>
       <nldd-text-cell
@@ -163,8 +163,8 @@ function select(categorie, lawId = null) {
         :selected="isSelected(WERKDOCUMENTEN) || undefined"
         @click="select(WERKDOCUMENTEN)"
       >
-        <nldd-icon-cell slot="start" size="20"><nldd-icon name="label"></nldd-icon></nldd-icon-cell>
-        <nldd-spacer-cell slot="start" size="8"></nldd-spacer-cell>
+        <nldd-icon-cell size="20"><nldd-icon name="label"></nldd-icon></nldd-icon-cell>
+        <nldd-spacer-cell size="8"></nldd-spacer-cell>
         <nldd-text-cell text="Werkdocumenten"></nldd-text-cell>
         <nldd-spacer-cell size="8"></nldd-spacer-cell>
         <nldd-text-cell
@@ -186,8 +186,8 @@ function select(categorie, lawId = null) {
         :selected="isSelected(WET, law.lawId) || undefined"
         @click="select(WET, law.lawId)"
       >
-        <nldd-icon-cell slot="start" size="20"><nldd-icon name="label"></nldd-icon></nldd-icon-cell>
-        <nldd-spacer-cell slot="start" size="8"></nldd-spacer-cell>
+        <nldd-icon-cell size="20"><nldd-icon name="label"></nldd-icon></nldd-icon-cell>
+        <nldd-spacer-cell size="8"></nldd-spacer-cell>
         <nldd-text-cell :text="law.name"></nldd-text-cell>
         <nldd-spacer-cell size="8"></nldd-spacer-cell>
         <nldd-text-cell

--- a/frontend/src/components/TasksListPane.vue
+++ b/frontend/src/components/TasksListPane.vue
@@ -162,12 +162,11 @@ function viewLaw(job) {
   <nldd-list v-if="!isEmpty" variant="simple">
     <nldd-list-item v-for="task in shownTasks" :key="task.id" size="md">
       <nldd-icon-cell
-        slot="start"
         size="20"
         :icon="taskIcon(task)"
         :color="task.task_type === 'job_failed' ? 'critical' : undefined"
       ></nldd-icon-cell>
-      <nldd-spacer-cell slot="start" size="8"></nldd-spacer-cell>
+      <nldd-spacer-cell size="8"></nldd-spacer-cell>
       <!-- Geen supporting-text met de foutmelding: die is technisch en lang, en
            duwt de rij uit z'n voegen. Hij staat achter "Toon details". -->
       <nldd-text-cell
@@ -220,14 +219,14 @@ function viewLaw(job) {
            timing="instant": de anti-flash-vertraging van 1000ms is bedoeld voor
            laadjes die zo weer weg zijn. Deze staan er minutenlang, dus die
            vertraging levert alleen een gat op waar de rij al zichtbaar is. -->
-      <nldd-cell slot="start" vertical-alignment="center">
+      <nldd-cell vertical-alignment="center">
         <nldd-activity-indicator
           size="20"
           timing="instant"
           :text="runningTitle(job, displayName)"
         ></nldd-activity-indicator>
       </nldd-cell>
-      <nldd-spacer-cell slot="start" size="8"></nldd-spacer-cell>
+      <nldd-spacer-cell size="8"></nldd-spacer-cell>
       <nldd-text-cell :text="runningTitle(job, displayName)"></nldd-text-cell>
       <nldd-spacer-cell size="8"></nldd-spacer-cell>
       <nldd-cell>

--- a/frontend/src/components/TasksSidebarItem.vue
+++ b/frontend/src/components/TasksSidebarItem.vue
@@ -34,8 +34,8 @@ const prioriteitCount = computed(() => tasks.value.filter(isPrioriteit).length);
 
 <template>
   <nldd-list-item size="md" button :selected="selected || undefined">
-    <nldd-icon-cell slot="start" size="20"><nldd-icon name="tasks"></nldd-icon></nldd-icon-cell>
-    <nldd-spacer-cell slot="start" size="8"></nldd-spacer-cell>
+    <nldd-icon-cell size="20"><nldd-icon name="tasks"></nldd-icon></nldd-icon-cell>
+    <nldd-spacer-cell size="8"></nldd-spacer-cell>
     <nldd-text-cell text="Taken"></nldd-text-cell>
     <template v-if="prioriteitCount > 0">
       <nldd-spacer-cell size="8"></nldd-spacer-cell>

--- a/frontend/src/components/TrajectCreateForm.vue
+++ b/frontend/src/components/TrajectCreateForm.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed, ref } from 'vue';
+import { deriveAuthRef, tokenEnvName as tokenEnvNameFor } from '../lib/corpusAuth.js';
 
 // Gedeeld aanmaakformulier voor een traject - gebruikt door de
 // TrajectMenu-sheet en de /editor/nieuw-traject-pagina. Gebouwd op de
@@ -42,19 +43,19 @@ function emptyForm() {
 const form = ref(emptyForm());
 const nameFieldEl = ref(null);
 
-// The backend derives the token's env-var name from the repo coordinates
-// (`derive_auth_ref` + `token_env_name`): lowercase `owner/repo`, runs of
-// non-alphanumerics collapsed to one separator, then uppercased. Showing the
-// exact name saves the operator from re-deriving it by hand.
+// Showing the exact env-var name saves the operator from deriving it by hand.
+// The derivation itself lives in lib/corpusAuth.js, next to the test that pins
+// it to the backend.
 const tokenEnvName = computed(() => {
   const owner = form.value.repo_owner.trim();
   const repo = form.value.repo_name.trim();
   if (!owner || !repo) return '';
-  const slug = `${owner}/${repo}`
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '_')
-    .replace(/^_+|_+$/g, '');
-  return `CORPUS_AUTH_${slug.toUpperCase()}_TOKEN`;
+  const authRef = deriveAuthRef(owner, repo);
+  // Input of nothing but separators leaves no ref, and the backend rejects that
+  // before the insert. Naming CORPUS_AUTH__TOKEN would send the operator off to
+  // set a variable that resolves nothing.
+  if (!authRef) return '';
+  return tokenEnvNameFor(authRef);
 });
 
 const repoIsCompleet = computed(() =>

--- a/frontend/src/components/TrajectCreateForm.vue
+++ b/frontend/src/components/TrajectCreateForm.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 
 // Gedeeld aanmaakformulier voor een traject - gebruikt door de
 // TrajectMenu-sheet en de /editor/nieuw-traject-pagina. Gebouwd op de
@@ -41,6 +41,25 @@ function emptyForm() {
 
 const form = ref(emptyForm());
 const nameFieldEl = ref(null);
+
+// The backend derives the token's env-var name from the repo coordinates
+// (`derive_auth_ref` + `token_env_name`): lowercase `owner/repo`, runs of
+// non-alphanumerics collapsed to one separator, then uppercased. Showing the
+// exact name saves the operator from re-deriving it by hand.
+const tokenEnvName = computed(() => {
+  const owner = form.value.repo_owner.trim();
+  const repo = form.value.repo_name.trim();
+  if (!owner || !repo) return '';
+  const slug = `${owner}/${repo}`
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  return `CORPUS_AUTH_${slug.toUpperCase()}_TOKEN`;
+});
+
+const repoIsCompleet = computed(() =>
+  Boolean(form.value.repo_owner.trim() && form.value.repo_name.trim()),
+);
 
 function reset() {
   form.value = emptyForm();
@@ -134,6 +153,11 @@ function bind(field) {
           :checked="form.useCustomRepo ? true : undefined"
           @change="form.useCustomRepo = Boolean($event.detail?.checked)"
         ></nldd-switch-field>
+        <nldd-form-field-help-text>
+          De standaardrepo is publiek: wat je in dit traject bewerkt, is voor
+          iedereen te zien. Kies een eigen repo als het werk nog niet openbaar mag
+          zijn, of als de regelgeving bij je eigen organisatie thuishoort.
+        </nldd-form-field-help-text>
       </nldd-form-field>
 
       <template v-if="form.useCustomRepo">
@@ -174,16 +198,18 @@ function bind(field) {
         </nldd-form-field>
       </template>
 
-      <nldd-form-field>
+      <!-- Bij een eigen repo pas tonen zodra eigenaar en repository ingevuld zijn:
+           een zin met lege plekken erin leest als een fout. -->
+      <nldd-form-field v-if="!form.useCustomRepo || repoIsCompleet">
         <nldd-rich-text>
           <p v-if="form.useCustomRepo">
             Bewerkingen worden gepusht naar
-            <code>{{ form.repo_owner || '…' }}/{{ form.repo_name || '…' }}</code>
-            (basis: <code>{{ form.base_branch || 'main' }}</code>).
-            Je beheerder moet voor deze repo een <code>CORPUS_AUTH_*_TOKEN</code>
-            env-var hebben gezet - anders krijg je een foutmelding bij aanmaken.
-            Commits verschijnen onder je eigen naam (uit je SSO-account), niet
-            onder het service-account.
+            <code>{{ form.repo_owner.trim() }}/{{ form.repo_name.trim() }}</code>
+            (basis: <code>{{ form.base_branch.trim() || 'main' }}</code>).
+            Je beheerder moet voor deze repo de env-var
+            <code>{{ tokenEnvName }}</code> hebben gezet - anders krijg je een
+            foutmelding bij aanmaken. Commits verschijnen onder je eigen naam
+            (uit je SSO-account), niet onder het service-account.
           </p>
           <p v-else>
             Bewerkingen in dit traject worden gepusht naar een aparte branch op

--- a/frontend/src/components/TrajectCreateForm.vue
+++ b/frontend/src/components/TrajectCreateForm.vue
@@ -58,9 +58,11 @@ const tokenEnvName = computed(() => {
   return tokenEnvNameFor(authRef);
 });
 
-const repoIsCompleet = computed(() =>
-  Boolean(form.value.repo_owner.trim() && form.value.repo_name.trim()),
-);
+// Complete enough to describe: the coordinates yield a token name. Checking the
+// derived name rather than the raw fields also catches input that trims to
+// something non-empty but carries no letters or digits ("..."), which leaves no
+// ref and so no env-var to point the operator at.
+const repoIsCompleet = computed(() => Boolean(tokenEnvName.value));
 
 function reset() {
   form.value = emptyForm();
@@ -199,8 +201,8 @@ function bind(field) {
         </nldd-form-field>
       </template>
 
-      <!-- Bij een eigen repo pas tonen zodra eigenaar en repository ingevuld zijn:
-           een zin met lege plekken erin leest als een fout. -->
+      <!-- Bij een eigen repo pas tonen zodra eigenaar en repository een naam
+           opleveren: een zin met lege plekken erin leest als een fout. -->
       <nldd-form-field v-if="!form.useCustomRepo || repoIsCompleet">
         <nldd-rich-text>
           <p v-if="form.useCustomRepo">

--- a/frontend/src/components/TrajectDetailsPane.vue
+++ b/frontend/src/components/TrajectDetailsPane.vue
@@ -116,10 +116,10 @@ async function confirmLeave() {
 
 <template>
   <nldd-simple-section>
-    <nldd-title v-if="paneChromeVisible(loading)" id="instellingen-pane-titel" size="3"><h3>Traject details</h3></nldd-title>
+    <nldd-title v-if="paneChromeVisible(loading)" id="instellingen-pane-titel" size="3"><h3>Algemeen</h3></nldd-title>
     <nldd-spacer v-if="paneChromeVisible(loading)" size="16"></nldd-spacer>
 
-    <nldd-activity-indicator v-if="loading" text="Traject details laden" show-text></nldd-activity-indicator>
+    <nldd-activity-indicator v-if="loading" text="Trajectgegevens laden" show-text></nldd-activity-indicator>
     <nldd-inline-dialog v-else-if="loadError" variant="alert" :text="loadError.message || 'Fout bij laden'"></nldd-inline-dialog>
     <template v-else-if="detail">
     <nldd-list variant="box">
@@ -179,13 +179,38 @@ async function confirmLeave() {
       </nldd-list-item>
     </nldd-list>
 
+    <!-- De onomkeerbare actie in een eigen vlak, met een kopje erboven: zo zie je
+         bij het scrollen dat er nog iets komt, in plaats van dat je een rode knop
+         onder een tabel moet ontdekken. -->
     <template v-if="detail.role === 'owner'">
       <nldd-spacer size="24"></nldd-spacer>
-      <nldd-button variant="destructive" size="md" text="Traject verwijderen" @click="askDelete"></nldd-button>
+      <nldd-box>
+        <nldd-title size="5"><h4>Traject verwijderen</h4></nldd-title>
+        <nldd-spacer size="4"></nldd-spacer>
+        <nldd-rich-text>
+          <p>
+            Het traject verdwijnt met zijn leden en uitnodigingen. De
+            traject-branch op GitHub blijft bestaan.
+          </p>
+        </nldd-rich-text>
+        <nldd-spacer size="8"></nldd-spacer>
+        <nldd-button variant="destructive" size="md" text="Traject verwijderen" @click="askDelete"></nldd-button>
+      </nldd-box>
     </template>
     <template v-else-if="detail.role">
       <nldd-spacer size="24"></nldd-spacer>
-      <nldd-button variant="destructive" size="md" text="Traject verlaten" @click="askLeave"></nldd-button>
+      <nldd-box>
+        <nldd-title size="5"><h4>Traject verlaten</h4></nldd-title>
+        <nldd-spacer size="4"></nldd-spacer>
+        <nldd-rich-text>
+          <p>
+            Je verliest toegang tot dit traject. Een eigenaar kan je later
+            opnieuw uitnodigen.
+          </p>
+        </nldd-rich-text>
+        <nldd-spacer size="8"></nldd-spacer>
+        <nldd-button variant="destructive" size="md" text="Traject verlaten" @click="askLeave"></nldd-button>
+      </nldd-box>
     </template>
     </template>
   </nldd-simple-section>

--- a/frontend/src/components/TrajectMembersPane.vue
+++ b/frontend/src/components/TrajectMembersPane.vue
@@ -135,9 +135,9 @@ async function confirmRemoveInvite() {
     <nldd-list variant="box">
       <template v-for="m in members" :key="m.account_id">
         <nldd-list-item size="md">
-          <nldd-spacer-cell slot="start" size="12"></nldd-spacer-cell>
-          <nldd-icon-cell slot="start" size="20"><nldd-icon name="user"></nldd-icon></nldd-icon-cell>
-          <nldd-spacer-cell slot="start" size="8"></nldd-spacer-cell>
+          <nldd-spacer-cell size="12"></nldd-spacer-cell>
+          <nldd-icon-cell size="20"><nldd-icon name="user"></nldd-icon></nldd-icon-cell>
+          <nldd-spacer-cell size="8"></nldd-spacer-cell>
           <nldd-text-cell :supporting-text="m.name ? m.email : null">
             <span class="member-name">
               <span>{{ m.name || m.email }}</span>
@@ -177,9 +177,9 @@ async function confirmRemoveInvite() {
            instead of scrolling them out of view in a separate section below. -->
       <template v-for="inv in pendingInvites" :key="inv.email">
         <nldd-list-item size="md">
-          <nldd-spacer-cell slot="start" size="12"></nldd-spacer-cell>
-          <nldd-icon-cell slot="start" size="20"><nldd-icon name="user"></nldd-icon></nldd-icon-cell>
-          <nldd-spacer-cell slot="start" size="8"></nldd-spacer-cell>
+          <nldd-spacer-cell size="12"></nldd-spacer-cell>
+          <nldd-icon-cell size="20"><nldd-icon name="user"></nldd-icon></nldd-icon-cell>
+          <nldd-spacer-cell size="8"></nldd-spacer-cell>
           <nldd-text-cell supporting-text="Openstaande uitnodiging. Wacht op eerste login voor activatie.">
             <span class="member-name">
               <span>{{ inv.email }}</span>

--- a/frontend/src/components/TrajectMembersPane.vue
+++ b/frontend/src/components/TrajectMembersPane.vue
@@ -135,8 +135,7 @@ async function confirmRemoveInvite() {
     <nldd-list variant="box">
       <template v-for="m in members" :key="m.account_id">
         <nldd-list-item size="md">
-          <nldd-spacer-cell size="12"></nldd-spacer-cell>
-          <nldd-icon-cell size="20"><nldd-icon name="user"></nldd-icon></nldd-icon-cell>
+          <nldd-icon-cell size="24"><nldd-icon name="user"></nldd-icon></nldd-icon-cell>
           <nldd-spacer-cell size="8"></nldd-spacer-cell>
           <nldd-text-cell :supporting-text="m.name ? m.email : null">
             <span class="member-name">
@@ -177,8 +176,7 @@ async function confirmRemoveInvite() {
            instead of scrolling them out of view in a separate section below. -->
       <template v-for="inv in pendingInvites" :key="inv.email">
         <nldd-list-item size="md">
-          <nldd-spacer-cell size="12"></nldd-spacer-cell>
-          <nldd-icon-cell size="20"><nldd-icon name="user"></nldd-icon></nldd-icon-cell>
+          <nldd-icon-cell size="24"><nldd-icon name="user"></nldd-icon></nldd-icon-cell>
           <nldd-spacer-cell size="8"></nldd-spacer-cell>
           <nldd-text-cell supporting-text="Openstaande uitnodiging. Wacht op eerste login voor activatie.">
             <span class="member-name">

--- a/frontend/src/components/TrajectMenu.vue
+++ b/frontend/src/components/TrajectMenu.vue
@@ -217,18 +217,22 @@ async function submitCreate() {
       icon="tasks"
       @click="goToTaken"
     ></nldd-menu-item>
-    <nldd-menu-item
-      v-if="activeTraject"
-      text="Leden"
-      icon="person-2"
-      @click="goToInstellingen('leden')"
-    ></nldd-menu-item>
-    <nldd-menu-item
-      v-if="activeTraject"
-      text="Traject details"
-      icon="traject"
-      @click="goToInstellingen('details')"
-    ></nldd-menu-item>
+    <!-- Zelfde nesting als de zijbalk: Instellingen met Algemeen en Leden
+         eronder, zodat het menu en de navigatie hetzelfde model tonen. -->
+    <nldd-menu-item v-if="activeTraject" text="Instellingen" icon="settings">
+      <nldd-menu>
+        <nldd-menu-item
+          text="Algemeen"
+          icon="traject"
+          @click="goToInstellingen('details')"
+        ></nldd-menu-item>
+        <nldd-menu-item
+          text="Leden"
+          icon="person-2"
+          @click="goToInstellingen('leden')"
+        ></nldd-menu-item>
+      </nldd-menu>
+    </nldd-menu-item>
     <!-- The group draws its own divider above (auto-suppressed when it's the
          first child, i.e. no active-traject actions precede it), so no manual
          nldd-menu-divider here. -->

--- a/frontend/src/components/TrajectMenu.vue
+++ b/frontend/src/components/TrajectMenu.vue
@@ -200,6 +200,7 @@ async function submitCreate() {
     :text="activeLabel"
     :popovertarget="menuId"
     :width="fullWidth ? 'full' : undefined"
+    :max-width="fullWidth ? undefined : '220px'"
     :horizontal-alignment="fullWidth ? 'left' : undefined"
   ></nldd-button>
   <!-- Logged in: the active traject's actions first, then the scope switcher

--- a/frontend/src/lib/corpusAuth.js
+++ b/frontend/src/lib/corpusAuth.js
@@ -1,0 +1,26 @@
+/**
+ * Mirror of the backend's token derivation, for display only.
+ *
+ * The editor-api derives an auth ref from the repo coordinates
+ * (`derive_auth_ref` in packages/editor-api/src/trajects.rs) and turns that
+ * into an env-var name (`token_env_name` in packages/corpus/src/auth.rs). The
+ * traject form shows operators the exact name they have to set, so it has to
+ * arrive at the same string.
+ *
+ * Kept in two steps like the backend, and pinned by corpusAuth.test.js with the
+ * fixtures from the Rust unit tests: a change on either side then shows up as a
+ * failing test instead of a wrong name on screen.
+ */
+
+/** Lowercase `owner/repo`, every run of non-alphanumerics collapsed to one dash. */
+export function deriveAuthRef(owner, repo) {
+  return `${owner}/${repo}`
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/** The env var the backend looks up for an auth ref. */
+export function tokenEnvName(authRef) {
+  return `CORPUS_AUTH_${authRef.toUpperCase().replace(/-/g, '_')}_TOKEN`;
+}

--- a/frontend/src/lib/corpusAuth.test.js
+++ b/frontend/src/lib/corpusAuth.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { deriveAuthRef, tokenEnvName } from './corpusAuth.js';
+
+// The fixtures below are the ones from the Rust unit tests in
+// packages/editor-api/src/trajects.rs (auth_ref_*). They are copied on purpose:
+// this file exists to catch the frontend drifting away from the backend.
+describe('deriveAuthRef', () => {
+  it('lowercases and collapses separator runs', () => {
+    expect(deriveAuthRef('Acme', 'Secret-Repo')).toBe('acme-secret-repo');
+    expect(deriveAuthRef('MinBZK', 'regelrecht-corpus')).toBe('minbzk-regelrecht-corpus');
+    expect(deriveAuthRef('a.b', 'c_d')).toBe('a-b-c-d');
+  });
+
+  it('leaves already normalised input untouched', () => {
+    expect(deriveAuthRef('acme', 'secret-repo')).toBe('acme-secret-repo');
+    expect(deriveAuthRef('minbzk', 'regelrecht-corpus')).toBe('minbzk-regelrecht-corpus');
+  });
+
+  it('trims leading and trailing dashes', () => {
+    expect(deriveAuthRef('...', '...')).toBe('');
+    expect(deriveAuthRef('.foo.', '.bar.')).toBe('foo-bar');
+  });
+});
+
+describe('tokenEnvName', () => {
+  it('uppercases the ref and turns dashes into underscores', () => {
+    expect(tokenEnvName('acme-secret-repo')).toBe('CORPUS_AUTH_ACME_SECRET_REPO_TOKEN');
+    expect(tokenEnvName('minbzk-regelrecht-corpus')).toBe('CORPUS_AUTH_MINBZK_REGELRECHT_CORPUS_TOKEN');
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       "dependencies": {
         "@cucumber/gherkin": "^41.0.0",
         "@cucumber/messages": "^34.2.0",
-        "@nldd/design-system": "^0.8.71",
+        "@nldd/design-system": "^0.8.72",
         "@regelrecht/frontend-shared": "*",
         "@vue-flow/background": "^1.3.2",
         "@vue-flow/controls": "^1.1.3",
@@ -971,9 +971,9 @@
       }
     },
     "node_modules/@nldd/design-system": {
-      "version": "0.8.71",
-      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.71.tgz",
-      "integrity": "sha512-j7xrsmfEK9t/noHxkJVmI9+w1kwLNamOTP8ig2EJ2lPAUFrEEIqopJBpoaZ6rYMTqNIkJP/ePlvELo7RZVwPRg==",
+      "version": "0.8.72",
+      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.72.tgz",
+      "integrity": "sha512-FiToAvEyP3GhUmXARKW+qmhk8w48FUGfjTvRU29LYTZ/JyW+iZhVQ1h7bZrQnnl6htJZUqOBDmKt6g17gdtMcQ==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       "dependencies": {
         "@cucumber/gherkin": "^41.0.0",
         "@cucumber/messages": "^34.2.0",
-        "@nldd/design-system": "^0.8.70",
+        "@nldd/design-system": "^0.8.71",
         "@regelrecht/frontend-shared": "*",
         "@vue-flow/background": "^1.3.2",
         "@vue-flow/controls": "^1.1.3",
@@ -47,7 +47,7 @@
       "name": "regelrecht-frontend-lawmaking",
       "version": "1.0.0",
       "dependencies": {
-        "@nldd/design-system": "^0.8.70",
+        "@nldd/design-system": "^0.8.71",
         "@regelrecht/frontend-shared": "*",
         "vue": "^3.5.38"
       },
@@ -971,9 +971,9 @@
       }
     },
     "node_modules/@nldd/design-system": {
-      "version": "0.8.70",
-      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.70.tgz",
-      "integrity": "sha512-ZukyL2Q5sFlIFRvU8VFDEdNUyNJim1D39GV0X+7smyBzacQSLJdnew1HwEWf8F/3CT1Qf9XbIyc07iiITmyxcQ==",
+      "version": "0.8.71",
+      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.71.tgz",
+      "integrity": "sha512-j7xrsmfEK9t/noHxkJVmI9+w1kwLNamOTP8ig2EJ2lPAUFrEEIqopJBpoaZ6rYMTqNIkJP/ePlvELo7RZVwPRg==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
       "name": "regelrecht-frontend-lawmaking",
       "version": "1.0.0",
       "dependencies": {
-        "@nldd/design-system": "^0.8.71",
+        "@nldd/design-system": "^0.8.72",
         "@regelrecht/frontend-shared": "*",
         "vue": "^3.5.38"
       },


### PR DESCRIPTION
Regelrecht draait weer op een gepubliceerd ontwerpsysteem in plaats van een lokale tarball. Het bijwerken bracht breaking changes mee, en tijdens het nalopen van de schermen kwam een reeks kleine dingen boven die hier meteen mee gaan.

### Ontwerpsysteem

- Volgt de breaking changes van `nldd-list-item`: gewijzigde slots en de nieuwe boxgeometrie.
- `@nldd/design-system` komt uit npm, op 0.8.72. Die versie herstelt ook het spoor van `nldd-timeline-track-cell`, dat bij elke rijgrens onderbroken werd.

### Traject

- Trajectinstellingen heten "Algemeen". De verwijderactie staat er niet meer verstopt onder een submenu, maar in beeld in een `nldd-box` met een regel uitleg.
- Het aanmaakformulier legt uit waarom je een eigen GitHub-repo kiest en toont de exacte tokennaam die de backend verwacht. De uitleg verschijnt pas zodra de repo ingevuld is, want een halve naam levert een halve variabele op.
- De trajectknop in de toolbar is begrensd op 220px en kapt af met een ellipsis, zodat een lange trajectnaam de rest van de balk niet wegdrukt.

### Bibliotheek en navigatie

- Favorieten krijgen een ster in plaats van een hart.
- "Ondersteuning" heet Help en krijgt het vraagteken-icoon.
- "Wet toevoegen…" gebruikt `book-badge-plus`, zodat het icoon dezelfde actie zegt als het label.
- Het ledenicoon staat op 24px zonder losse spacer, in lijn met de andere lijsten.