### PR TITLE
docs(docs): rfc-026 over de werkvoorraad van de enricher

### DIFF
--- a/docs/src/content/rfcs/rfc-026.md
+++ b/docs/src/content/rfcs/rfc-026.md
@@ -25,7 +25,7 @@ bepalen of één artikel goed verrijkt is. Verbruikt taken.
 
 **RFC-028, Steps and Runtimes.** Hoe één stap uit die keten draait.
 
-**RFC-029, Test Fixtures.** Waaraan het geheel gemeten wordt.
+**RFC-029, Test Fixtures.** De maatlat voor het geheel.
 
 Deze RFC is de eerste laag.
 ## Context
@@ -302,6 +302,20 @@ requirement 2: zonder hash is hergebruik van eerder werk een gok.
 De graaf komt in Postgres, maar als afgeleide. De waarheid staat in de bestanden
 en de index is weg te gooien en opnieuw op te bouwen. Twee bronnen van waarheid
 lopen uit elkaar, en de bestanden zijn degene die gereviewd worden.
+
+De index neemt alleen documenten op vanaf schemaversie 0.6.0. Daaronder ontbreken
+`placement`, `norm_gaps` en de verbijzondering van `untranslatables`, dus zo'n
+document kan de kanten en de markeringen die de graaf nodig heeft niet dragen.
+Een harde ondergrens is hier goedkoper dan een index die half gevulde knopen
+bevat, en hij voorkomt de fout die de eerste twee enricher-rondes waardeloos
+maakte: alfamateriaal dat meetelde in een meting die over de enricher hoorde te
+gaan. Een wet verschijnt in de graaf zodra hij op het nieuwe schema staat, wat de
+index meteen tot voortgangsmeter van de migratie maakt.
+
+Dat geldt voor de verrijkte kant. De resolve-stap leest brontekst en heeft die
+ondergrens niet nodig, dus kanten kunnen bestaan naar knopen die zelf nog geen
+0.6.0-document hebben. Zo'n knoop staat in de graaf als bekend en onverrijkt, wat
+precies de toestand is die de werkvoorraad wil zien.
 
 ## Werkvoorraad
 

--- a/docs/src/content/rfcs/rfc-026.md
+++ b/docs/src/content/rfcs/rfc-026.md
@@ -66,6 +66,8 @@ zorgtoeslag.
 4. Elke begrenzing van de sluiting laat een zichtbare markering achter.
 5. Een wet of document dat de uitvoering verandert zonder dat het corpus dat
    weet, is de enige faalvorm die niet mag voorkomen.
+6. Een artikel gaat nooit naar een agent zonder zijn plaats in de
+   documentstructuur en zonder wat er binnen zijn eigen wet op inwerkt.
 
 ## Twee soorten gaten
 
@@ -106,7 +108,9 @@ stand dan een losse vergelijking.
 | optionele dependency, niet ingeschakeld | delegatie naar een beleidsregel |
 | prelude | kaderwet |
 | lockfile met hashes | sidecar met een hash per fragment |
-| resolve tegenover build | resolve-stap tegenover enrich-stap |
+| resolve tegenover build | traversal tegenover verrijking |
+| feature die een optionele dependency uitschakelt | artikel buiten de hot path |
+| trait-impl elders in de crate | artikel dat een ander artikel wijzigt |
 | entry point en tree shaking | scenario als wortel |
 
 De analogie breekt op twee punten, en allebei kosten ze iets.
@@ -131,9 +135,8 @@ tweede lid van de Awir" is een kant naar knoop `awir#8` met adres `2`. Dat is de
 verhouding tussen een compilatie-eenheid en een symbool. Je hercompileert de hele
 module, en tegelijk weet de afhankelijkheidsanalyse welk symbool je gebruikt.
 
-Daaruit volgt dat je bij het aflopen van de keten altijd het hele artikel
-verrijkt, ook als er maar één lid gevraagd is. Dat is een keuze en geen
-concessie. Leden zijn niet zelfstandig leesbaar, want een tweede lid begint
+Een gevraagd lid trekt daarom altijd zijn hele artikel mee. Dat is een keuze en
+geen concessie. Leden zijn niet zelfstandig leesbaar, want een tweede lid begint
 geregeld met "In afwijking van het eerste lid" en een agent die alleen dat lid
 krijgt, vertaalt iets anders dan er staat. De marginale kosten zijn bovendien
 laag: de dure stap is het lezen en kwalificeren van het artikel, en de overige
@@ -145,13 +148,98 @@ de invalidatie, want verandert lid 3 terwijl de afhankelijkheid op lid 2 zit, da
 is de afhankelijke wet niet geraakt. En het maakt de graaf precies genoeg om
 bruikbaar te zijn zonder het aantal knopen te vermenigvuldigen.
 
