### PR TITLE
docs: rfc-028 over stappen en runtimes in de enrichment-keten

### DIFF
--- a/docs/src/content/rfcs/rfc-028.md
+++ b/docs/src/content/rfcs/rfc-028.md
@@ -869,13 +869,29 @@ Branching is routing, and routing is Rust rather than data:
 ```rust
 /// Builds the chain for one law. This is where RFC-027's lexical routing sits:
 /// high risk gets the full adversary, targeted risk one lens, low risk none.
-/// Chunk planning is also here, unchanged, including its termination guarantee.
+/// Window planning is also here, including its termination guarantee.
 pub fn plan_enrichment(ctx: &EnrichmentContext, profile: &AgentProfile) -> Result<Chain>;
 ```
 
 The result is a flat list, and a flat list serialises. What ran is provenance, including which steps the routing skipped.
 
 **Cheap and fallible before expensive.** A chain orders every fallible native step ahead of every agent step. Without step-level resume, a failure after three agent runs pays for those runs again on the next attempt, and the source gate, the schema checks and the context assembly can all fail for free. The chain validator enforces the ordering.
+
+### Windowing
+
+Every agent step runs over a window of articles and never over a whole law. Round 1 of the enricher archive is the measurement: the Zorgverzekeringswet was translated in one run and its 434 leden hit the 64k output ceiling, so the law came back truncated and the run was lost. No model tier fixes that, because the ceiling is per response.
+
+Three rules follow, and the first two come from RFC-026.
+
+**The window is a set of articles, never a fraction of one.** An article is the unit of work there because leden are not independently readable, and a window that cuts an article in half hands the agent a second lid whose "in afwijking van het eerste lid" points at text it cannot see.
+
+**What works on an article travels with every window that contains it.** The scoping rules of RFC-026 are per article and not per law, so they cannot be satisfied by putting the definitions in the first window and hoping. The placement path, the definitions of every enclosing container, the law-wide provisions, and the articles that modify anything in this window are assembled per window. That assembly is the largest input cost and the reason a window is smaller than the output ceiling alone would suggest.
+
+**Enumerative articles may be split by lid.** A definition article carrying forty begripsbepalingen is one article by numbering and forty independent statements by content, and the argument against splitting does not hold there: no lid modifies another. This is the one exception, and it is decided by the same `is_definition_text` test the coverage check already uses.
+
+A judgement about the law as a whole cannot be windowed at all: name collisions between articles, one concept modelled two ways in two places, an output nothing consumes. Those are deterministic checks over the finished file rather than agent work, which is where they already sit. Where a law-wide judgement does need a model, it is map-reduce over per-article summaries and never a run that reads the law whole.
+
+`EditInPlace` exists for the same reason. A runtime that can only answer with one document rewrites the file it was given, so its output ceiling becomes the file size ceiling; a runtime that edits in place is bounded by the change and not by the law.
 
 ### Artefacts
 

