### PR TITLE
fix(dev): trek schemaversies in de law-skills gelijk naar v0.5.6

### DIFF
--- a/.claude/skills/law-download/SKILL.md
+++ b/.claude/skills/law-download/SKILL.md
@@ -228,7 +228,7 @@ xmlns:bwb="http://www.overheid.nl/2011/BWB"
 
 **Target Structure:**
 ```yaml
-$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.5.0/schema.json
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.5.6/schema.json
 $id: "{LAW_SLUG}"
 name: "{LAW_TITLE}"
 regulatory_layer: "{MAPPED_LAYER}"

--- a/.claude/skills/law-download/download_law.py
+++ b/.claude/skills/law-download/download_law.py
@@ -73,6 +73,7 @@ def parse_wti_metadata(wti_tree):
         "GRONDWET", "WET", "AMVB", "KONINKLIJK_BESLUIT", "MINISTERIELE_REGELING",
         "BELEIDSREGEL", "EU_VERORDENING", "EU_RICHTLIJN", "VERDRAG",
         "UITVOERINGSBELEID", "GEMEENTELIJKE_VERORDENING", "PROVINCIALE_VERORDENING",
+        "WATERSCHAPS_VERORDENING",
     }
     soort = wti_tree.find(f".//{{{NS}}}soort-regeling")
     if soort is not None:
@@ -85,12 +86,13 @@ def parse_wti_metadata(wti_tree):
             "ministeriële regeling": "MINISTERIELE_REGELING",
             "beleidsregel": "BELEIDSREGEL",
             "koninklijk besluit": "KONINKLIJK_BESLUIT",
+            "waterschapsverordening": "WATERSCHAPS_VERORDENING",
         }
         layer = type_mapping.get(soort_text, soort_text.upper().replace(" ", "_"))
         if layer not in VALID_LAYERS:
             raise ValueError(
                 f"'{soort_text}' maps to '{layer}' which is not a valid "
-                f"schema v0.5.0 regulatory_layer. Map manually to e.g. AMVB."
+                f"schema v0.5.6 regulatory_layer. Map manually to e.g. AMVB."
             )
         metadata["regulatory_layer"] = layer
 
@@ -197,9 +199,9 @@ def generate_yaml(metadata, articles, effective_date):
     bwb_id = metadata.get("bwb_id")
     law_id = slugify(metadata.get("title", bwb_id or "unknown"))
 
-    # Create YAML structure matching schema v0.5.0
+    # Create YAML structure matching schema v0.5.6
     law_data = {
-        "$schema": "https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.5.0/schema.json",
+        "$schema": "https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.5.6/schema.json",
         "$id": law_id,
         "name": metadata.get("title", law_id),
         "regulatory_layer": metadata.get("regulatory_layer", "WET"),

--- a/.claude/skills/law-download/reference.md
+++ b/.claude/skills/law-download/reference.md
@@ -150,17 +150,18 @@ Map `<bwb-dl:soort>` to `regulatory_layer`:
 | ministeriële regeling | MINISTERIELE_REGELING |
 | beleidsregel | BELEIDSREGEL |
 | koninklijk besluit | KONINKLIJK_BESLUIT |
+| waterschapsverordening | WATERSCHAPS_VERORDENING |
 
-**Note:** `VERORDENING` and `REGELING` are NOT valid schema v0.5.0 enum values.
+**Note:** `VERORDENING` and `REGELING` are NOT valid schema v0.5.6 enum values.
 Valid values: GRONDWET, WET, AMVB, KONINKLIJK_BESLUIT, MINISTERIELE_REGELING,
 BELEIDSREGEL, EU_VERORDENING, EU_RICHTLIJN, VERDRAG, UITVOERINGSBELEID,
-GEMEENTELIJKE_VERORDENING, PROVINCIALE_VERORDENING.
+GEMEENTELIJKE_VERORDENING, PROVINCIALE_VERORDENING, WATERSCHAPS_VERORDENING.
 
 ## Target YAML Schema
 
 **Schema URL:**
 ```
-https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.5.0/schema.json
+https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.5.6/schema.json
 ```
 
 **Required Fields (always):**

--- a/.claude/skills/law-interpret/SKILL.md
+++ b/.claude/skills/law-interpret/SKILL.md
@@ -52,12 +52,12 @@ the pipeline.
 
 ## Step 2.5: Schema Version Check
 
-Before generating, verify the target file's `$schema` URL points to v0.5.0. If it points
-to an older version (e.g., v0.3.2 or v0.4.0), update it to:
+Before generating, verify the target file's `$schema` URL points to v0.5.6. If it points
+to an older version (e.g., v0.3.2, v0.4.0, or v0.5.0), update it to:
 ```
-https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.5.0/schema.json
+https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.5.6/schema.json
 ```
-This prevents generating v0.5.0 logic against an old schema declaration.
+This prevents generating v0.5.6 logic against an old schema declaration.
 
 ## Step 3: Generate Machine-Readable Logic
 

--- a/.claude/skills/law-reverse-validate/SKILL.md
+++ b/.claude/skills/law-reverse-validate/SKILL.md
@@ -111,7 +111,8 @@ does not close it.
 
 ## Operation Correctness Check
 
-Verify that no v0.4.0-only operations are used:
+Verify that none of these operations, removed from the schema as of v0.5.0 and still absent
+in v0.5.6, are used:
 - No `when`/`then`/`else` on IF operations (must be `cases`/`default`)
 - No SUBTRACT_DATE (must be AGE)
 - No CONCAT (must be ADD with string values)


### PR DESCRIPTION
`law-interpret`, `law-reverse-validate` en `law-download` verwezen naar v0.3.2 tot v0.5.0.

Onderweg gevonden: `download_law.py` weigerde een geldige `WATERSCHAPS_VERORDENING` omdat de guard niet was meegegroeid.

Closes #1009. `law-generate` blijft in #1008.