-Die granulariteit is het belangrijkste antwoord op de uitwaaiering. Een verwijzing
-tussen wetten is bijna nooit "de Awir" maar "het toetsingsinkomen, bedoeld in
-artikel 8 van de Awir". Dat staat er letterlijk, en het is al een symboolimport.
-Wie de wet als knoop neemt, sleept bij artikel 8 de andere 86 artikelen mee en
-ziet de sluiting openklappen. Wie het artikel als knoop neemt, volgt de drie
-verwijzingen die artikel 8 zelf heeft. De oneindigheid is een eigenschap van te
-grove knopen en niet van het recht.
+Die granulariteit is het belangrijkste antwoord op de uitwaaiering, en hij zit op
+de traversal en niet op de verrijking. Een verwijzing tussen wetten is bijna nooit
+"de Awir" maar "het toetsingsinkomen, bedoeld in artikel 8 van de Awir". Dat staat
+er letterlijk, en het is al een symboolimport. Wie de wet als traversal-eenheid
+neemt, volgt bij artikel 8 ook de verwijzingen van de andere 86 artikelen en ziet
+de sluiting openklappen. Wie het artikel als traversal-eenheid neemt, volgt de
+drie verwijzingen die artikel 8 zelf heeft. De oneindigheid is een eigenschap van
+te grove traversal en niet van het recht.
+
+## Verrijken per wet, traverseren per artikel
+
+De verrijkingseenheid en de traversal-eenheid vallen niet samen.
+
+Kom je wet X tegen, dan verrijk je X helemaal. Alle artikelen, ook de artikelen
+die niemand gevraagd heeft. De uitgaande verwijzingen van al die artikelen volg je
+daarentegen niet. Alleen de artikelen die de reden waren dat X binnenkwam,
+en wat daarbinnen op ze inwerkt, leveren kanten die de sluiting laten groeien.
+Die verzameling heet de hot path.
+
+Cargo doet hetzelfde. Het bouwt het hele package en niet alleen de functie die je
+aanroept, terwijl het optionele dependencies achter uitgeschakelde features niet
+ophaalt. Bouwen is breed, resolven is smal.
+
+De winst van breed verrijken zit in requirement 2. Een half verrijkte wet is een
+wet met gaten waarvan niemand weet of ze bewust zijn, en de volgende aanvrager
+die een ander artikel nodig heeft, begint opnieuw. Een wet die in één keer af is,
+is voor iedere volgende wortel meteen klaar. Het haalt bovendien de druk van de
+vraag of de hot path wel compleet is: mist hij een artikel, dan is dat artikel
+toch verrijkt, en het gevolg blijft beperkt tot een kant die niet gevolgd is.
+
+De prijs is reëel en ik wil er niet omheen. De Wet inkomstenbelasting helemaal
+verrijken omdat er één inkomensbegrip nodig is, kost een veelvoud van wat de
+wortel vraagt, en de Zorgverzekeringswet liep in ronde 1 al op één artikel tegen
+de outputlimiet van het model. Daarom splitst de wet-taak in tweeën: de hot path
+blokkeert de wortel en heeft diens prioriteit, de rest van de wet blokkeert niets
+en draait erachteraan. De wortel wacht op wat hij nodig heeft en het corpus wordt
+alsnog compleet.
+
+Kanten uit artikelen buiten de hot path worden vastgelegd en niet gevolgd. Dat is
+een bekend gat volgens requirement 4, en de sluitings-poort telt het niet als
+bevinding. Groeit de hot path later omdat een andere wortel dat artikel nodig
+heeft, dan wordt de kant alsnog gevolgd. De hot path is een eigenschap van de
+wortel en niet van de wet.
+
+## Wat binnen een wet op een artikel inwerkt
+
+De hot path is niet de verzameling gevraagde artikelen. Artikel 10 kan bepalen wat
+artikel 8 betekent, en dan hoort 10 er ook bij, met zijn eigen uitgaande kanten.
+
+Drie manieren waarop dat gebeurt.
+
+**Een artikel verwijst naar het gevraagde artikel.** "In afwijking van artikel 8"
+staat in artikel 10 en de invloed loopt van 10 naar 8, terwijl de verwijzing de
+andere kant op wijst. De resolver moet binnen een wet dus ook de omgekeerde vraag
+beantwoorden: wie verwijst naar dit artikel. Binnen één wet is dat goedkoop, want
+de tekst ligt er al, en daarom geldt hier het omgekeerde van de regel voor
+verwijzingen naar buiten: binnen een wet resolven we volledig en in beide
+richtingen, daarbuiten smal en vooruit.
+
+Niet elke inkomende verwijzing hoort erbij. "Het bedrag, bedoeld in artikel 8"
+gebruikt artikel 8 en verandert het niet. "In afwijking van", "onverminderd",
+"in aanvulling op" en "is niet van toepassing" doen dat wel. De inkomende kant
+krijgt daarom een strekking, gebruikend of wijzigend, en alleen de wijzigende
+trekt het bronartikel de hot path in. De lexicale signalen daarvoor zijn dezelfde
+connectieven die de dekkingscheck van RFC-027 al kent.
+
+**De omhullende structuur bepaalt mee wat er staat.** Een begripsbepaling aan het
+begin van een afdeling geldt voor die hele afdeling zonder dat enig artikel
+ernaar verwijst. Een reikwijdtebepaling in hoofdstuk 1 werkt op alles daaronder.
+Welke van die bepalingen op artikel 8 werken, volgt uit waar 8 staat, en daarom
+is `placement` uit schema 0.6.0 geen decoratie maar de scoperegel: de
+begripsbepalingen van elke omhullende container zitten in de hot path van elk
+artikel daarbinnen.
+
+Dat is ook de reden dat een artikel nooit zonder zijn pad naar de agent gaat.
+Een artikel dat zijn kopjes kwijt is, mist de helft van zijn betekenis, en een
+model dat op zo'n tekst is gebouwd is niet te repareren met een betere prompt.
+De structuur reist mee als het pad "Hoofdstuk 3 Besluiten > Afdeling 3.3
+Advisering", zoals de bronpoort hem al vastlegt.
+
+**Bepalingen die op de hele wet werken.** Overgangsrecht, een hardheidsclausule,
+slotbepalingen, delegatiegrondslagen. Die noemen geen artikelnummers en zijn dus
+met verwijzingen niet te vinden. Dit is de lokale variant van de kaderwet, en het
+antwoord is hetzelfde: aanwijzen. Per wet is dat een handvol artikelen, en omdat
+de wet toch in zijn geheel verrijkt wordt, is de enige beslissing die overblijft
+of hun kanten gevolgd worden.
+
+Hetzelfde patroon staat daarmee op drie schalen. Het hele artikel gaat mee omdat
+leden niet zelfstandig leesbaar zijn. De omhullende bepalingen van de wet gaan mee
+omdat ze zonder verwijzing werken. En de kaderwetten gaan mee omdat ze zichzelf
+van toepassing verklaren. Steeds is de vraag dezelfde: wat werkt hierop in zonder
+dat er een pijl naartoe wijst.
 
 Kanten zijn getypeerd, omdat de traversalregel per type verschilt.
 