--- a/docs/src/content/rfcs/rfc-028.md
+++ b/docs/src/content/rfcs/rfc-028.md
@@ -1,0 +1,1124 @@
+---
+title: "RFC-028: Steps and Runtimes for the Enrichment Chain"
+status: Draft
+implementation: Not implemented
+date: '2026-08-01'
+authors:
+  - Eelco Hotting
+depends_on:
+  - RFC-012 (Untranslatables)
+  - RFC-026 (Enrichment a Legal Expert Can Check)
+short_title: Agent Steps
+---
+
+## Context
+
+RFC-026 splits enrichment into roles with separate contexts: a qualifier that reads and classifies, a producer that translates within that classification, an adversary that tries to bring the translation down, and an arbiter that decides. Those roles are separate agent runs whose firewalls are the whole point, and the pipeline has no way to say what a run is.
+
+The seam it has instead couples the agent to the domain. The invocation trait takes the enrichment payload, so the thing that knows how to run an agent also knows what enrichment means; a second chain therefore needs a second trait, which is why document conversion and law structuring each grew their own. Below that seam the tool allowlist of one CLI travels through three signatures as a boolean named after a shell.
+
+The cost of having no step object is recorded in issue #1036. The shape of it: an instruction prescribes work the runtime cannot perform, nothing compares the two, and the step runs to a clean exit having done nothing. A gate that only inspects the final file cannot tell that apart from a step that had nothing to do.
+
+This RFC defines the layer underneath RFC-026's roles: a step is data that says what must happen and what it needs, a runtime is a thing that can execute such a step and translate its needs into its own flags, and the choice of runtime, model and budget per step is configuration. It also decides how far that abstraction reaches, because the interesting half of the design is what it refuses to hide.
+
+The name for the boundary is deliberate. An ORM hides which database answers a query and does not hide that a query can fail, that a column has a type, or that a join costs something. The same applies here: the runtime layer hides which agent runs a step, and refuses to hide that a step needs a shell, that a model has a context window, or that an instruction assumes a tool loop.
+
+## Requirements
+
+**A step must declare what it needs, and the declaration must be checkable against the instruction.** A capability field a human fills in by hand next to a prompt a human writes by hand reproduces the failure it is meant to prevent: the same person forgets in both places, and comparing two hand-written declarations catches nothing. The declaration is only worth its cost when part of it is derived and part of it is verified against what the run actually did.
+
+**A step that cannot be executed as specified must not start.** A missing capability, a model whose context window cannot hold the mounted inputs, an instruction that assumes a tool loop on a runtime that has none: all three are known before a process is spawned, and all three are configuration faults rather than properties of the law being translated.
+
+**A step must not be able to see what the chain withheld from it.** RFC-026 requires the adversary to re-derive the classification without the reading note, and the qualifier to classify without knowing what the model looks like. That must be a property of what is placed in front of the agent rather than a sentence in a prompt, and the enforcement level must be stated honestly, because a context boundary between cooperating processes is not a security boundary.
+
+**The runtime must be identified in the provenance well enough to answer "which agent wrote this".** Runtime name, CLI version, resolved model, the instruction digest, the digest of every mounted skill, the granted capabilities and what the run did with them.
+
+**Per-step configuration must reach model choice and budget.** The reading is the expensive judgement and the production is bound by it; a single model for the whole chain overpays for one or underpays for the other.
+
+**Failure must be typed at the point it is known.** Whether a job retries, exhausts a law, or waits for a human is decided from the shape of the failure, and reconstructing that shape by matching substrings against an error's display format makes a formatting change a behaviour change.
+
+**Every agent run must be countable.** The spend guard, the throughput budget and the question "which laws ran under the old qualifier" are all queries over runs. A chain multiplies runs per job, so a counter that counts jobs stops meaning what it meant.
+
+## The step
+
+A step is data. It states what must happen and what the result must satisfy, and it says nothing about which agent, which model or which flags. The module is `packages/pipeline/src/agent/`.
+
+```rust
+/// Stable identity of one step within a chain. Configuration key, provenance
+/// key, and the name in the logs. Never reused with a different meaning,
+/// because older runs refer to it.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct StepId(pub Cow<'static, str>);
+
+impl fmt::Display for StepId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// The role the agent stands in. Carries the default configuration and the
+/// context firewall. A chain may hold several steps in one role.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Role {
+    Qualifier,
+    Producer,
+    Adversary,
+    Arbiter,
+    Converter,
+}
+
+/// How the agent is expected to work. A `SingleShot` step can run on any
+/// runtime; an `Agentic` step assumes a tool loop that reads, edits and
+/// re-reads, and is refused by a runtime that answers in one turn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Modality {
+    SingleShot,
+    Agentic,
+}
+
+/// One agent step, fully resolved for one invocation.
+#[derive(Clone)]
+pub struct StepSpec {
+    pub id: StepId,
+    pub role: Role,
+    pub modality: Modality,
+
+    /// The instruction as the agent receives it. Already rendered: no
+    /// template, no placeholders, no CLI syntax. The chain planner builds it,
+    /// and its digest is provenance.
+    pub instruction: String,
+
+    /// What appears in the working directory and what the agent may do with
+    /// it. Anything absent from this list does not exist in that directory.
+    pub mounts: Vec<Mount>,
+
+    /// Capabilities the step needs beyond what the mounts imply. An empty set
+    /// is valid and is the intended value for most steps.
+    pub capabilities: CapabilitySet,
+
+    /// What "done" means. Deterministic, evaluated in the worker's own
+    /// process against published artefacts, without the agent.
+    pub success: Arc<dyn Criterion>,
+
+    /// What happens when the success criterion is not met.
+    pub on_unmet: OnUnmet,
+}
+```
+
+`timeout`, `model`, `attempts` and `runtime` are deliberately absent. `StepSpec` says what the step wants; `StepLimits` says what it is allowed to spend and on what. A step must stay readable without knowing which agent runs it, and the same step must mean the same thing in a local single-law run and in the worker.
+
+### Mounts
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Mode {
+    /// The agent reads this and may not change it. A changed read mount is a
+    /// recorded violation and is never published.
+    Read,
+    /// Does not exist yet; the agent must create it at this path.
+    Create,
+    /// Exists and is edited in place. Input and output at once.
+    Modify,
+    /// The agent produces an unknown number of files under this directory.
+    /// Only files matching `suffix` are published, under generated artefact
+    /// names derived from `artifact`.
+    CreateSet { suffix: Cow<'static, str> },
+}
+
+#[derive(Debug, Clone)]
+pub struct Mount {
+    pub artifact: ArtifactRef,
+    /// Path inside the working directory, always relative and always
+    /// normalised. The agent sees this path in its instruction and never an
+    /// absolute path belonging to the worker.
+    pub path: PathBuf,
+    pub mode: Mode,
+}
+
+impl StepSpec {
+    pub fn inputs(&self) -> impl Iterator<Item = &Mount>;   // Read | Modify
+    pub fn outputs(&self) -> impl Iterator<Item = &Mount>;  // Create | Modify | CreateSet
+}
+```
+
+One list with a mode, because an artefact appearing in two lists can be given two contradictory modes. `Modify` covers the law YAML, which is input and output at once. `CreateSet` covers the case where the number and the names of the outputs are the agent's choice, as they are for MvT-derived feature files; without it those files are silently discarded by the write-back rule.
+
+Mount paths pass the same normaliser that guards payload paths against traversal and absolute paths. Mounts originate in Rust code, which makes that theoretical until the first one arrives from configuration, and by then the guard has to already be there.
+
+### Success criteria
+
+```rust
+/// Everything a criterion may look at. The bus rather than the working
+/// directory, because a criterion judges what the step published, and both
+/// snapshots, because most of these criteria are deltas.
+pub struct CriterionCtx<'a> {
+    pub bus: &'a ArtifactBus,
+    pub before: &'a Snapshot,
+    pub after: &'a Snapshot,
+    /// Corpus root for cross-law checks, when the chain has one.
+    pub corpus_root: Option<&'a Path>,
+    /// The article window this run was assigned, when the chain is chunked.
+    pub window: Option<&'a ArticleWindow>,
+    pub ledger: &'a ToolLedger,
+}
+
+#[async_trait::async_trait]
+pub trait Criterion: Send + Sync {
+    /// Short name for logs and provenance ("schema_valid", "window_progress").
+    fn name(&self) -> &'static str;
+    async fn evaluate(&self, ctx: &CriterionCtx<'_>) -> Judgement;
+}
+
+pub enum Judgement {
+    Met,
+    /// The reasons go into the repair instruction verbatim, because a
+    /// paraphrase loses the instance path that says where the problem is.
+    /// `kind` classifies the failure at the point where it is known.
+    NotMet {
+        reasons: Vec<String>,
+        kind: FailureKind,
+    },
+}
+
+/// Digest plus the parsed facts a criterion needs, captured at a chain
+/// boundary. Taken before and after each step so deltas are expressible.
+pub struct Snapshot {
+    entries: BTreeMap<ArtifactRef, ArtifactState>,
+}
+
+pub struct ArtifactState {
+    pub digest: Digest,
+    pub bytes: u64,
+    /// Article and coverage counts, when the artefact is a law document.
+    pub law_stats: Option<LawStats>,
+}
+```
+
+The type is named `Judgement` rather than `Verdict` because the source gate already owns `Verdict` in the same crate.
+
+The signature takes the bus and two snapshots rather than the working directory. A criterion that could only see the directory the agent worked in could express none of the checks that matter: article count unchanged is a delta, window progress is a delta against a window the planner assigned, binding integrity reads sibling laws from the corpus root, and the schema gate only applies when the run changed something.
+
+The criteria the chain needs, and where each already lives:
+
+| Criterion | Source |
+|---|---|
+| `SchemaValid` | `enrich_v2::checks::schema_errors` |
+| `ArticleCountUnchanged` | inline in the enrichment orchestration |
+| `WindowProgress` | inline, including the rule that a chunk report must name an article of this window |
+| `NoNewFindings { max }` | `enrich_v2::checks::run` |
+| `SourceGateVerified` | `enrich_v2::source_gate::GateReport::passes` |
+| `OutputsPresent` | the empty-output guards in law and document conversion |
+| `NoUndeclaredToolDenials` | new, from the tool ledger |
+| `DeclaredCapabilitiesWereUsed` | new, from the tool ledger |
+
+`AllOf(Vec<Arc<dyn Criterion>>)` combines them and reports the heaviest `FailureKind` among the unmet ones. The producer step gets `AllOf([ArticleCountUnchanged, SchemaValid, WindowProgress])`.
+
+`SourceGateVerified` cannot be a criterion on its own, because verification compares the corpus file against the official toestand and that comparison needs the official text. The gate is a native step that fetches and publishes the official articles as an artefact; the criterion compares two published artefacts. That split is the general rule: a criterion reads the bus and never the network.
+
+`OutputsPresent` needs the distinction the chunk guard already draws. A step that ran and legitimately produced nothing is not a failed step: RFC-026 lets the adversary state that no tenable counter-reading exists on a lens, and that is an empty findings file from a successful run. Emptiness therefore only fails where the step's own contract says the artefact must be non-empty, and where a step may legitimately be empty it must publish a report saying so.
+
+### When a criterion is not met
+
+```rust
+#[derive(Clone)]
+pub enum OnUnmet {
+    /// Stop the chain. The failure class comes from the judgement, not from
+    /// this variant, so one step with several criteria keeps their distinct
+    /// classes instead of flattening them into one.
+    Fail,
+
+    /// Re-run the same step with a repair instruction carrying the reasons.
+    /// Same role, same mounts, same capabilities: the firewall stands. The
+    /// round limit comes from `StepLimits::repair_rounds`, which is the only
+    /// place it is written.
+    Repair {
+        prompt: Arc<dyn RepairPrompt>,
+        then: Box<OnUnmet>,
+    },
+
+    /// Record the reasons on a marking channel and continue. RFC-026 treats a
+    /// recorded disagreement as a usable output. The chain validator rejects a
+    /// chain where a later step mounts an artefact this step may fail to
+    /// produce.
+    Mark { channel: MarkChannel },
+}
+
+/// The three terminal semantics the job queue distinguishes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FailureKind {
+    /// The same input reproduces the same failure. The job fails terminally
+    /// and the law's exhaustion counter advances.
+    Deterministic,
+    /// May be tried again. A chunk that produced nothing reviewable belongs
+    /// here: a healthy law whose window hiccupped must never be exhausted in
+    /// one step.
+    Retryable,
+    /// The chain, the profile or the runtime is wrong, and the law has nothing
+    /// to do with it. The job fails terminally, the law is marked failed, and
+    /// the exhaustion counter is left alone, because a profile error that hits
+    /// a whole sweep must not cost one manual reset per law.
+    Misconfigured,
+}
+
+/// The channels of RFC-026 section 6, kept apart because they have different
+/// owners.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MarkChannel {
+    /// The engine cannot express this (RFC-012).
+    Untranslatable,
+    /// The text did not determine the structure and the agent chose.
+    StructuralChoice,
+    /// A disagreement that survived arbitration, for a legal expert.
+    OpenQuestion,
+}
+
+pub trait RepairPrompt: Send + Sync {
+    fn render(&self, reasons: &[String], ctx: &CriterionCtx<'_>) -> String;
+}
+```
+
+`Mark` always writes a record. There is no variant that continues silently, because a step that produced nothing and reported nothing is the failure this RFC exists to remove.
+
+`Repair` generalises the two identical one-round repair loops that exist separately for schema errors in enrichment and validation errors in law conversion: same policy, two implementations, two prompt builders.
+
+## Capabilities
+
+A capability is what the step must be able to do, stated in the vocabulary of the work. Tool allowlists are a translation of it, and the translation belongs to the runtime.
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum Capability {
+    /// Read files in the working directory.
+    ReadFiles,
+    /// Create or overwrite files in the working directory.
+    WriteFiles,
+    /// Change a file in place rather than rewriting it whole. Separate from
+    /// `WriteFiles` because a runtime that answers with one document cannot do
+    /// it, and a law of 140 KB rewritten whole through an 8k output limit
+    /// comes back truncated.
+    EditInPlace,
+    /// Search within the working directory.
+    SearchFiles,
+    /// Run named programs. The step names which, never "a shell".
+    RunTools(ToolSet),
+    /// Retrieve from named, allowed sources.
+    FetchSources(SourceAllow),
+    /// Open-ended web search. Unbounded and uncacheable, and therefore a
+    /// different capability from `FetchSources`.
+    SearchWeb,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CapabilitySet(BTreeSet<Capability>);
+
+impl CapabilitySet {
+    pub fn insert(&mut self, cap: Capability) -> bool;
+    pub fn contains(&self, cap: &Capability) -> bool;
+    pub fn is_empty(&self) -> bool;
+    pub fn difference(&self, other: &CapabilitySet) -> CapabilitySet;
+    pub fn union(&self, other: &CapabilitySet) -> CapabilitySet;
+}
+
+/// The rendering of a set is the body of the refusal message, so it is part of
+/// the design rather than a formality.
+impl fmt::Display for CapabilitySet { /* comma-separated, sorted */ }
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ToolSet(pub BTreeSet<String>);        // {"pandoc", "pdftotext"}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum SourceAllow {
+    /// These hosts, exactly.
+    Hosts(BTreeSet<String>),
+}
+```
+
+Corpus access is not a capability. Reading another law is fulfilled by mounting that law, which the planner resolves to concrete paths, so it is a mount and nothing else. A whole-corpus capability is deliberately absent: the sparse checkout exists because indexing the whole corpus blew up the context window and the memory ceiling, and a capability that reinstates it is one that would have to be withdrawn later.
+
+`FetchSources` on an agent step is almost always the wrong answer, and the right one is that the worker fetches and mounts the result. That is what the source gate already does and why: the fetching belongs to harvesting, the worker validates what it fetched, and the agent reads what the worker vouched for. The capability exists anyway, because the alternative is the failure it is named after: an instruction that requires the network, a runtime that does not provide it, and nothing that says so.
+
+The same holds for `RunTools`. A validate-and-test loop inside the agent is not a capability to be granted; it disappears, because the validator is a library call in the worker and its result is a success criterion. `RunTools` remains for work that is genuinely the agent's, such as converting a document format the deterministic extractors do not handle.
+
+### Derived rather than declared twice
+
+Three things derive the required set, and only the third is written by hand.
+
+```rust
+impl StepSpec {
+    /// Capabilities implied by the mounts.
+    fn mount_capabilities(&self) -> CapabilitySet;
+
+    /// The full set: implied by mounts, declared by mounted skills, plus
+    /// whatever the step states explicitly.
+    pub fn required_capabilities(&self, skills: &SkillIndex) -> Result<CapabilitySet>;
+}
+
+/// `allowed-tools` from a skill's front matter, mapped back into this
+/// vocabulary. A mounted skill therefore carries its own requirements, and the
+/// step author cannot forget them on the step's behalf.
+pub fn capabilities_of_skill(front_matter: &str) -> Result<CapabilitySet>;
+```
+
+A mount of mode `Create`, `Modify` or `CreateSet` yields `WriteFiles`; `Modify` also yields `EditInPlace`; any input yields `ReadFiles`. A step that mounts an output and forgets to ask for write access therefore cannot exist.
+
+The skill derivation is what makes the declaration self-checking rather than a second place to remember the same thing. A step that mounts a research skill whose front matter declares web access acquires `FetchSources` and `SearchWeb` from that mount, and a runtime that cannot provide them refuses the step before it starts. The instruction and the grant stop being two independent guesses, because the skill is the instruction's own statement of what it needs.
+
+### Declared, realised, observed
+
+Checking a declaration against a declaration closes one failure mode and leaves the other open: it catches a step asking for something the runtime does not know, and it cannot catch a step whose instruction requires something nobody declared. Three levels are needed, and only the third settles what happened.
+
+**Declared.** `AgentRuntime::capabilities(&limits)`, hand-written per runtime and model. Proves nothing on its own.
+
+**Realised.** `CommandBuilder::probe()` at construction, once per process, checking that the named tools are on `PATH` and that the CLI's flag vocabulary supports the translation this builder emits. A version bump that removes a flag is otherwise a silent change to the effective grant, which is the failure of issue #1036 arriving through a different door.
+
+**Observed.** The agent's own event stream, folded into a bounded ledger while the process runs.
+
+```rust
+#[derive(Debug, Default, Clone)]
+pub struct ToolLedger {
+    /// Tool name to successful invocations.
+    pub used: BTreeMap<String, u32>,
+    /// Tool name to denied invocations.
+    pub denied: BTreeMap<String, u32>,
+}
+
+/// Folds one line of a runtime's event stream into the ledger. Bounded by
+/// construction: the line is parsed and dropped, never retained, because a
+/// verbose agent inlines whole fetched pages into that stream.
+pub trait EventParser: Send + Sync {
+    fn absorb(&self, line: &str, ledger: &mut ToolLedger);
+}
+```
+
+Two facts become hard failures instead of silence. A denied call to a capability the step did not declare is a defect in the step, not in the law, and fails as `Misconfigured`. A declared capability that was never exercised means the egress is closed, or the account does not have the tool, or the instruction never asks for it, and all three are worth knowing.
+
+This is the only mechanism in the design that would have caught the failure in #1036 on the run that had it, and it is the reason the capability model is worth its weight. Without the ledger and the skill derivation, a capability field is a comment with a type.
+
+### Refuse before the start
+
+A shortfall is knowable before a process exists, so it is refused there.
+
+```rust
+/// Checked for every step of a chain before the first one runs, against the
+/// resolved runtime and limits. A chain that would spend three agent runs
+/// before discovering that the fourth cannot execute fails in zero seconds
+/// instead of forty minutes.
+pub fn preflight(
+    step: &StepSpec,
+    rt: &dyn AgentRuntime,
+    limits: &StepLimits,
+    ws: &WorkspacePlan,
+    skills: &SkillIndex,
+) -> std::result::Result<(), RuntimeError>;
+```
+
+Three refusals, all before spawning. A capability the runtime does not provide. A modality the runtime does not support, where an `Agentic` instruction meets a single-turn runtime. And a step whose mounts do not fit, where the planned mount bytes exceed what the resolved model's context window can hold.
+
+The third is what makes the abstraction honest about the difference that actually separates the two existing lanes. A model with a 32k context window does not fail the producer step because it holds too many tools; it fails because the law does not fit. The mounted bytes are known and the window is known, so "this model cannot do this step" is a refusal rather than an invented output format discovered later by a schema check.
+
+There is no fallback path. A step that requires the network on a runtime without the network does not run, not even for the rest of the work, because the failure this design removes is a step that started and did nothing.
+
+### Over-granting
+
+A runtime that cannot narrow a capability to what was asked may run, and must say so.
+
+```rust
+pub struct CapabilityGrant {
+    /// What the step asked for.
+    pub requested: CapabilitySet,
+    /// What the runtime actually permits. A superset of `requested` where the
+    /// runtime cannot be finer.
+    pub effective: CapabilitySet,
+    /// `effective` minus `requested`, recorded per run.
+    pub over_granted: CapabilitySet,
+    /// Files the runtime wrote into the working directory to realise the
+    /// grant, such as a settings or permission file. Exempt from the
+    /// write-back rule and never published.
+    pub scaffold: Vec<PathBuf>,
+    /// The runtime's own rendering, for the logs. The only place where flag
+    /// syntax exists.
+    pub rendered: Vec<String>,
+}
+```
+
+Over-granting is computed from what the builder could actually render, per capability, rather than from a fixed table. Where a CLI supports scoped permissions, a tool set narrows to those programs and a source allowance narrows to those hosts, and the over-grant is empty even though prefix matching is not a security boundary. Where it does not, the over-grant is recorded and shows up as a number rather than as a suspicion.
+
+## The runtime
+
+```rust
+#[async_trait::async_trait]
+pub trait AgentRuntime: Send + Sync {
+    /// Name in configuration, logs and provenance.
+    fn name(&self) -> &str;
+
+    /// Full identity for the provenance: name, CLI version, resolved model.
+    fn identity(&self, limits: &StepLimits) -> RuntimeIdentity;
+
+    /// What this runtime provides for these limits. A function of runtime and
+    /// model together, because the model decides the context window and
+    /// therefore what fits.
+    fn capabilities(&self, limits: &StepLimits) -> CapabilitySet;
+
+    /// Whether this step can be executed here at all: modality, and whether
+    /// the planned mounts fit the window.
+    fn fit(&self, step: &StepSpec, ws: &WorkspacePlan, limits: &StepLimits)
+        -> std::result::Result<(), RuntimeError>;
+
+    /// Write whatever scaffold this runtime needs into the prepared working
+    /// directory and return the resulting grant. Runtimes that realise their
+    /// permissions through a configuration file rather than through argv do it
+    /// here, which is why this takes the workspace and `build` does not.
+    fn realize(&self, step: &StepSpec, ws: &Workspace, limits: &StepLimits)
+        -> std::result::Result<CapabilityGrant, RuntimeError>;
+
+    /// Run one step in a prepared working directory.
+    async fn run(&self, req: StepRequest<'_>)
+        -> std::result::Result<StepReport, RuntimeError>;
+}
+```
+
+### Input
+
+```rust
+pub struct StepRequest<'a> {
+    pub step: &'a StepSpec,
+    /// The working directory. Already created and already populated by the
+    /// executor, which also removes it afterwards.
+    pub workspace: &'a Workspace,
+    pub grant: &'a CapabilityGrant,
+    pub limits: &'a StepLimits,
+    /// 1-based. A repair round counts as a further attempt of the same step.
+    pub attempt: u8,
+}
+
+pub struct Workspace {
+    root: PathBuf,
+    mounts: Vec<RealizedMount>,
+}
+
+pub struct RealizedMount {
+    pub artifact: ArtifactRef,
+    pub abs_path: PathBuf,
+    pub mode: Mode,
+    pub digest_before: Option<Digest>,
+}
+
+impl Workspace {
+    pub fn root(&self) -> &Path;
+    pub fn path_of(&self, artifact: &ArtifactRef) -> Option<&Path>;
+    /// The single `Modify` mount, if there is exactly one. Runtimes that take
+    /// an input-file flag derive it from this rather than from a parameter.
+    pub fn primary_input(&self) -> Option<&RealizedMount>;
+    pub fn total_input_bytes(&self) -> u64;
+}
+```
+
+The runtime does not choose the working directory. The executor owns it, creates it empty per step, lays the mounts, and removes it afterwards including on a panic. Every runtime is given the same directory in the same way, including the ones whose CLI takes a directory flag rather than inheriting a process working directory, because a runtime whose process working directory is the worker's own resolves relative paths against the wrong tree the moment a step is allowed to run a program.
+
+The input-file flag is derived from the mounts rather than passed by the caller, which is where it belongs: a caller with no single input file should not have to know that one provider reads that flag as text context and would misread a binary document through it. Note that such a flag feeds a file as context and does not give the agent a route to write it back, so `EditInPlace` on a runtime whose only file mechanism is that flag is not provided, and preflight refuses the step.
+
+### Output
+
+```rust
+pub struct StepReport {
+    pub runtime: RuntimeIdentity,
+    pub started_at: DateTime<Utc>,
+    pub duration: Duration,
+    /// How the process ended. All four are facts about the run; what they mean
+    /// is the executor's decision.
+    pub exit: AgentExit,
+    /// Bounded tail, retained for diagnostics.
+    pub stderr_tail: String,
+    pub grant: CapabilityGrant,
+    pub ledger: ToolLedger,
+    /// Only when the runtime reports it. Never estimated.
+    pub usage: Option<Usage>,
+}
+
+pub enum AgentExit {
+    Completed,
+    NonZero { code: Option<i32> },
+    TimedOut { limit: Duration },
+    MemoryKilled { observed_mb: u64, limit_mb: u64 },
+}
+```
+
+**Only `AgentExit::Completed` publishes.** A step killed on the timeout leaves a half-rewritten law behind, and publishing that risks a truncated file passing an article count and a schema check and being recorded as done. A non-completing exit discards the working directory and the chain fails; nothing partial reaches the bus.
+
+### Errors mean "could not run"
+
+`Err(RuntimeError)` means the agent could not be run. `Ok(StepReport)` means it ran, including badly.
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum RuntimeError {
+    /// The step asks for capabilities this runtime does not provide.
+    #[error("step {step} requires capabilities runtime {runtime} does not provide: {missing}")]
+    Unsupported {
+        step: StepId,
+        runtime: String,
+        missing: CapabilitySet,
+    },
+
+    /// The step's modality or its mounted bytes do not fit this runtime and
+    /// model.
+    #[error("step {step} does not fit runtime {runtime}: {reason}")]
+    DoesNotFit {
+        step: StepId,
+        runtime: String,
+        reason: String,
+    },
+
+    /// The runtime binary is absent or refuses to start.
+    #[error("runtime {runtime} is unavailable: {reason}")]
+    RuntimeMissing { runtime: String, reason: String },
+
+    /// Authentication was rejected. Separate from `RuntimeMissing` because
+    /// token rotation gives a later attempt a different credential, so this
+    /// one is worth retrying and the other is not.
+    #[error("runtime {runtime} rejected authentication: {reason}")]
+    AuthRejected { runtime: String, reason: String },
+
+    /// The container can no longer start processes or threads. Separate
+    /// branch because the worker restarts on this rather than failing the job.
+    #[error("environment exhausted: {reason}")]
+    ResourceExhausted { reason: String },
+}
+
+impl RuntimeError {
+    pub fn failure_kind(&self) -> FailureKind;
+}
+```
+
+Resource exhaustion is not only a spawn failure. The markers that identify it also arrive in the agent's stderr on a non-zero exit, so the executor classifies `stderr_tail` on every non-completing exit and can raise `ResourceExhausted` from a report as well as from an error. Without that, moving non-zero exits from the error channel to the report channel would quietly stop the worker restarting when it should.
+
+### The supervisor
+
+Everything protecting the worker from the subprocess lives in one place, and no runtime reimplements it.
+
+```rust
+/// Starts and supervises a subprocess. Provider-agnostic.
+pub struct Supervisor;
+
+pub struct SupervisorLimits {
+    pub timeout: Duration,
+    pub max_rss_mb: u64,
+    /// Ceiling on any single argv entry. An instruction that exceeds it is
+    /// passed on stdin instead, and an instruction that exceeds it on a
+    /// runtime with no stdin path is a `DoesNotFit`.
+    pub max_argv_bytes: usize,
+}
+
+pub struct Supervised {
+    pub exit: AgentExit,
+    pub stderr_tail: String,
+    pub ledger: ToolLedger,
+}
+
+impl Supervisor {
+    pub async fn supervise(
+        &self,
+        cmd: tokio::process::Command,
+        instruction: &str,
+        limits: &SupervisorLimits,
+        events: &dyn EventParser,
+    ) -> std::result::Result<Supervised, RuntimeError>;
+}
+
+/// What a provider owns. This is all a new agent must supply.
+pub trait CommandBuilder: Send + Sync {
+    fn identity(&self, limits: &StepLimits) -> RuntimeIdentity;
+    fn capabilities(&self, limits: &StepLimits) -> CapabilitySet;
+    fn fit(&self, step: &StepSpec, ws: &WorkspacePlan, limits: &StepLimits)
+        -> std::result::Result<(), RuntimeError>;
+    fn realize(&self, step: &StepSpec, ws: &Workspace, limits: &StepLimits)
+        -> std::result::Result<CapabilityGrant, RuntimeError>;
+    fn build(&self, req: &StepRequest<'_>)
+        -> std::result::Result<tokio::process::Command, RuntimeError>;
+    fn events(&self) -> &dyn EventParser;
+    /// Verifies at construction that the named tools are on `PATH` and that
+    /// this CLI version supports the flags this builder emits.
+    fn probe(&self) -> std::result::Result<(), RuntimeError>;
+}
+
+/// The only `AgentRuntime` that starts a process.
+pub struct ProcessRuntime {
+    supervisor: Supervisor,
+    builder: Box<dyn CommandBuilder>,
+}
+
+/// The environment the subprocess is allowed to see. Shared by every builder,
+/// because stripping the worker's database credentials out of an agent's
+/// environment is not a property of one provider.
+pub fn safe_env() -> Vec<(String, String)>;
+```
+
+What the supervisor owns, and what must survive the move: the process group so a kill reaches the whole tree rather than the direct child, with the guard against signalling process group zero and the drop-time kill as a backstop; the RSS watchdog over `/proc` with its explicit degradation on non-Linux and the reason it is not a resource limit; the bounded stderr tail with re-logging and the cancellation of the drain task on every exit path; the fixed-block draining of stdout so a full pipe cannot deadlock the child, now feeding the event parser instead of being discarded; the stripped environment; the node heap ceiling, which is the first brake the memory watchdog is the second of; and stdin, which is closed or carries the instruction and is never inherited from the worker.
+
+Token rotation across several subscription credentials is provider-specific and belongs to that provider's builder. The environment allowlist is not, because it carries names for more than one provider and it protects the worker rather than the agent.
+
+### What the runtime hides and what it does not
+
+Capabilities are rendered onto whichever axes the CLI has. Where a CLI separates the set of tools offered to the model from the set of calls permitted without confirmation, both are set from the same grant: an undeclared capability is neither offered nor permitted. Offering a tool that is then refused at call time is precisely how an instruction can prescribe work that never happens, so a grant renders on every axis the runtime has, and `rendered` is a list rather than a string.
+
+A runtime that discovers configuration from the working directory and its ancestors, or that keeps session state in the home directory, has a second channel into the step that the mount list does not describe. The grant therefore also fixes which setting sources are active and whether session state persists, and those settings are part of what `realize` returns. A firewall stated only over files in one directory, on a runtime that reads instructions from three other places, is not stated.
+
+## Configuration
+
+Three layers, resolved per field, last one wins.
+
+```rust
+/// What one step execution may spend, and on what. Everything `StepSpec`
+/// deliberately does not say.
+#[derive(Debug, Clone)]
+pub struct StepLimits {
+    pub runtime: RuntimeId,
+    /// Resolved, never optional, so a run can never record its model as
+    /// "default".
+    pub model: String,
+    /// Ceiling for this step. The chain budget may allot less.
+    pub timeout: Duration,
+    /// Attempts at runtime level (spawn failure, timeout). Distinct from the
+    /// job retry ladder.
+    pub attempts: u8,
+    /// Ceiling for `OnUnmet::Repair`, written here and nowhere else.
+    pub repair_rounds: u8,
+}
+
+/// Optional per field, so inheritance works field by field rather than
+/// section by section.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct PartialLimits { /* Option<T> per field */ }
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct RuntimeId(pub String);
+
+/// Everything about a runtime that is environmental rather than per step: the
+/// binary, the memory ceiling, the context window of its models.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RuntimeSpec {
+    pub kind: RuntimeKind,
+    pub bin: PathBuf,
+    pub max_rss_mb: u64,
+    pub models: BTreeMap<String, ModelSpec>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+pub struct ModelSpec {
+    pub context_tokens: u32,
+    pub max_output_tokens: u32,
+}
+
+pub struct AgentProfile {
+    defaults: StepLimits,
+    by_role: HashMap<Role, PartialLimits>,
+    by_step: HashMap<StepId, PartialLimits>,
+    runtimes: HashMap<RuntimeId, RuntimeSpec>,
+}
+
+impl AgentProfile {
+    pub fn from_toml(src: &str) -> Result<Self>;
+    /// Environment overlay, applied after the file.
+    pub fn with_env_overlay(self) -> Self;
+    /// Chain-wide runtime override, which is what a lane selection is.
+    pub fn with_runtime_override(self, runtime: RuntimeId) -> Self;
+    pub fn resolve(&self, step: &StepSpec) -> StepLimits;
+    /// Recorded per run so a result can be traced to the configuration that
+    /// produced it.
+    pub fn digest(&self) -> String;
+}
+```
+
+The memory ceiling sits on the runtime rather than on the step, because it describes a process rather than a piece of work and means nothing for a runtime that does not start one.
+
+The profile is a checked-in TOML file built into the image. TOML because this is configuration; the corpus stays YAML. This adds a `toml` dependency to the workspace.
+
+```toml
+[defaults]
+runtime       = "claude"
+model         = "sonnet"
+timeout_secs  = 600
+attempts      = 1
+repair_rounds = 1
+
+# The qualifier does the reading, which is the most expensive judgement in the
+# chain: six questions per lid that each require a legal call, and an error
+# here propagates into everything after it.
+[role.qualifier]
+model        = "opus"
+timeout_secs = 900
+
+# The producer translates within a classification that is already fixed. More
+# mechanical, and its success criterion is deterministic, so an error is seen.
+[role.producer]
+model         = "sonnet"
+timeout_secs  = 900
+repair_rounds = 1
+
+# The adversary must find a counter-reading nobody else saw.
+[role.adversary]
+model        = "opus"
+timeout_secs = 600
+
+[role.arbiter]
+model        = "opus"
+timeout_secs = 300
+
+[runtime.claude]
+kind       = "process"
+bin        = "claude"
+max_rss_mb = 3500
+
+[runtime.claude.models.sonnet]
+context_tokens     = 200000
+max_output_tokens  = 64000
+
+[runtime.claude.models.opus]
+context_tokens     = 200000
+max_output_tokens  = 64000
+```
+
+Running the qualifier on a different model is one line in this file, or one environment variable for a single run.
+
+### The chain budget
+
+Per-step timeouts in the profile are ceilings rather than reservations, and the chain never spends more than the job allows.
+
+```rust
+pub struct ChainBudget {
+    /// What the job leaves, minus reserve for commit and cleanup.
+    pub total: Duration,
+    /// Below this a step is not worth starting.
+    pub floor: Duration,
+}
+
+impl ChainBudget {
+    /// Whether the whole chain can run at all, checked before the first step.
+    pub fn admits(&self, chain: &Chain, profile: &AgentProfile) -> bool;
+
+    /// The actual limit for the next step, or `None` when what remains after
+    /// reserving the floor for the steps still to come is itself below the
+    /// floor. Then the chain fails with an explicit budget error rather than
+    /// starting a step that is certain to be cut off.
+    pub fn allot(&self, remaining: Duration, steps_left: usize, want: Duration)
+        -> Option<Duration>;
+}
+```
+
+`admits` runs before the first step. A chain that cannot fit must not spend three agent runs discovering it, and on a chain without step-level resume a `None` halfway through discards everything before it.
+
+A four-role chain does not fit inside a job timeout sized for one agent run, and the job timeout cannot be raised past the orphan reaper's threshold without the reaper killing healthy jobs. Both move together or the chain does not run, and moving them lengthens the time a stuck job blocks a serial queue. The numbers are in the decision list rather than here, because they are deployment values.
+
+## The chain
+
+### Shape
+
+A linear sequence rather than a graph.
+
+```rust
+pub enum ChainStep {
+    Agent(StepSpec),
+    /// Work the worker does itself: the source gate, the assembler, the
+    /// deterministic checks.
+    Native(NativeStep),
+}
+
+pub struct Chain {
+    pub id: ChainId,
+    pub steps: Vec<ChainStep>,
+    /// Artefacts that leave the chain, with the corpus path each takes.
+    pub exports: Vec<Export>,
+}
+
+pub struct NativeStep {
+    pub id: StepId,
+    pub op: Arc<dyn NativeOp>,
+}
+
+#[async_trait::async_trait]
+pub trait NativeOp: Send + Sync {
+    fn name(&self) -> &'static str;
+    /// Whether this operation can fail. Chain ordering uses it: a fallible
+    /// native step may not sit behind an agent step.
+    fn can_fail(&self) -> bool;
+    async fn run(&self, bus: &mut ArtifactBus, corpus_root: Option<&Path>) -> Result<()>;
+}
+```
+
+Native operations get the corpus root, because the checks that motivate the whole exercise read sibling laws and a bus of artefacts cannot supply them.
+
+Linear because RFC-026's chain is linear, and because parallelism buys nothing here: the roles are separate runs inside one job rather than separate job types, since three job types would clone one law three times and hit the per-provider rate cap three times for it.
+
+Branching is routing, and routing is Rust rather than data:
+
+```rust
+/// Builds the chain for one law. This is where RFC-026's lexical routing sits:
+/// high risk gets the full adversary, targeted risk one lens, low risk none.
+/// Chunk planning is also here, unchanged, including its termination guarantee.
+pub fn plan_enrichment(ctx: &EnrichmentContext, profile: &AgentProfile) -> Result<Chain>;
+```
+
+The result is a flat list, and a flat list serialises. What ran is provenance, including which steps the routing skipped.
+
+**Cheap and fallible before expensive.** A chain orders every fallible native step ahead of every agent step. Without step-level resume, a failure after three agent runs pays for those runs again on the next attempt, and the source gate, the schema checks and the context assembly can all fail for free. The chain validator enforces the ordering.
+
+### Artefacts
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ArtifactRef(pub Cow<'static, str>);
+
+pub struct Artifact {
+    pub name: ArtifactRef,
+    /// Path in the run directory, outside every working directory.
+    pub path: PathBuf,
+    pub digest: Digest,
+    pub produced_by: Option<StepId>,
+    pub kind: ArtifactKind,
+}
+
+pub enum ArtifactKind {
+    LawYaml,
+    StatutoryText,
+    ReadingNote,
+    Findings,
+    Markdown,
+    Sidecar,
+    Skill,
+}
+
+pub struct Export {
+    pub artifact: ArtifactRef,
+    /// Where this artefact lands in the corpus repository.
+    pub repo_path: PathBuf,
+}
+
+pub struct ArtifactBus {
+    root: PathBuf,
+    entries: BTreeMap<ArtifactRef, Artifact>,
+}
+
+impl ArtifactBus {
+    pub fn publish(&mut self, name: ArtifactRef, from: &Path, by: Option<StepId>)
+        -> Result<Digest>;
+    pub fn get(&self, name: &ArtifactRef) -> Option<&Artifact>;
+    pub fn snapshot(&self, names: &[ArtifactRef]) -> Snapshot;
+    /// Copy the exported artefacts onto their corpus paths under `repo_path`
+    /// and return the list git must stage.
+    pub async fn checkout_into(&self, repo_path: &Path, exports: &[Export])
+        -> Result<Vec<PathBuf>>;
+}
+```
+
+`checkout_into` is the chain's way back to git. A chain that produces artefacts in a run directory and never writes them onto the paths the corpus expects produces nothing, so exports are part of the chain rather than an afterthought. The metadata sidecar, the result envelope carrying related legislation, and the generated feature files are all declared exports.
+
+Per step the executor does five things: create an empty working directory; copy each mount to its declared path, with read mounts set read-only; let the runtime write its scaffold and run; on a completed exit, read back exactly the output mounts, hash them and publish them; and remove the directory.
+
+Copying rather than linking, throughout. With whole-corpus mounting gone, the cost is a law file and its context, and copying is what makes the write-back rule honest.
+
+The write-back rule is what makes the boundary two-sided. Anything else the agent left in its working directory is discarded with a warning, so a step cannot smuggle context forward through an undeclared file, and a read mount that comes back changed is a recorded violation rather than a published artefact. Runtime scaffold is a third category next to mounts and agent output, named in the grant and exempt from both rules.
+
+### The context firewall, and what it is worth
+
+RFC-026 requires the adversary to receive the statutory text and the produced YAML and not the reading note, so that it re-derives the classification independently and therefore also catches the qualifier's errors. That becomes a mount list:
+
+```rust
+StepSpec {
+    id: StepId("qualifier".into()),
+    role: Role::Qualifier,
+    modality: Modality::Agentic,
+    mounts: vec![
+        Mount { artifact: A_STATUTORY_TEXT, path: "wettekst.md".into(),      mode: Mode::Read },
+        Mount { artifact: A_LAW_CONTEXT,    path: "context.yaml".into(),     mode: Mode::Read },
+        Mount { artifact: A_LEGAL_MEMO,     path: "memo.md".into(),          mode: Mode::Read },
+        Mount { artifact: A_READING_NOTE,   path: "leesnotitie.yaml".into(), mode: Mode::Create },
+    ],
+    capabilities: CapabilitySet::default(),
+    ..
+}
+
+StepSpec {
+    id: StepId("adversary_competence".into()),
+    role: Role::Adversary,
+    modality: Modality::Agentic,
+    mounts: vec![
+        Mount { artifact: A_STATUTORY_TEXT, path: "wettekst.md".into(),      mode: Mode::Read },
+        Mount { artifact: A_LAW_YAML,       path: "law.yaml".into(),         mode: Mode::Read },
+        Mount { artifact: A_FINDINGS,       path: "bevindingen.yaml".into(), mode: Mode::Create },
+    ],
+    capabilities: CapabilitySet::default(),
+    ..
+}
+```
+
+Skills are artefacts with names and are mounted per step, which is what lets the qualifier run without the schema and without the generation skill. A skill mounted by no step is not present at all, so linking every available skill into the tree the agent works in stops.
+
+**What this enforces, precisely.** The agent is not told where the withheld artefact is, it is not in the directory it was given, no tool of the step points at it, and the step's own capability grant does not include search outside that directory. Nothing else in the chain hands it over, and a later edit that adds the mount fails a test rather than a review.
+
+**What it does not enforce.** The agent runs under the same user as the worker with the same filesystem rights. An agent that decides to look outside its directory can read what that user can read. This is a context boundary between cooperating processes and not a security boundary, and the difference matters for one reason: an untrusted input document must never be handed to a step that can run programs, which is why deterministic extraction comes first and the agent is the fallback. Making the boundary hard needs a mount namespace or a separate user per step, which is an image change and a privilege model in the pod, and is out of scope here with that reason stated rather than implied.
+
+A static check keeps a later edit from opening the boundary by accident:
+
+```rust
+pub struct FirewallRule {
+    pub role: Role,
+    /// Artefacts this role may never see, with the reason for the message.
+    pub denied: &'static [(ArtifactRef, &'static str)],
+}
+
+pub enum ChainDefect {
+    FirewallViolation { step: StepId, artifact: ArtifactRef, reason: &'static str },
+    MissingProducer { step: StepId, artifact: ArtifactRef },
+    OptionalArtifactRequired { producer: StepId, consumer: StepId, artifact: ArtifactRef },
+    FallibleNativeAfterAgent { step: StepId },
+    Preflight(RuntimeError),
+    BudgetExceeded { want: Duration, have: Duration },
+}
+
+/// One validator: firewall rules, artefact availability, ordering, preflight
+/// over every step, and the budget. `plan_enrichment` calls it before
+/// returning a chain, and a unit test runs it over every routing branch.
+pub fn validate_chain(
+    chain: &Chain,
+    rules: &[FirewallRule],
+    profile: &AgentProfile,
+    registry: &RuntimeRegistry,
+    skills: &SkillIndex,
+    budget: &ChainBudget,
+) -> std::result::Result<(), Vec<ChainDefect>>;
+```
+
+## Provenance and measurement
+
+Per agent run the chain records: step id, role, runtime identity including CLI version and resolved model, the instruction digest, the digest of every mounted skill, the profile digest, the exit, the duration, the grant including what was over-granted, the tool ledger, and the judgement of every criterion including the ones that were met. The met judgements are recorded alongside the unmet ones, because the question "why was this law accepted" is answered by them and by nothing else.
+
+The instruction digest covers the instruction and the skills that were mounted for this step, which is what actually varies per step. A missing skill mount is a `Misconfigured` failure rather than a warning, because a digest computed over the files that happened to be present is a digest that looks valid and means nothing.
+
+These records go in a table rather than in a metrics endpoint. The metrics surface is a set of SQL aggregations over the job tables, exported by the admin service; the worker has no metrics endpoint and several replicas would need aggregating anyway. So the shape is a `job_steps` row per agent run, keyed on job and step, carrying exactly the fields above, and a handful of aggregations beside the existing ones.
+
+```sql
+CREATE TABLE job_steps (
+    id            uuid PRIMARY KEY,
+    job_id        uuid NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
+    step_id       text NOT NULL,
+    role          text NOT NULL,
+    runtime       text NOT NULL,
+    runtime_ver   text NOT NULL,
+    model         text NOT NULL,
+    attempt       smallint NOT NULL,
+    started_at    timestamptz NOT NULL,
+    duration_ms   integer NOT NULL,
+    exit          text NOT NULL,
+    over_granted  jsonb NOT NULL DEFAULT '[]',
+    tool_ledger   jsonb NOT NULL DEFAULT '{}',
+    judgements    jsonb NOT NULL DEFAULT '[]',
+    instruction_digest text NOT NULL,
+    profile_digest     text NOT NULL
+);
+```
+
+What that table is for, beyond the record:
+
+**The spend guard counts runs.** The hourly cap counts jobs started per provider on the assumption that one job is one agent run. A chain breaks that assumption in the direction that matters, letting the same cap through several times the model usage. The cap query moves to this table and counts agent runs.
+
+**Exit classes become queryable.** A timeout and a memory kill both dissolve into an error string in the job result, which makes "step two times out on a third of the long laws" a search through logs rather than a query.
+
+**Judgement ratios are the alarm.** A criterion that meets on zero runs out of hundreds is the shape of the failure in #1036, and as a ratio per step and criterion it is one panel and one alert rule beside the existing daily summary.
+
+**Over-granting becomes a number.** A runtime that cannot narrow its permissions reports a non-empty over-grant on every run, which states as a measurement what would otherwise be an anecdote about two lanes not being comparable.
+
+Job progress is written by the executor at step boundaries rather than polled from a file the agent writes. The executor knows which step is running without asking, and an agent that hangs stops updating a file it was going to write anyway. The progress value carries the step id, the index, the total and the start time, which changes the shape the frontend reads and needs checking against that contract.
+
+## What is deliberately not abstracted
+
+**No agent framework.** No planner, no tool-call loop, no message history, no agent calling another agent. RFC-026 is explicit that agents never talk to each other and everything moves through artefacts. This layer orchestrates processes and files.
+
+**No sandbox.** The capability set is a contract with the runtime and not a security boundary, as stated above. Reading this as isolation is a mistake with consequences, so it is written down twice.
+
+**No abstraction over the model.** No prompt DSL, no template language, no provider-neutral message format, no token accounting, no heuristics over refusals. The instruction is a `String` that Rust code produces. Where a runtime wants a system and user split, it splits on its own convention. Where a runtime needs an output schema to demultiplex several outputs from one answer, that is a property of the step and is declared there rather than being appended to the instruction behind the digest's back.
+
+**No configurable capabilities per environment.** A step's capabilities are a property of the step. Granting network in production and withdrawing it in development brings back the silent-nothing failure in a new form.
+
+**No step definitions in YAML for non-programmers.** Steps are Rust values and configuration is TOML. A success criterion is behaviour that moves with the schema and with the checks, and that cannot travel through YAML in both directions. The rendered spec does serialise, one way, for the provenance.
+
+**No graph, no parallelism, no conditional steps as data.** Routing is code and its output is a flat list.
+
+**No abstraction over git, the corpus or the job queue.** A working directory is a directory. Who filled the checkout, how drift against the base is decided, and how the retry ladder works stay where they are.
+
+**The deterministic checks stay outside the abstraction.** The check runner, the source gate and the assembler are library calls used by criteria and by native steps. They never become steps with capabilities, because our own code has every capability by definition.
+
+**No distribution across jobs.** Every step of one chain runs in one job in one worker, for the reason RFC-026 gives and because of the uniqueness constraint on the queue.
+
+**No step-level resume, in the first version.** Making a chain resumable means a durable cursor with the three properties the chunk cursor has: one small value, committed together with the work it describes, and validated on read so a stale value falls back rather than skipping work. That is a commit per step boundary and a question about what the corpus repository tolerates. The ordering rule buys most of it for nothing, and the boundary between the expensive phase and the cheap phase is the one place a checkpoint would pay for itself.
+
+## Migration and sequencing
+
+**This does not reorder RFC-026's sequencing, and it must not delay it.** Items three and four of that sequence, the mechanical checks and the source integrity gate, address the two largest measured failure classes, are already written, and are not wired into the worker. They run against the existing seam and need nothing from this RFC. Building them first and this second is the order, because this layer on its own improves no translation: it changes what a step is allowed to be, not what any current step sees.
+
+Where this RFC sits in that sequence is item five, separate runs instead of one session, and as a precondition for item ten, the adversary and the arbiter with lexical routing. Item five is reachable without the whole chain machinery, and stage one below is what it needs.
+
+**Stage 1: the runtime layer, with nothing above it changed.** The `agent` module with capabilities, the supervisor, the command builders, the event parsers and the ledger. The existing subprocess helper stays as a thin wrapper that builds a one-step spec and calls a runtime. The three existing invocation traits keep their signatures and every existing test keeps running. This is where the shell boolean dies: the three call sites pass a capability set instead, the document converter asks for the two extraction programs by name, the law structurer asks for them only on the raw-file branch, and enrichment asks for nothing. Behaviour is unchanged except that a runtime which cannot narrow its permissions now says so. Stage one is worth building on its own merits and is the majority of the value in this RFC.
+
+**Stage 2: the failure taxonomy, in two commits.** The supervisor yields typed exits and typed errors. The first commit keeps the existing error display formats exactly, so the worker's substring classifiers keep working, guarded by the test that pins those formats. The second switches the worker to the typed fields and deletes the classifiers, including the third terminal semantics for `Misconfigured`. Two commits rather than one, because a retry ladder that changes behaviour silently cannot be found again.
+
+**Stage 3: enrichment onto the chain, in one move.** The enrichment orchestration becomes chain execution, the invocation trait disappears, and the inline gates become criteria. This cannot be staged, because the trait and its fakes are the same object: the enrichment test module alone holds ten implementations, and law and document conversion hold one each with their own recorded assertions. They become one scripted runtime.
+
+```rust
+/// Test runtime. Per step id, performs the scripted acts against the declared
+/// output mounts and returns the scripted exit, recording every request it
+/// received.
+pub struct ScriptedRuntime {
+    script: HashMap<StepId, Vec<Act>>,
+    capabilities: CapabilitySet,
+    seen: Mutex<Vec<RecordedRequest>>,
+}
+
+pub enum Act {
+    /// Write fixed content to a declared output mount.
+    Write { artifact: ArtifactRef, content: String },
+    /// Rewrite a mounted artefact through a function. Most existing fakes
+    /// transform their input rather than emitting fixed content, so this
+    /// carries the majority of them.
+    Transform {
+        artifact: ArtifactRef,
+        f: Arc<dyn Fn(&str) -> String + Send + Sync>,
+    },
+    /// Do nothing, for the no-output guards.
+    Leave,
+    Exit(AgentExit),
+    Fail(RuntimeError),
+}
+
+pub struct RecordedRequest {
+    pub step: StepId,
+    pub attempt: u8,
+    pub capabilities: CapabilitySet,
+    pub mounts: Vec<(ArtifactRef, Mode)>,
+    pub instruction_digest: String,
+}
+```
+
+This is not less code than the fakes it replaces, and claiming otherwise would be wrong. What it buys is that the assertions get sharper: three existing tests assert on what the runner received, which is what pins the chunk loop, and those become assertions over a recorded request including the capability set, which is exactly the property this RFC adds.
+
+The base-action decision that compares the enrichment branch against the corpus is checkout work that happens before a chain begins, and it stays where it is.
+
+**Stage 4: law conversion and document conversion, later and separately.** After stage one they already run on the runtime layer, so this can wait. Both traits disappear, both fakes become the scripted runtime, law conversion becomes a two-step chain with the repair round expressed as `OnUnmet::Repair`, and document conversion becomes a chain that starts with a native step, because deterministic extraction comes first and the agent is the fallback. That ordering is the pattern this whole design generalises.
+
+**What runs alongside.** The chain lands next to the existing enrichment path, and the local single-law binary runs it against a real law before the worker notices. The worker keeps calling the existing entry point until the chain replaces it wholesale. The task-flow enrichment path is a second caller with its own working directory and no git checkout, and it moves at the same time as the corpus-wide one rather than after it.
+
+**What splits.** The current enrichment configuration carries two things. Runtime, model, timeout and memory ceiling move to the profile; the article budget, the code commit and the branch stay in a settings struct. The provider override becomes a chain-wide runtime override.
+
+**What the queue key means.** A lane is identified in the job payload and the uniqueness index is built on it. Per-step runtime overrides in a payload would make that key stop describing what the job does, so they are not allowed: overrides live in the profile, and a payload carries one lane identifier.
+
+## Open decisions
+
+1. **Criterion as trait object or enum.** A trait object extends without touching the core and does not serialise; an enum serialises and forces every new check through the core. The choice here is the trait object with a name and a digest over the criterion set, because the deterministic checks are still growing and what has to be reproducible is the judgement plus which criterion set was in force, rather than the code.
+2. **Whether over-granting only records or also refuses.** Recording is the cheap form. Refusing to run a chain on a runtime that cannot narrow its permissions is an operational choice with an immediate consequence for one lane.
+3. **Whether the chain checkpoints at the phase boundary.** A commit between the expensive and the cheap phase makes one failure class cost less, at the price of more commits per law per window against a repository whose tolerance for that is unmeasured.
+4. **The job and reaper timeouts.** A four-role chain does not fit the current job timeout, and raising it past the orphan reaper's threshold breaks the reaper. Both are deployment values with a queue-blocking consequence.
+
+## References
+
+- Issue #1036 records how enrichment runs at the time of writing, with the measurements that motivate this design
+- RFC-026 defines the roles, the firewalls and the sequencing this layer serves
+- RFC-012 defines the untranslatable channel that `MarkChannel` routes to

--- a/docs/src/content/rfcs/rfc-028.md
+++ b/docs/src/content/rfcs/rfc-028.md
@@ -7,19 +7,34 @@ authors:
   - Eelco Hotting
 depends_on:
   - RFC-012 (Untranslatables)
-  - RFC-026 (Enrichment a Legal Expert Can Check)
+  - RFC-027 (Enrichment a Legal Expert Can Check)
 short_title: Agent Steps
 ---
 
+## This RFC in the series
+
+Four RFCs describe layers of the same machine, from the outside in.
+
+**RFC-026, Werkvoorraad.** Which articles must be enriched and in what order. It
+produces tasks.
+
+**RFC-027, Enrichment Quality.** The roles, the gates and the failure classes
+that decide whether a single article is enriched well. It consumes tasks.
+
+**RFC-028, Steps and Runtimes.** How a single step in that chain runs.
+
+**RFC-029, Test Fixtures.** The yardstick for the whole.
+
+This RFC is the third layer.
 ## Context
 
-RFC-026 splits enrichment into roles with separate contexts: a qualifier that reads and classifies, a producer that translates within that classification, an adversary that tries to bring the translation down, and an arbiter that decides. Those roles are separate agent runs whose firewalls are the whole point, and the pipeline has no way to say what a run is.
+RFC-027 splits enrichment into roles with separate contexts: a qualifier that reads and classifies, a producer that translates within that classification, an adversary that tries to bring the translation down, and an arbiter that decides. Those roles are separate agent runs whose firewalls are the whole point, and the pipeline has no way to say what a run is.
 
 The seam it has instead couples the agent to the domain. The invocation trait takes the enrichment payload, so the thing that knows how to run an agent also knows what enrichment means; a second chain therefore needs a second trait, which is why document conversion and law structuring each grew their own. Below that seam the tool allowlist of one CLI travels through three signatures as a boolean named after a shell.
 
 The cost of having no step object is recorded in issue #1036. The shape of it: an instruction prescribes work the runtime cannot perform, nothing compares the two, and the step runs to a clean exit having done nothing. A gate that only inspects the final file cannot tell that apart from a step that had nothing to do.
 
-This RFC defines the layer underneath RFC-026's roles: a step is data that says what must happen and what it needs, a runtime is a thing that can execute such a step and translate its needs into its own flags, and the choice of runtime, model and budget per step is configuration. It also decides how far that abstraction reaches, because the interesting half of the design is what it refuses to hide.
+This RFC defines the layer underneath RFC-027's roles: a step is data that says what must happen and what it needs, a runtime is a thing that can execute such a step and translate its needs into its own flags, and the choice of runtime, model and budget per step is configuration. It also decides how far that abstraction reaches, because the interesting half of the design is what it refuses to hide.
 
 The name for the boundary is deliberate. An ORM hides which database answers a query and does not hide that a query can fail, that a column has a type, or that a join costs something. The same applies here: the runtime layer hides which agent runs a step, and refuses to hide that a step needs a shell, that a model has a context window, or that an instruction assumes a tool loop.
 
@@ -29,7 +44,7 @@ The name for the boundary is deliberate. An ORM hides which database answers a q
 
 **A step that cannot be executed as specified must not start.** A missing capability, a model whose context window cannot hold the mounted inputs, an instruction that assumes a tool loop on a runtime that has none: all three are known before a process is spawned, and all three are configuration faults rather than properties of the law being translated.
 
-**A step must not be able to see what the chain withheld from it.** RFC-026 requires the adversary to re-derive the classification without the reading note, and the qualifier to classify without knowing what the model looks like. That must be a property of what is placed in front of the agent rather than a sentence in a prompt, and the enforcement level must be stated honestly, because a context boundary between cooperating processes is not a security boundary.
+**A step must not be able to see what the chain withheld from it.** RFC-027 requires the adversary to re-derive the classification without the reading note, and the qualifier to classify without knowing what the model looks like. That must be a property of what is placed in front of the agent rather than a sentence in a prompt, and the enforcement level must be stated honestly, because a context boundary between cooperating processes is not a security boundary.
 
 **The runtime must be identified in the provenance well enough to answer "which agent wrote this".** Runtime name, CLI version, resolved model, the instruction digest, the digest of every mounted skill, the granted capabilities and what the run did with them.
 
@@ -215,7 +230,7 @@ The criteria the chain needs, and where each already lives:
 
 `SourceGateVerified` cannot be a criterion on its own, because verification compares the corpus file against the official toestand and that comparison needs the official text. The gate is a native step that fetches and publishes the official articles as an artefact; the criterion compares two published artefacts. That split is the general rule: a criterion reads the bus and never the network.
 
-`OutputsPresent` needs the distinction the chunk guard already draws. A step that ran and legitimately produced nothing is not a failed step: RFC-026 lets the adversary state that no tenable counter-reading exists on a lens, and that is an empty findings file from a successful run. Emptiness therefore only fails where the step's own contract says the artefact must be non-empty, and where a step may legitimately be empty it must publish a report saying so.
+`OutputsPresent` needs the distinction the chunk guard already draws. A step that ran and legitimately produced nothing is not a failed step: RFC-027 lets the adversary state that no tenable counter-reading exists on a lens, and that is an empty findings file from a successful run. Emptiness therefore only fails where the step's own contract says the artefact must be non-empty, and where a step may legitimately be empty it must publish a report saying so.
 
 ### When a criterion is not met
 
@@ -236,7 +251,7 @@ pub enum OnUnmet {
         then: Box<OnUnmet>,
     },
 
-    /// Record the reasons on a marking channel and continue. RFC-026 treats a
+    /// Record the reasons on a marking channel and continue. RFC-027 treats a
     /// recorded disagreement as a usable output. The chain validator rejects a
     /// chain where a later step mounts an artefact this step may fail to
     /// produce.
@@ -260,7 +275,7 @@ pub enum FailureKind {
     Misconfigured,
 }
 
-/// The channels of RFC-026 section 6, kept apart because they have different
+/// The channels of RFC-027 section 6, kept apart because they have different
 /// owners.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MarkChannel {
@@ -847,12 +862,12 @@ pub trait NativeOp: Send + Sync {
 
 Native operations get the corpus root, because the checks that motivate the whole exercise read sibling laws and a bus of artefacts cannot supply them.
 
-Linear because RFC-026's chain is linear, and because parallelism buys nothing here: the roles are separate runs inside one job rather than separate job types, since three job types would clone one law three times and hit the per-provider rate cap three times for it.
+Linear because RFC-027's chain is linear, and because parallelism buys nothing here: the roles are separate runs inside one job rather than separate job types, since three job types would clone one law three times and hit the per-provider rate cap three times for it.
 
 Branching is routing, and routing is Rust rather than data:
 
 ```rust
-/// Builds the chain for one law. This is where RFC-026's lexical routing sits:
+/// Builds the chain for one law. This is where RFC-027's lexical routing sits:
 /// high risk gets the full adversary, targeted risk one lens, low risk none.
 /// Chunk planning is also here, unchanged, including its termination guarantee.
 pub fn plan_enrichment(ctx: &EnrichmentContext, profile: &AgentProfile) -> Result<Chain>;
@@ -920,7 +935,7 @@ The write-back rule is what makes the boundary two-sided. Anything else the agen
 
 ### The context firewall, and what it is worth
 
-RFC-026 requires the adversary to receive the statutory text and the produced YAML and not the reading note, so that it re-derives the classification independently and therefore also catches the qualifier's errors. That becomes a mount list:
+RFC-027 requires the adversary to receive the statutory text and the produced YAML and not the reading note, so that it re-derives the classification independently and therefore also catches the qualifier's errors. That becomes a mount list:
 
 ```rust
 StepSpec {
@@ -1031,7 +1046,7 @@ Job progress is written by the executor at step boundaries rather than polled fr
 
 ## What is deliberately not abstracted
 
-**No agent framework.** No planner, no tool-call loop, no message history, no agent calling another agent. RFC-026 is explicit that agents never talk to each other and everything moves through artefacts. This layer orchestrates processes and files.
+**No agent framework.** No planner, no tool-call loop, no message history, no agent calling another agent. RFC-027 is explicit that agents never talk to each other and everything moves through artefacts. This layer orchestrates processes and files.
 
 **No sandbox.** The capability set is a contract with the runtime and not a security boundary, as stated above. Reading this as isolation is a mistake with consequences, so it is written down twice.
 
@@ -1047,13 +1062,13 @@ Job progress is written by the executor at step boundaries rather than polled fr
 
 **The deterministic checks stay outside the abstraction.** The check runner, the source gate and the assembler are library calls used by criteria and by native steps. They never become steps with capabilities, because our own code has every capability by definition.
 
-**No distribution across jobs.** Every step of one chain runs in one job in one worker, for the reason RFC-026 gives and because of the uniqueness constraint on the queue.
+**No distribution across jobs.** Every step of one chain runs in one job in one worker, for the reason RFC-027 gives and because of the uniqueness constraint on the queue.
 
 **No step-level resume, in the first version.** Making a chain resumable means a durable cursor with the three properties the chunk cursor has: one small value, committed together with the work it describes, and validated on read so a stale value falls back rather than skipping work. That is a commit per step boundary and a question about what the corpus repository tolerates. The ordering rule buys most of it for nothing, and the boundary between the expensive phase and the cheap phase is the one place a checkpoint would pay for itself.
 
 ## Migration and sequencing
 
-**This does not reorder RFC-026's sequencing, and it must not delay it.** Items three and four of that sequence, the mechanical checks and the source integrity gate, address the two largest measured failure classes, are already written, and are not wired into the worker. They run against the existing seam and need nothing from this RFC. Building them first and this second is the order, because this layer on its own improves no translation: it changes what a step is allowed to be, not what any current step sees.
+**This does not reorder RFC-027's sequencing, and it must not delay it.** Items three and four of that sequence, the mechanical checks and the source integrity gate, address the two largest measured failure classes, are already written, and are not wired into the worker. They run against the existing seam and need nothing from this RFC. Building them first and this second is the order, because this layer on its own improves no translation: it changes what a step is allowed to be, not what any current step sees.
 
 Where this RFC sits in that sequence is item five, separate runs instead of one session, and as a precondition for item ten, the adversary and the arbiter with lexical routing. Item five is reachable without the whole chain machinery, and stage one below is what it needs.
 
@@ -1120,5 +1135,5 @@ The base-action decision that compares the enrichment branch against the corpus 
 ## References
 
 - Issue #1036 records how enrichment runs at the time of writing, with the measurements that motivate this design
-- RFC-026 defines the roles, the firewalls and the sequencing this layer serves
+- RFC-027 defines the roles, the firewalls and the sequencing this layer serves
 - RFC-012 defines the untranslatable channel that `MarkChannel` routes to


### PR DESCRIPTION
RFC-028 beschrijft de laag onder de rollen uit RFC-027. Een stap is data die zegt wat er moet gebeuren en wat hij nodig heeft, een runtime voert zo'n stap uit en vertaalt die behoeften naar zijn eigen vlaggen, en de keuze van runtime, model en budget per stap is configuratie. Concreet genoeg om te bouwen: Rust-signaturen, geen pseudocode.

De keten uit RFC-027 bestaat uit rollen met gescheiden contexten, en de pipeline heeft geen manier om te zeggen wat een run is. Het naadje dat er wel is koppelt de agent aan het domein: de aanroeptrait krijgt de enrichment-payload mee, dus wie weet hoe je een agent draait weet ook wat enrichment betekent. Daarom heeft elke tweede keten een eigen trait gekregen. Daaronder reist de toolallowlist van één CLI door drie signaturen als een boolean die naar een shell is vernoemd. In #1036 staat wat het kost om geen stapobject te hebben: een instructie schrijft werk voor dat de runtime niet kan uitvoeren, niets vergelijkt die twee, en de stap eindigt netjes zonder iets gedaan te hebben.

De ORM-vergelijking wordt in het document zelf begrensd. Een ORM verbergt welke database een query beantwoordt en verbergt niet dat een query kan falen, dat een kolom een type heeft, of dat een join iets kost. Zo ook hier: de laag verbergt welke agent een stap draait, en weigert te verbergen dat een stap een shell nodig heeft, dat een model een contextvenster heeft, en dat een instructie een tool-lus veronderstelt.

Vier reviewers, waaronder een adversariële, hebben het ontwerp beoordeeld. Op één punt is het voorstel overtuigend onderuitgehaald en dat is overgenomen: deze laag verbetert op zichzelf geen enkele vertaling. De deterministische controles en de bronpoort uit #1037 doen dat wel, ze werken tegen het bestaande naadje, en ze zijn nog niet op de worker aangesloten. Het document zet die aansluiting daarom eerst en deze abstractie daarna.

Twee dingen die de reviewers toevoegden maakten het ontwerp scherper. Een vermogensdeclaratie die alleen met de hand wordt ingevuld reproduceert de fout die hij moet voorkomen, dus een deel wordt afgeleid uit de skill-frontmatter en een deel geverifieerd tegen wat de run werkelijk deed. En een contextgrens tussen samenwerkende processen is geen beveiligingsgrens, dus het document zegt welk niveau van afdwinging het claimt.

Acht beslissingen staan met hun context in de reviewsamenvatting. De zwaarste raken de bouwvolgorde, de job- en reaper-timeouts (een keten van vier rollen past niet in de huidige 1200 seconden), en de uur-cap die jobs telt terwijl één keten vier of vijf runs is.

Niet automatisch mergen, dit is een document om zelf na te lezen.

De vier enrichment-RFC's zijn hernummerd zodat ze van buiten naar binnen lopen: 026 werkvoorraad, 027 kwaliteit, 028 stappen, 029 fixtures. Elk document opent met een kadertje dat de reeks uitlegt.