### PR TITLE
ci(deps): dependabot gebruikt scope deps ook voor dev-dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,14 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    # Zonder dit gebruikt Dependabot `chore(deps-dev)` voor dev-dependencies,
+    # en die scope staat niet in de lijst van `pr-title.yml` — waardoor elke
+    # dev-dependency-PR op de titelcheck strandt. Eén spelling voor één
+    # begrip is beter dan de scope-lijst uitbreiden: `deps` blijft dan de
+    # enige term waar een toekomstig filter of changelog op hoeft te letten.
+    commit-message:
+      prefix: chore(deps)
+      prefix-development: chore(deps)
     labels:
       - dependencies
       - rust
@@ -38,6 +46,10 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    # Zie de toelichting bij het cargo-blok hierboven.
+    commit-message:
+      prefix: chore(deps)
+      prefix-development: chore(deps)
     labels:
       - dependencies
       - javascript
@@ -118,6 +130,10 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    # Zie de toelichting bij het cargo-blok hierboven.
+    commit-message:
+      prefix: chore(deps)
+      prefix-development: chore(deps)
     labels:
       - dependencies
       - javascript

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -2,7 +2,7 @@ import { fileURLToPath, URL } from 'node:url';
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 
-// @cucumber/messages 33 runs `createRequire(import.meta.url)('../package.json')`
+// @cucumber/messages 34 runs `createRequire(import.meta.url)('../package.json')`
 // at import time (a Node-only API). In the browser build that throws and
 // crashes every view importing the gherkin parser, so alias `node:module` to a
 // browser shim that provides a harmless `createRequire`. Scope it to the build
@@ -54,7 +54,7 @@ export default defineConfig({
     pool: 'vmThreads',
     testTimeout: 10000,
     server: {
-      // @cucumber/gherkin 40 and @cucumber/messages 33 ship as pure ESM. The
+      // @cucumber/gherkin 41 and @cucumber/messages 34 ship as pure ESM. The
       // vmThreads pool loads external ESM in a separate VM context, which throws
       // "Linked modules must use the same context". Inlining lets vitest process
       // them in the test context instead. The @regelrecht/frontend-shared


### PR DESCRIPTION
Dependabot gebruikt `chore(deps-dev)` voor dev-dependencies. Die scope staat niet in `pr-title.yml`, dus die PR's stranden op de titelcheck (#1000 stond erop vast).

Opgelost met een `commit-message`-prefix in `.github/dependabot.yml`, bij de drie ecosystemen die dev-dependencies kennen. Zo blijft `deps` de enige spelling.

Verder: twee verouderde versienummers in de comments van `frontend/vite.config.js`.