--- a/docs/src/content/rfcs/rfc-026.md
+++ b/docs/src/content/rfcs/rfc-026.md
@@ -1,5 +1,5 @@
 ---
-title: "RFC-029: De werkvoorraad van de enricher"
+title: "RFC-026: De werkvoorraad van de enricher"
 status: Draft
 implementation: Not implemented
 date: '2026-08-01'
@@ -9,13 +9,28 @@ depends_on:
   - RFC-003 (Inversion of Control for Delegated Values)
   - RFC-008 (Awb Procedures and Lifecycle)
   - RFC-012 (Untranslatables)
-  - RFC-026 (Enrichment a Legal Expert Can Check)
+  - RFC-027 (Enrichment a Legal Expert Can Check)
 short_title: Werkvoorraad
 ---
 
+## Deze RFC in de reeks
+
+Vier RFC's beschrijven lagen van dezelfde machine, van buiten naar binnen.
+
+**RFC-026, Werkvoorraad.** Welke artikelen verrijkt moeten worden en in welke
+volgorde. Levert taken op.
+
+**RFC-027, Enrichment Quality.** De rollen, de poorten en de faalvormen die
+bepalen of één artikel goed verrijkt is. Verbruikt taken.
+
+**RFC-028, Steps and Runtimes.** Hoe één stap uit die keten draait.
+
+**RFC-029, Test Fixtures.** Waaraan het geheel gemeten wordt.
+
+Deze RFC is de eerste laag.
 ## Context
 
-RFC-026 beschrijft hoe je één wet goed verrijkt. Deze RFC gaat over de vraag die
+RFC-027 beschrijft hoe je één wet goed verrijkt. Deze RFC gaat over de vraag die
 daarvoor komt: welke wetten, en welke delen daarvan, moeten verrijkt worden om
 een bepaalde uitvoering mogelijk te maken, en hoe weet je dat je klaar bent.
 
@@ -75,11 +90,60 @@ niet op te houden. Stille gaten zijn de enige echte faalvorm. Elke
 keuze hieronder om de sluiting te begrenzen is toegestaan zolang die keuze een
 bekend gat produceert en geen stil gat. Afkappen mag, stil afkappen niet.
 
+## Analogie met package management
+
+Het ontwerp leunt op de analogie met een package manager, en die houdt verder
+stand dan een losse vergelijking.
+
+| software | wet |
+|---|---|
+| package | wet |
+| compilatie-eenheid | artikel |
+| symbool | lid of onderdeel |
+| import van een symbool | "als bedoeld in artikel 8, tweede lid" |
+| type-only import | definitorische verwijzing |
+| runtime-import | uitvoerende verwijzing |
+| optionele dependency, niet ingeschakeld | delegatie naar een beleidsregel |
+| prelude | kaderwet |
+| lockfile met hashes | sidecar met een hash per fragment |
+| resolve tegenover build | resolve-stap tegenover enrich-stap |
+| entry point en tree shaking | scenario als wortel |
+
+De analogie breekt op twee punten, en allebei kosten ze iets.
+
+Cycli zijn hier normaal. Een package manager weigert ze en bouwt in topologische
+volgorde; wetten verwijzen over en weer en er is geen volgorde die dat oplost.
+Zie de sectie over cycli.
+
+Er is geen equivalent van de prelude die je moet aanwijzen. In software staat de
+prelude in de taaldefinitie en klopt hij per constructie. Hier is het een
+handgeschreven lijst die kan verouderen, en dat is de enige plek in het ontwerp
+waar een stil gat kan ontstaan.
+
 ## Knopen en kanten
 
-Knopen zijn `(wet, versie, adres)`, waarbij het adres een artikel of een fragment
-daarbinnen is. Uitvoeringsdocumenten en beleidsregels zijn knopen van dezelfde
-soort. De wet zelf is een groepering van knopen.
+Knopen zijn `(wet, versie, artikel)`. Uitvoeringsdocumenten en beleidsregels zijn
+knopen van dezelfde soort. De wet zelf is een groepering van knopen.
+
+Het artikel is de eenheid van werk en status; het lid is de eenheid van precisie.
+Een kant draagt daarom een adres binnen zijn doel: de verwijzing naar "artikel 8,
+tweede lid van de Awir" is een kant naar knoop `awir#8` met adres `2`. Dat is de
+verhouding tussen een compilatie-eenheid en een symbool. Je hercompileert de hele
+module, en tegelijk weet de afhankelijkheidsanalyse welk symbool je gebruikt.
+
+Daaruit volgt dat je bij het aflopen van de keten altijd het hele artikel
+verrijkt, ook als er maar één lid gevraagd is. Dat is een keuze en geen
+concessie. Leden zijn niet zelfstandig leesbaar, want een tweede lid begint
+geregeld met "In afwijking van het eerste lid" en een agent die alleen dat lid
+krijgt, vertaalt iets anders dan er staat. De marginale kosten zijn bovendien
+laag: de dure stap is het lezen en kwalificeren van het artikel, en de overige
+leden meenemen kost daarbovenop weinig.
+
+Het adres doet drie dingen. Het bepaalt welke tekst de agent als het gevraagde
+fragment aangeboden krijgt, met het hele artikel eromheen als context. Het stuurt
+de invalidatie, want verandert lid 3 terwijl de afhankelijkheid op lid 2 zit, dan
+is de afhankelijke wet niet geraakt. En het maakt de graaf precies genoeg om
+bruikbaar te zijn zonder het aantal knopen te vermenigvuldigen.
 
 Die granulariteit is het belangrijkste antwoord op de uitwaaiering. Een verwijzing
 tussen wetten is bijna nooit "de Awir" maar "het toetsingsinkomen, bedoeld in
@@ -137,22 +201,42 @@ De Awb is op vrijwel elk besluit van toepassing zonder dat de Wet op de
 zorgtoeslag dat vermeldt. Wie vanuit de materiewet zoekt, vindt hem nooit. Dit is
 het stille gat uit requirement 5.
 
-Er zijn er weinig. Awb, Awir, Algemene termijnenwet, Wet inkomstenbelasting voor
-de inkomensbegrippen, en nog een handvol. Die worden vooraf uitgewerkt en
-vastgelegd als data, niet als proza in een skill: per kaderwet het
-toepassingsbereik, het patroon waaraan je herkent dat het aan de orde is, en wat
-er dan meegenomen moet worden. Een verrijkingsopdracht krijgt die kaarten mee als
-extra invoer, en de poort na de verrijking controleert dat de vermelde werking
-ook echt is meegenomen. Een besluit dat verrijkt is zonder dat de Awb-termijnen
-erin zitten, faalt.
+Kaderwetten worden aangewezen en niet opgespoord. Kaderwet zijn is een juridische
+kwalificatie en geen eigenschap van de graaf, dus er valt niets aan te detecteren.
+Een heuristiek op ingaande graad zou bovendien het omgekeerde vinden van wat we
+zoeken: die vindt de wetten waar veel naar verwezen wordt, zoals de Awir en de Wet
+inkomstenbelasting, en dat zijn juist de wetten die al gewone kanten hebben. De
+Awb heeft die kanten niet, want dat is precies waarom hij een probleem is.
 
-Dat het data is en geen prozaregel is het punt. Een regel in een skill veroudert
-stil en niemand merkt het. Een lijst met een eigenaar en een poort die erop
-controleert, veroudert zichtbaar.
+De aanwijzing is een prelude. Zoals een taal een handvol namen impliciet
+beschikbaar stelt zonder dat een module ze importeert, verklaart een kaderwet zich
+van toepassing zonder dat de materiewet ernaar verwijst. Een prelude wordt niet
+gevonden door de resolver, hij wordt gedeclareerd, en wie hem niet declareert
+compileert code waarin de helft van de namen ontbreekt zonder dat er een import
+mist.
+
+Het zijn er weinig. Awb, Awir, Algemene termijnenwet, Wet inkomstenbelasting voor
+de inkomensbegrippen, en nog een handvol. Ze worden vooraf uitgewerkt en
+vastgelegd als data: per kaderwet het toepassingsbereik, het patroon waaraan je
+herkent dat het aan de orde is, en wat er dan meegenomen moet worden. Een
+verrijkingsopdracht krijgt die kaarten mee als extra invoer, en de poort na de
+verrijking controleert dat de vermelde werking ook echt is meegenomen. Een besluit
+dat verrijkt is zonder dat de Awb-termijnen erin zitten, faalt.
+
+Dat het data is en geen prozaregel in een skill is het punt. Een regel in een
+skill veroudert stil en niemand merkt het. Een lijst met een eigenaar en een poort
+die erop controleert, veroudert zichtbaar.
+
+Het duurste eraan is dat de kaart machinaal toetsbaar moet zijn. "De Awb is van
+toepassing" zegt een poort niets. "Een output die een besluit representeert heeft
+een beslistermijn en een bezwaarpad" is toetsbaar, en zo'n formulering is
+juristenwerk per kaderwet. Voor de Awb en de Awir samen is dat de moeite waard,
+omdat die twee bijna elke materiewet in dit domein raken. Daarna weegt het per
+geval.
 
 De lijst zelf blijft een erkend risico: wat er niet op staat, mis je nog steeds
-stil. Dat is een aanvaarde beperking en geen opgelost probleem, en de lijst
-hoort dus periodiek tegen het licht.
+stil. Dat is een aanvaarde beperking en geen opgelost probleem, en de lijst hoort
+dus periodiek tegen het licht.
 
 ## Scenario als wortel
 
@@ -183,10 +267,12 @@ rest. Uitkomst zijn kanten en geen YAML.
 
 De enrich-stap is duur en draait alleen over de knopen in de sluiting.
 
-De resolve-stap hoeft niet over het hele geoogste corpus te draaien om te
-beginnen, want de delegatiegrens en de kaderwetkaarten vangen samen af waar de
-omgekeerde relaties zaten. Breder resolven wordt pas interessant als je vragen
-wilt beantwoorden over wat er nog niet verrijkt is.
+De resolve-stap blijft smal en draait alleen over de sluiting. Cargo werkt zo:
+de resolver haalt metadata op van de packages in de dependency tree en niet van
+de hele registry. Wie omgekeerde vragen wil beantwoorden ("welke wetten hangen
+van dit artikel af"), heeft een brede index nodig, en dat is bij cargo ook een
+aparte dienst die naast de resolver staat. Zo'n index is hier later te bouwen op
+dezelfde resolve-stap, en hij hoeft niet in de enricher-lus te zitten.
 
 ## Cycli
 
@@ -259,25 +345,12 @@ Deze RFC zegt niets over de vraag wanneer een wet opnieuw verrijkt moet worden
 omdat de enricher beter is geworden. Dat is een herbouwvraag en de sidecar-versies
 zijn er de grondstof voor.
 
-## Verhouding tot andere RFC's
+## Gevolg voor RFC-027
 
-Vier RFC's beschrijven verschillende lagen van dezelfde machine en zijn geen van
-alle samen te voegen.
-
-Deze RFC bepaalt welke knopen verrijkt moeten worden en in welke volgorde. Hij
-levert taken op.
-
-RFC-026 bepaalt wat een goede verrijking van één knoop is: de keten van rollen,
-de poorten en de faalvormen. Hij verbruikt taken.
-
-RFC-028 bepaalt hoe één stap uit die keten draait: het stap-object, de
-capabilities en de runtime.
-
-RFC-027 bepaalt waarop het geheel getoetst wordt.
-
-De enige verschuiving tussen bestaande RFC's die hieruit volgt, is dat de
-bindingspoort van RFC-026 een sluitings-poort wordt en dat de volgorde waarin
-wetten verrijkt worden daar niet meer thuishoort.
+De bindingscheck van RFC-027 wordt een sluitings-poort. Een binding naar een
+knoop die zelf nog in de werkvoorraad staat, is daar geen bevinding maar een
+openstaande taak, en pas bij een lege sluiting telt een onvervulde binding als
+fout.
 
 ## Volgorde
 
@@ -299,18 +372,10 @@ het bovenstaande.
 
 ## Open beslissingen
 
-Is de knoop het artikel of het fragment. De verwijzingen gaan vaak naar een lid
-("artikel 8, tweede lid"), wat voor fijnere knopen pleit, maar het geoogste corpus
-fragmenteert tot `2.1.e.1°` en dat is fijner dan zinvol.
-
-Draait de resolve-stap over het hele geoogste corpus of alleen over de sluiting.
-Alleen over de sluiting is goedkoper, maar dan kun je geen vragen beantwoorden
-over wat er nog niet in zit.
-
-Wie beheert de kaderwetlijst en met welk reviewritme.
+Wie wijst de kaderwetten aan en beheert de lijst en met welk reviewritme.
 
 Is de sidecar een bestand naast de wet of een map. Bij fijne fragmentatie wordt
 één bestand groot.
 
-Deze RFC is in het Nederlands terwijl RFC-026 en RFC-028 in het Engels staan. Dat
+Deze RFC is in het Nederlands terwijl RFC-027 en RFC-028 in het Engels staan. Dat
 moet een keer één kant op.

--- a/docs/src/content/rfcs/rfc-029.md
+++ b/docs/src/content/rfcs/rfc-029.md
@@ -1,0 +1,316 @@
+---
+title: "RFC-029: De werkvoorraad van de enricher"
+status: Draft
+implementation: Not implemented
+date: '2026-08-01'
+authors:
+  - Eelco Hotting
+depends_on:
+  - RFC-003 (Inversion of Control for Delegated Values)
+  - RFC-008 (Awb Procedures and Lifecycle)
+  - RFC-012 (Untranslatables)
+  - RFC-026 (Enrichment a Legal Expert Can Check)
+short_title: Werkvoorraad
+---
+
+## Context
+
+RFC-026 beschrijft hoe je één wet goed verrijkt. Deze RFC gaat over de vraag die
+daarvoor komt: welke wetten, en welke delen daarvan, moeten verrijkt worden om
+een bepaalde uitvoering mogelijk te maken, en hoe weet je dat je klaar bent.
+
+Een wet staat niet op zichzelf. De Wet op de zorgtoeslag rekent met een
+toetsingsinkomen dat in de Awir staat, met een verzekeringsplicht uit de
+Zorgverzekeringswet, met een inkomensbegrip uit de Wet inkomstenbelasting, en met
+bedragen die bij ministeriële regeling worden vastgesteld. Elk van die wetten
+verwijst weer verder. Wie een wet verrijkt en de verwijzingen volgt, staat binnen
+drie stappen voor het halve belastingrecht.
+
+De werkvoorraad die er nu is, kan dat niet aan. `jobs` heeft een `law_id` en een
+`priority` tussen 0 en 100. `law_entries` heeft `law_id` als primaire sleutel met
+één status per wet, zonder versie en zonder artikel. Er is geen veld waarin staat
+dat een wet in de lijst staat omdat een andere wet hem nodig had. Een taak die
+volgt uit een andere taak is niet te onderscheiden van een taak die iemand met de
+hand heeft ingevoerd, en de prioriteit van de afgeleide taak heeft geen relatie
+met die van zijn oorzaak.
+
+Het gevolg is meetbaar in ronde 2 van het enricher-archief. De zorgtoeslag is van
+bovenaf verrijkt en bindt daardoor aan outputs die de Awir en de
+Zorgverzekeringswet niet produceren, omdat die nog niet verrijkt zijn. Zes van de
+zeven bindingsbevindingen komen daarvandaan. Dat zijn geen fouten in de
+zorgtoeslag.
+
+## Requirements
+
+1. De sluiting van een verrijkingsopdracht is eindig en klein genoeg om af te
+   lopen.
+2. Werk dat één keer gedaan is, wordt niet opnieuw gedaan, ook niet wanneer een
+   andere opdracht hetzelfde artikel nodig heeft.
+3. Elke taak draagt de reden waarom hij bestaat, en zijn prioriteit volgt uit die
+   reden.
+4. Elke begrenzing van de sluiting laat een zichtbare markering achter.
+5. Een wet of document dat de uitvoering verandert zonder dat het corpus dat
+   weet, is de enige faalvorm die niet mag voorkomen.
+
+## Twee soorten gaten
+
+Requirement 4 en 5 komen uit dezelfde asymmetrie.
+
+Een **bekend gat** is een norm waarvan we weten dat hij nog niet is ingevuld, en
+waarvan we weten waar de invulling hoort te staan. Een open norm die bij
+ministeriële regeling wordt uitgewerkt, terwijl die regeling nog niet geoogst is.
+Dat gat is niet schadelijk. De wet wordt niet uitgevoerd tot de invulling er is,
+of de uitvoering blijft vragen om een invoer waarvan de ambtenaar weet dat het
+antwoord in beleidsdocument X staat. Het gat is bovendien werk dat weggezet kan
+worden: een agent of een analist zoekt het document op. Wat de aanleiding was om
+dat gat te vullen, doet er niet toe.
+
+Een **stil gat** is een werking die we niet kennen. Een algemene wet die zichzelf
+van toepassing verklaart op de materiewet, een beleidsregel die de bevoegdheid
+inperkt, een wijzigingswet die niet is meegenomen. Daar geeft de uitvoering een
+antwoord dat fout is, en niemand ziet het.
+
+Bekende gaten zijn een normale toestand van het corpus en hoeven de verrijking
+niet op te houden. Stille gaten zijn de enige echte faalvorm. Elke
+keuze hieronder om de sluiting te begrenzen is toegestaan zolang die keuze een
+bekend gat produceert en geen stil gat. Afkappen mag, stil afkappen niet.
+
+## Knopen en kanten
+
+Knopen zijn `(wet, versie, adres)`, waarbij het adres een artikel of een fragment
+daarbinnen is. Uitvoeringsdocumenten en beleidsregels zijn knopen van dezelfde
+soort. De wet zelf is een groepering van knopen.
+
+Die granulariteit is het belangrijkste antwoord op de uitwaaiering. Een verwijzing
+tussen wetten is bijna nooit "de Awir" maar "het toetsingsinkomen, bedoeld in
+artikel 8 van de Awir". Dat staat er letterlijk, en het is al een symboolimport.
+Wie de wet als knoop neemt, sleept bij artikel 8 de andere 86 artikelen mee en
+ziet de sluiting openklappen. Wie het artikel als knoop neemt, volgt de drie
+verwijzingen die artikel 8 zelf heeft. De oneindigheid is een eigenschap van te
+grove knopen en niet van het recht.
+
+Kanten zijn getypeerd, omdat de traversalregel per type verschilt.
+
+`uses-definition` betekent dat een knoop de betekenis van een begrip uit een
+andere knoop nodig heeft. `computes-with` betekent dat er een waarde berekend moet
+worden. Dat verschil is het verschil tussen een type-import en een
+runtime-import, en het is de tweede grote begrenzer. Een definitorische verwijzing
+sleept niets mee: je hebt de tekst van dat ene artikel nodig en verder niets. Een
+uitvoerende trekt zijn eigen keten mee. Wie die twee niet onderscheidt, verrijkt
+het halve belastingrecht om te weten wat "partner" betekent.
+
+`delegates-to` verbindt een open norm met het document dat hem invult, en wordt
+niet gevolgd. Zie de volgende sectie.
+
+`applies-to` loopt tegen de leesrichting in: van de kaderwet naar de materiewet.
+
+`amends` verbindt een wijzigingswet met wat hij wijzigt, en is vooral relevant
+voor invalidatie.
+
+## Delegatie eindigt de traversal
+
+Een `delegates-to`-kant wordt niet automatisch gevolgd. Hij levert een `norm_gap`
+op en daar houdt de sluiting op.
+
+Dit is de derde en waarschijnlijk grootste begrenzer. Delegatie is precies waar
+het corpus explodeert: er zijn duizenden ministeriële regelingen en
+beleidsregels, en een enricher die ze volgt komt nooit klaar. Tegelijk is het
+gat dat je overhoudt onschadelijk, want het is een bekend gat in de zin van de
+vorige sectie.
+
+Een `norm_gap` met een `expected_source` is daarmee geen mislukking maar een
+afgerond resultaat. Hij gaat naar een tweede werkvoorraad, van gevonden gaten,
+met een eigen prioritering. Iemand zoekt dat document op, laat het oogsten, en
+dan wordt de gap vervuld. Dat kan een agent zijn of een mens; het is analistenwerk
+en de aanleiding doet er niet toe.
+
+Dat maakt de vraag naar beleidsregels ook opportunistisch in plaats van
+volledig. Er is geen omgekeerde index over het hele corpus nodig om te weten
+welke beleidsregels bestaan. Je verrijkt, je krijgt gaten met een adres erbij, en
+dan zoek je gericht.
+
+## Kaderwetten
+
+Blijft over de klasse die je niet met een markering kunt afvangen: de kaderwet
+die zichzelf van toepassing verklaart terwijl de materiewet daar niets over zegt.
+De Awb is op vrijwel elk besluit van toepassing zonder dat de Wet op de
+zorgtoeslag dat vermeldt. Wie vanuit de materiewet zoekt, vindt hem nooit. Dit is
+het stille gat uit requirement 5.
+
+Er zijn er weinig. Awb, Awir, Algemene termijnenwet, Wet inkomstenbelasting voor
+de inkomensbegrippen, en nog een handvol. Die worden vooraf uitgewerkt en
+vastgelegd als data, niet als proza in een skill: per kaderwet het
+toepassingsbereik, het patroon waaraan je herkent dat het aan de orde is, en wat
+er dan meegenomen moet worden. Een verrijkingsopdracht krijgt die kaarten mee als
+extra invoer, en de poort na de verrijking controleert dat de vermelde werking
+ook echt is meegenomen. Een besluit dat verrijkt is zonder dat de Awb-termijnen
+erin zitten, faalt.
+
+Dat het data is en geen prozaregel is het punt. Een regel in een skill veroudert
+stil en niemand merkt het. Een lijst met een eigenaar en een poort die erop
+controleert, veroudert zichtbaar.
+
+De lijst zelf blijft een erkend risico: wat er niet op staat, mis je nog steeds
+stil. Dat is een aanvaarde beperking en geen opgelost probleem, en de lijst
+hoort dus periodiek tegen het licht.
+
+## Scenario als wortel
+
+Een sluiting heeft een beginpunt nodig, en "verrijk de zorgtoeslag" is er geen,
+want daaruit volgt niet wanneer je klaar bent.
+
+Het bruikbare beginpunt is een scenario. De BDD-features zijn de entry points,
+zoals bij tree-shaking. "Deze burger met dit inkomen krijgt dit bedrag" bepaalt
+welke outputs berekend moeten kunnen worden, en daaruit volgt welke knopen nodig
+zijn. De stopconditie is dan niet dat de graaf leeg is maar dat de scenario's
+draaien.
+
+Een dieptelimiet en een budget blijven bestaan als vangnet, maar zijn niet de
+eerste verdediging. Ze markeren en loggen wat ze afkappen, volgens
+requirement 4.
+
+## Resolven en verrijken zijn twee stappen
+
+Er zit een kip-ei in de opzet: de afhankelijkheden zijn pas bekend na verrijking,
+terwijl de verrijking gestuurd moet worden op de afhankelijkheden. Dat lost een
+package manager op door resolven en bouwen te scheiden, en hier werkt dat ook.
+
+De resolve-stap is goedkoop en leest alleen verwijzingen uit de wettekst: welk
+artikel verwijst naar welk artikel van welke wet, met een type erbij. Dat is
+grotendeels mechanisch, want "als bedoeld in artikel 8 van de Algemene wet
+inkomensafhankelijke regelingen" is een vaste vorm, met een lichte agent voor de
+rest. Uitkomst zijn kanten en geen YAML.
+
+De enrich-stap is duur en draait alleen over de knopen in de sluiting.
+
+De resolve-stap hoeft niet over het hele geoogste corpus te draaien om te
+beginnen, want de delegatiegrens en de kaderwetkaarten vangen samen af waar de
+omgekeerde relaties zaten. Breder resolven wordt pas interessant als je vragen
+wilt beantwoorden over wat er nog niet verrijkt is.
+
+## Cycli
+
+Wetten verwijzen over en weer, dus de graaf is niet acyclisch en er is geen
+topologische volgorde om in te bouwen.
+
+Daaruit volgt een concrete verandering in wat er nu staat: de bindingspoort mag
+geen wet-poort zijn maar moet een sluitings-poort zijn. Zolang een binding wijst
+naar een knoop die zelf nog in de werkvoorraad staat, is dat geen bevinding maar
+een openstaande taak. Pas als de sluiting leeg is, telt een onvervulde binding als
+fout. Dat verklaart de zes van zeven bindingsbevindingen uit ronde 2 en haalt ze
+weg zonder de controle te verzwakken.
+
+## Status per artikel per versie
+
+De status hoort per knoop en niet per wet, en hij hoort naast de wet in een
+sidecar bij de toestandsdatum. De wet-YAML zelf is het contract dat de engine
+leest en daar hoort geen procesadministratie in.
+
+Per fragment: welke enricher-versie, welke schemaversie, de poortuitslagen, de
+markeringen, en een hash van de brontekst. Die hash is de invalidatie. Verandert
+de toestand door een wijzigingswet, dan vervalt de status van precies de
+artikelen die veranderd zijn en niet van de wet als geheel. Dat is de
+integriteitscheck die een lockfile ook doet, en het is de voorwaarde voor
+requirement 2: zonder hash is hergebruik van eerder werk een gok.
+
+De graaf komt in Postgres, maar als afgeleide. De waarheid staat in de bestanden
+en de index is weg te gooien en opnieuw op te bouwen. Twee bronnen van waarheid
+lopen uit elkaar, en de bestanden zijn degene die gereviewd worden.
+
+## Werkvoorraad
+
+Een taak is een knoop plus de wortels waarvoor hij nodig is. Prioriteit is het
+maximum over die wortels. Dezelfde knoop die vanuit twee wortels gevraagd wordt,
+is één taak met twee redenen en niet twee taken.
+
+Dat geeft ook gratis antwoord op de vraag waarom iets in de wachtrij staat, en
+het maakt de prioritering van afgeleid werk afhankelijk van zijn oorzaak in
+plaats van van een los ingevuld getal.
+
+Naast deze voorraad staat de tweede, van gevonden gaten uit de delegatiesectie.
+Die twee zijn bewust gescheiden, want ze hebben verschillende uitvoerders en
+verschillende afwegingen.
+
+## Clustering
+
+De verwachting is dat de graaf uiteenvalt in gemeenschappen die met rechtsgebieden
+samenvallen: sociale zekerheid rond de Awir en de Wet inkomstenbelasting,
+omgevingsrecht rond de Omgevingswet, met de kaderwetten als kanten dwars door
+alles heen.
+
+Als dat klopt, is het bruikbaar: de sluiting van een scenario ligt dan grotendeels
+binnen één cluster plus een paar kaderwetten, en dan is de werkvoorraad per
+gebied planbaar in plaats van per wet. Het is toetsbaar zodra de resolve-stap over
+genoeg corpus heeft gedraaid, door de modulariteit van de graaf te meten. Tot dan
+is het een vermoeden.
+
+## Wat dit niet oplost
+
+De kaderwetlijst is handwerk en veroudert. Een werking die er niet op staat
+blijft een stil gat.
+
+De resolve-stap moet verwijzingen herkennen die niet in de standaardvorm staan.
+Impliciete verwijzingen ("de daartoe bevoegde minister") vindt hij niet.
+
+Een `norm_gap` die verkeerd geadresseerd is, wijst de zoeker naar het verkeerde
+document. De poort kan controleren dát er een adres is, niet of het klopt.
+
+Deze RFC zegt niets over de vraag wanneer een wet opnieuw verrijkt moet worden
+omdat de enricher beter is geworden. Dat is een herbouwvraag en de sidecar-versies
+zijn er de grondstof voor.
+
+## Verhouding tot andere RFC's
+
+Vier RFC's beschrijven verschillende lagen van dezelfde machine en zijn geen van
+alle samen te voegen.
+
+Deze RFC bepaalt welke knopen verrijkt moeten worden en in welke volgorde. Hij
+levert taken op.
+
+RFC-026 bepaalt wat een goede verrijking van één knoop is: de keten van rollen,
+de poorten en de faalvormen. Hij verbruikt taken.
+
+RFC-028 bepaalt hoe één stap uit die keten draait: het stap-object, de
+capabilities en de runtime.
+
+RFC-027 bepaalt waarop het geheel getoetst wordt.
+
+De enige verschuiving tussen bestaande RFC's die hieruit volgt, is dat de
+bindingspoort van RFC-026 een sluitings-poort wordt en dat de volgorde waarin
+wetten verrijkt worden daar niet meer thuishoort.
+
+## Volgorde
+
+De goedkoopste eerste stap is de sidecar met status per fragment, inclusief de
+hash. Die is los bruikbaar, want hij maakt hergebruik meteen veilig, en hij is
+nodig voor al het andere.
+
+Daarna de resolve-stap over de wetten die nu in de ronde zitten, zodat de graaf
+bestaat voordat er iets op gebouwd wordt.
+
+Daarna de kaderwetkaarten voor Awb en Awir, omdat die twee de meeste materiewetten
+raken en de poort erop de gevaarlijkste faalvorm afdekt.
+
+Daarna de werkvoorraad met herkomst, en pas dan de sluitings-poort, want die heeft
+de werkvoorraad nodig om te weten wat nog open staat.
+
+De visualisatie van de graaf staat in een apart ontwerp en is geen voorwaarde voor
+het bovenstaande.
+
+## Open beslissingen
+
+Is de knoop het artikel of het fragment. De verwijzingen gaan vaak naar een lid
+("artikel 8, tweede lid"), wat voor fijnere knopen pleit, maar het geoogste corpus
+fragmenteert tot `2.1.e.1°` en dat is fijner dan zinvol.
+
+Draait de resolve-stap over het hele geoogste corpus of alleen over de sluiting.
+Alleen over de sluiting is goedkoper, maar dan kun je geen vragen beantwoorden
+over wat er nog niet in zit.
+
+Wie beheert de kaderwetlijst en met welk reviewritme.
+
+Is de sidecar een bestand naast de wet of een map. Bij fijne fragmentatie wordt
+één bestand groot.
+
+Deze RFC is in het Nederlands terwijl RFC-026 en RFC-028 in het Engels staan. Dat
+moet een keer één kant op.


### PR DESCRIPTION
RFC-027 beschrijft hoe je één wet goed verrijkt. Deze RFC gaat over de vraag die daarvoor komt: welke wetten, en welke delen daarvan, moeten verrijkt worden voordat een scenario uitvoerbaar is, en wanneer je klaar bent.

De kern is dat de dependency-keten wordt afgelopen op artikelniveau in plaats van wetniveau, met getypeerde kanten die verschillend traverseren. Een definitorische verwijzing sleept niets mee, een uitvoerende wel, en een delegatie naar een beleidsregel wordt helemaal niet gevolgd maar levert een `norm_gap` op die naar een tweede werkvoorraad gaat. Daarmee blijft de sluiting eindig.

Wat overblijft is de kaderwet die zichzelf van toepassing verklaart terwijl de materiewet daar niets over zegt, zoals de Awb. Die vind je vanuit de materiewet nooit, en daar is het voorstel een vooraf uitgewerkte lijst als data, met een poort die controleert dat de werking is meegenomen.

Er volgt één verschuiving in RFC-027 uit: de bindingscheck wordt een sluitings-poort. Dat verklaart de zes van zeven bindingsbevindingen in ronde 2 van het enricher-archief, die geen fouten in de zorgtoeslag waren maar het gevolg van bovenaf beginnen.

De visualisatie van de graaf staat in een apart ontwerp en is geen voorwaarde. Open beslissingen staan onderaan de RFC.

De vier enrichment-RFC's zijn hernummerd zodat ze van buiten naar binnen lopen: 026 werkvoorraad, 027 kwaliteit, 028 stappen, 029 fixtures. Elk document opent met een kadertje dat de reeks uitlegt.