### PR TITLE
docs(docs): rfc-030 over wetshistorie in het corpus

### DIFF
--- a/docs/src/content/rfcs/rfc-030.md
+++ b/docs/src/content/rfcs/rfc-030.md
@@ -13,31 +13,6 @@ depends_on:
 short_title: Wetshistorie
 ---
 
-## Deze RFC in de reeks
-
-Vier RFC's beschrijven lagen van dezelfde machine, van buiten naar binnen.
-
-**RFC-026, Werkvoorraad.** Welke artikelen verrijkt moeten worden en in welke
-volgorde. Levert taken op.
-
-**RFC-027, Enrichment Quality.** De rollen, de poorten en de faalvormen die
-bepalen of één artikel goed verrijkt is. Verbruikt taken.
-
-**RFC-028, Steps and Runtimes.** Hoe één stap uit die keten draait.
-
-**RFC-029, Test Fixtures.** De maatlat voor het geheel.
-
-**RFC-030, Wetshistorie.** Welk materiaal er naast de wettekst ligt wanneer een
-artikel verrijkt wordt.
-
-Deze RFC staat naast de reeks en niet erin. De vier andere beschrijven lagen van
-één machine: de een levert taken aan de ander, en samen zijn ze de enricher.
-Deze RFC beschrijft een corpusuitbreiding met een eigen oogstketen en een eigen
-opslagvorm. De enricher is er de eerste afnemer van en niet de enige: een jurist
-die een modelkeuze beoordeelt en een analist die een open norm zoekt, willen
-hetzelfde materiaal. Dat het via de contextlagen van RFC-027 bij de agent komt,
-maakt het een invoer voor de reeks en geen laag erin.
-
 ## Aanleiding
 
 De verrijkingsprompt in `packages/pipeline/src/enrich.rs` opent met een stap die

--- a/docs/src/content/rfcs/rfc-030.md
+++ b/docs/src/content/rfcs/rfc-030.md
@@ -1,0 +1,604 @@
+---
+title: "RFC-030: Wetshistorie in het corpus"
+status: Draft
+implementation: Not implemented
+date: '2026-08-01'
+authors:
+  - Eelco Hotting
+depends_on:
+  - RFC-026 (De werkvoorraad van de enricher)
+  - RFC-027 (Enrichment a Legal Expert Can Check)
+  - RFC-028 (Steps and Runtimes for the Enrichment Chain)
+  - RFC-029 (Test Fixtures)
+short_title: Wetshistorie
+---
+
+## Deze RFC in de reeks
+
+Vier RFC's beschrijven lagen van dezelfde machine, van buiten naar binnen.
+
+**RFC-026, Werkvoorraad.** Welke artikelen verrijkt moeten worden en in welke
+volgorde. Levert taken op.
+
+**RFC-027, Enrichment Quality.** De rollen, de poorten en de faalvormen die
+bepalen of één artikel goed verrijkt is. Verbruikt taken.
+
+**RFC-028, Steps and Runtimes.** Hoe één stap uit die keten draait.
+
+**RFC-029, Test Fixtures.** De maatlat voor het geheel.
+
+**RFC-030, Wetshistorie.** Welk materiaal er naast de wettekst ligt wanneer een
+artikel verrijkt wordt.
+
+Deze RFC staat naast de reeks en niet erin. De vier andere beschrijven lagen van
+één machine: de een levert taken aan de ander, en samen zijn ze de enricher.
+Deze RFC beschrijft een corpusuitbreiding met een eigen oogstketen en een eigen
+opslagvorm. De enricher is er de eerste afnemer van en niet de enige: een jurist
+die een modelkeuze beoordeelt en een analist die een open norm zoekt, willen
+hetzelfde materiaal. Dat het via de contextlagen van RFC-027 bij de agent komt,
+maakt het een invoer voor de reeks en geen laag erin.
+
+## Aanleiding
+
+De verrijkingsprompt in `packages/pipeline/src/enrich.rs` opent met een stap die
+de agent niet kan uitvoeren. `build_chunk_prompt` schrijft voor: lees
+`.claude/skills/law-mvt-research/SKILL.md` en volg die instructies om de Memorie
+van Toelichting op te zoeken. De skill zoekt over een SRU-API en haalt
+documenten op met WebFetch. De agent draait met `--allowedTools
+Read,Edit,Write,Grep,Glob` en `allow_bash: false`, dus zonder netwerk en zonder
+shell. Er is geen route waarlangs die stap kan slagen.
+
+De uitkomst daarvan staat in ronde 2 van het enricher-archief. Er kwam een
+kamerstuknummer uit met een werkende URL, `kst-29762-3`, in een
+`.feature`-bestand dat toen door geen enkele poort werd bekeken. De wet-YAML
+zelf was schoon. Het nummer is bij navraag ook goed: kamerstuk 29 762, nr. 3,
+vergaderjaar 2003-2004, is de memorie van toelichting bij de Wet op de
+zorgtoeslag. Dat maakt het geval erger en niet lichter. De agent kende de
+conventie dat het dossiernummer van de wet plus ondernummer 3 meestal de MvT is,
+heeft die conventie ingevuld en heeft het resultaat gepresenteerd als citaat.
+Bij een initiatiefwet, een novelle of een wet waar het advies van de Raad van
+State onder nummer 3 staat, levert dezelfde redenering een verkeerd nummer op,
+en niets in de keten ziet het verschil.
+
+Dat is de faalvorm uit issue #1036: een instructie schrijft werk voor dat de
+runtime niet kan uitvoeren, niets vergelijkt die twee, en de stap eindigt
+schoon. RFC-028 lost de structurele helft op met capabilities en een preflight
+die zo'n stap weigert voordat er een proces bestaat. Daarmee wordt de opdracht
+afgewezen en blijft de agent zonder toelichting zitten. Deze RFC gaat over de
+andere helft: zorgen dat het materiaal er is, gepind en leesbaar vanaf schijf,
+zodat de instructie uitvoerbaar wordt in plaats van geschrapt.
+
+In `packages/pipeline/src/enrich_v2/checks.rs` staat inmiddels
+`citations_in_companion_files`, die aanslaat op `kst-`, `stb-`, `stcrt-` en
+`ecli:` in elk bestand naast de wet wanneer die tekenreeks in geen enkele
+aangeboden tekst voorkomt. Die poort dicht het gat van ronde 2. Hij maakt de
+verrijking ook armer, want de enige toegestane uitkomst is nu zwijgen over de
+parlementaire geschiedenis.
+
+## Reikwijdte
+
+Wetshistorie is hier het geheel van door de wetgever geproduceerde documenten
+die uitleggen wat een bepaling moet doen. De MvT is het bekendste lid en niet
+het enige dat telt.
+
+Binnen scope, in volgorde van waarde per eenheid oogstwerk:
+
+- **Memorie van toelichting** bij een wetsvoorstel, en de **nota van toelichting**
+  bij een AMvB of KB. Zelfde functie, andere naam, andere vindplaats: de nota van
+  toelichting staat in het Staatsblad bij het besluit zelf en niet in een
+  kamerstukdossier.
+- **Nota's van wijziging** en de bijbehorende toelichting. Deze corrigeren de MvT
+  tijdens de behandeling en zijn de reden dat de MvT alleen niet volstaat.
+- **Amendementen** met hun toelichting. Een aangenomen amendement verandert de
+  wettekst nadat de MvT geschreven is, waarmee de MvT op dat punt een tekst
+  beschrijft die nooit wet geworden is.
+- **Nota naar aanleiding van het verslag**. Hier staan de uitgewerkte
+  rekenvoorbeelden en de randgevallen die kamerleden hebben afgedwongen, vaak
+  concreter dan de MvT.
+- **Advies van de Raad van State en het nader rapport**. Het advies benoemt waar
+  de norm onduidelijk is en het nader rapport zegt wat de regering daarmee heeft
+  gedaan. Voor open normen is dit het meest bruikbare materiaal dat er is.
+- **Wijzigingswetten zelf**, als tekst. Die zijn geen toelichting, ze zijn de brug
+  tussen de nummering van de toelichting en de nummering van de geconsolideerde
+  wet. Zie de sectie over koppeling.
+- **Transponeringstabellen** bij implementatiewetgeving. Die zeggen welk artikel
+  van de richtlijn in welk artikel van de wet zit, en dat is een kant in de graaf
+  van RFC-026 met een EU-knoop aan de andere kant.
+
+Buiten scope, met de reden erbij:
+
+- **Inwerkingtredingsbesluiten.** De informatie die we eruit zouden halen (welke
+  bepaling wanneer werkt) staat al in het BWB-manifest en in de WTI, en de
+  harvester leest die twee al. Een eigen oogstketen voor een tweede bron van
+  dezelfde waarheid levert alleen de kans op dat de twee uiteenlopen.
+- **Wetsevaluaties.** Die beschrijven hoe de wet uitpakt en niet wat hij
+  voorschrijft. Waardevol voor beleid, geen invoer voor kwalificatie van een
+  bepaling. Het onderscheid is bruikbaar als toets: een document hoort erbij als
+  het is geschreven om de bepaling vast te stellen, en niet als het is geschreven
+  om het resultaat te beoordelen.
+- **Handelingen en verslagen van debatten.** Enorm volume, lage dichtheid, geen
+  vaste structuur per artikel. Als er iets in staat dat telt, staat het meestal
+  ook in de nota naar aanleiding van het verslag.
+- **Jurisprudentie.** Dit is een eigen categorie en geen deel van deze. Een
+  uitspraak is geen wetgevershistorie: hij komt van een andere macht, hij is niet
+  aan een wetsversie gebonden maar aan een geschil, hij vindt via ECLI en
+  Rechtspraak.nl in plaats van via de parlementaire keten, en hij heeft een eigen
+  gezagsvraag (welke instantie, welke instantie erboven, is het nog geldend
+  recht). Een uitspraak die een open norm invult, hoort in het model van RFC-026
+  eerder thuis als invulling van een `norm_gap` dan als toelichting bij een
+  artikel. Dat verdient een eigen RFC en die wordt hier niet geschreven.
+
+## Stapels toelichtingen
+
+Een toestand van een wet op een datum is de oorspronkelijke wet plus elke
+wijziging daarna. Elke wijziging heeft een eigen toelichting; de toestand zelf
+heeft er geen. Er bestaat geen document dat de geconsolideerde wet van
+2025-01-01 uitlegt.
+
+Bij een artikel wil je dus een stapel, en de bron zegt hoe hoog die is. Ik heb
+de WTI van de Wet op de zorgtoeslag (BWBR0018451, 714 KB) uitgelezen. In het
+`wijzigingen`-blok staat naast de wetsbrede chronologie een `regelingelement`
+per artikel, met een eigen `datum`-reeks. Voor deze wet zijn dat 15 elementen
+met samen 99 wijzigingsregels. Artikel 2 heeft er 33, terug tot
+`nieuwe-regeling` in 2006. Van de 99 regels dragen er 53 een `dossiernummer`,
+oftewel een verwijzing naar een kamerstukdossier; 14 komen uit een
+Staatscourant-regeling, waar de toelichting in de regeling zelf staat en niet in
+een kamerstuk. De 33 wijzigingen van artikel 2 gaan terug op 4 unieke dossiers,
+want de meeste zijn ministeriële bijstellingen van percentages.
+
+Het model volgt die structuur en plat hem niet. Drie soorten knopen:
+
+- **Artikelversie**: `(wet, artikel, inwerkingtredingsdatum)`. Dit is de knoop
+  van RFC-026 met de versie erbij.
+- **Wijziging**: een `amends`-kant uit RFC-026, met de Staatsblad- of
+  Staatscourant-bekendmaking als identiteit.
+- **Toelichtingsfragment**: een stuk tekst uit één document, met de bepaling die
+  het toelicht als adres.
+
+De kant die erbij komt is `explained-by`, en die hangt aan de wijziging en niet
+aan het artikel. Een fragment legt uit wat een wijziging deed; dat die wijziging
+een bepaald artikel raakte, staat al vast in de `amends`-kant. Wie de twee
+kanten achter elkaar volgt, krijgt voor een artikelversie de toelichting bij de
+wijziging die hem opleverde, en door de reeks af te lopen de lagen daaronder.
+
+Dat de laatste wijziging maar een deel van het artikel raakte, is de normale
+situatie. Een wijziging die alleen lid 3 verving, verklaart lid 1 niet, en de
+toelichting bij lid 1 zit dan in een oudere laag. Het adres per fragment is
+daarom een bepaling en geen artikel: lid, onderdeel of zinsnede waar de bron dat
+levert. Waar de bron alleen het artikel noemt, is het adres het artikel, en dan
+is de stapel grover dan we zouden willen.
+
+De volgorde van aanbieden is chronologisch aflopend, jongste laag eerst, met de
+inwerkingtredingsdatum bij elk fragment. Een agent die drie lagen leest, ziet
+dan welke de huidige tekst beschrijft.
+
+## Koppeling tussen twee nummeringen
+
+De toelichting bij een wijzigingswet spreekt in de nummering van die
+wijzigingswet. "Artikel I, onderdeel C" is een adres in het wetsvoorstel en niet
+in de wet die gewijzigd wordt. De wijzigingswet zelf legt de brug ("Artikel 8,
+tweede lid, komt te luiden:"), en die brug is wat je moet parsen om een fragment
+aan een artikel te hangen. Dit is het duurste onderdeel van het ontwerp en het
+onderdeel waar ik het minst zeker van ben.
+
+Er zijn drie routes, en ze zijn niet even duur.
+
+**Route 1: het kopje van de toelichting leest de brug voor.** De artikelsgewijze
+paragraaf van een MvT gebruikt tussenkoppen, en die noemen het doelartikel vaak
+tussen haakjes: "Artikel I, onderdeel C (artikel 4 van de Wtcg)". Ik heb dat
+gemeten. Voor de 26 dossiers uit de wijzigingsgeschiedenis van de zorgtoeslag
+heb ik de MvT opgehaald (24 gevonden) en de artikelsgewijze koppen geteld: 868
+koppen, waarvan er 349 een doelartikel tussen haakjes noemen. Dat is 40 procent.
+De spreiding is het probleem: 12 van de 23 documenten met koppen doen het
+nergens en schrijven kaal "Artikel I, onderdeel A", terwijl documenten die het
+wel doen het bijna overal doen. De conventie is per document en niet per kop,
+waarschijnlijk omdat ze per departement of per wetgevingsjurist verschilt. Route
+1 is dus goedkoop (een reguliere expressie op de kop) en dekt ongeveer de helft
+van de documenten volledig en de andere helft niet.
+
+**Route 2: de toestand-XML noemt de bron per artikel.** In het BWB-toestandsbestand
+draagt elk `artikel`-element attributen die dit werk al half gedaan hebben:
+
+```xml
+<artikel label-id="7153784" label="Artikel 2" inwerking="2025-01-01"
+         bron="Stb.2011-620" effect="wijziging" ondertekening_bron="2011-12-06">
+```
+
+`bron` noemt de bekendmaking die deze versie van dit artikel opleverde, en via
+de WTI hoort daar een dossiernummer bij. Daarmee is "welke wijziging raakte dit
+artikel het laatst" al beantwoord zonder één regel wijzigingswettekst te parsen.
+Dat is minder dan waar we op uit zijn (het levert het document en niet het
+fragment), en het is genoeg om een MvT op documentniveau aan een artikel te
+hangen met een gerichte tussenkop-zoekactie erin.
+
+**Route 3: de wijzigingswet parsen.** De wijzigingswet staat als BWB-regeling in
+dezelfde repository en heeft dezelfde XML-vorm, dus de tekst is er. De opgave is
+per onderdeel de zin "Artikel 8, tweede lid, komt te luiden" herkennen en er een
+doeladres uit halen. De vormen zijn beperkt in aantal (komt te luiden, wordt
+vervangen door, vervalt, wordt ingevoegd, wordt gewijzigd als volgt) en de
+grammatica is redelijk vast, want de Aanwijzingen voor de regelgeving schrijven
+hem voor. Ik gok dat een parser 80 tot 90 procent van de onderdelen goed
+adresseert en dat de rest bestaat uit samengestelde constructies ("in de
+artikelen 3, 5 en 7 wordt telkens ..."). Dat gokken is de reden dat route 3
+achteraan staat: het is de enige route waarvan ik de trefkans niet gemeten heb.
+
+Het antwoord als het niet lukt is een gemarkeerd gat en geen stilte, in de zin
+van RFC-026. Een fragment zonder betrouwbaar adres wordt niet aan een artikel
+gehangen. Het document blijft geoogst, gepind en doorzoekbaar op wetniveau, en
+de agent krijgt het aangeboden met de mededeling dat de koppeling per artikel
+ontbreekt. Beter een toelichting die de agent moet doorzoeken dan een fragment
+dat bij het verkeerde artikel is gehangen, want dat laatste is niet als fout te
+herkennen aan de output.
+
+## Toelichting is geen recht
+
+De opdrachtgever eist dat alles in de YAML één op één terug te vinden is in de
+wetsartikelen zelf. Wetshistorie is invoer voor kwalificatie, voor het begrijpen
+van open normen en voor het schrijven van scenario's. Het is nooit een grondslag
+voor een `machine_readable`-regel. Zonder afdwinging is het toevoegen van
+toelichting aan de context een verslechtering, want de kwaliteitsauditskill
+`law-letter-fidelity-audit` kent toelichting-bleed al als eigen faalklasse: een
+criterium dat in het model staat terwijl de wettekst alleen een open norm bevat.
+
+Vier maatregelen, van goedkoop naar duur.
+
+**Mount-modus.** In het model van RFC-028 komt een toelichtingsfragment binnen als
+`Mode::Read`. Een gewijzigde read mount is een geregistreerde schending en wordt
+niet gepubliceerd. Dat kost niets omdat de machinerie er is.
+
+**Aparte artefactsoort.** `ArtifactKind` uit RFC-028 krijgt een lid voor
+wetshistorie, gescheiden van `StatutoryText`. De contextassemblage van RFC-027
+markeert de twee verschillend in het venster, met een kop boven elk fragment die
+zegt welke bron het is en dat hij niet bindt.
+
+**Verankeringspoort.** Een `legal_basis` en elk element dat
+`law-reverse-validate` naar een tekstfragment moet herleiden, mag alleen naar
+een `StatutoryText`-artefact wijzen. Een verankering die op een
+toelichtingsfragment uitkomt, is een harde fout. Dit is een aanscherping van een
+controle die al bestaat en die vandaag alleen niet kan afgaan, omdat er nog geen
+toelichting in het venster ligt.
+
+**Vocabulairescan.** De coverage-controle van RFC-027 kijkt per lid welke
+elementen van de tekst in het model zitten. Daar hoort een spiegel bij: elk
+begrip in het model dat in geen aangeboden `StatutoryText` voorkomt en wel in
+een aangeboden toelichtingsfragment, is een sterke aanwijzing voor bleed. Dat is
+een mechanische controle over twee tekstverzamelingen en hij vraagt geen model.
+De uitkomst is een bevinding voor de reviewer en niet automatisch een afkeuring,
+want een begrip kan legitiem uit beide komen.
+
+De citatiepoort keert bij dit alles om. Vandaag slaat
+`citations_in_companion_files` aan wanneer een `kst-`-verwijzing voorkomt in
+geen enkele aangeboden tekst. Zodra wetshistorie wordt aangeboden, wordt de
+regel strenger en preciezer: elke `kst-`, `stb-` of `stcrt-`-verwijzing in de
+output moet oplosbaar zijn naar een gemount fragment, met het documentnummer en
+de alinea erbij. Een citaat is dan een verwijzing naar iets dat op schijf staat
+en dus door een reviewer na te lopen is.
+
+## Verouderde toelichting
+
+Een verkeerde toelichting aanbieden is de gevaarlijkste faalvorm van dit
+ontwerp, gevaarlijker dan helemaal geen toelichting hebben. De MvT bij de
+oorspronkelijke wet beschrijft een artikel dat sindsdien vijf keer gewijzigd kan
+zijn. Een agent die die tekst naast de huidige redactie legt, leest een
+zelfverzekerde beschrijving van iets anders, en de beschrijving is intern
+consistent en overtuigend. Vandaag heeft de agent geen toelichting en gokt hij;
+met een verouderd fragment gokt hij niet meer en heeft hij ongelijk, wat door
+een reviewer moeilijker te betrappen is.
+
+Er is nog een variant die zelfs bij de eerste versie speelt. Een MvT beschrijft
+het wetsvoorstel zoals het is ingediend. Een aangenomen amendement verandert de
+tekst daarna zonder dat iemand de MvT herschrijft. De MvT bij de ingediende wet
+is dus niet automatisch de toelichting bij de wet zoals hij in werking trad. Dit
+is de reden dat amendementen en nota's van wijziging binnen scope staan: zij
+zijn de correctielaag op de MvT.
+
+Het antwoord is versiepinning, en weigeren wanneer die niet hard te maken is.
+
+Elk fragment draagt het bereik waarvoor het geldt: de artikelversie die de
+bijbehorende wijziging opleverde, met de inwerkingtredingsdatum en de opvolgende
+datum als bovengrens. Bij de assemblage van het venster voor artikel X op
+toestand T geldt dan:
+
+1. Fragmenten waarvan het bereik T omvat, komen in het venster zonder
+   waarschuwing. Dit is de toelichting bij de tekst die er staat.
+2. Fragmenten uit oudere lagen komen mee tot een limiet, elk met de tekst van de
+   artikelversie die zij beschrijven ernaast, en met het verschil tussen die
+   redactie en de huidige erbij. Een agent die ziet dat de beschreven zinsnede
+   niet meer in de wet staat, weet wat hij met de laag aan moet.
+3. Een fragment waarvan het bereik niet vast te stellen is, gaat niet in het
+   venster. Het blijft opvraagbaar in laag 2 van RFC-027, waar de agent er
+   gericht om moet vragen, en het draagt de mededeling dat de versie onbekend is.
+
+Regel 2 is de dure regel, want hij vraagt de tekst van oudere artikelversies.
+Die is er wel: BWB publiceert elke toestand, en het manifest noemt ze. Voor de
+zorgtoeslag is dat een handvol extra ophaalacties per artikel. Voor een wet met
+tientallen toestanden is het meer, en daar snijdt de limiet.
+
+Een waarschuwing op het fragment alleen, zonder pinning, is te zwak. Een agent
+die een blok tekst krijgt met "let op, dit kan verouderd zijn" erboven, gebruikt
+het toch, want het is het enige houvast dat hij heeft. De pinning hoort dus in
+de selectie te zitten.
+
+## Volume en fragmentatie
+
+Toelichtingen zijn lang. Van de 24 MvT's die ik heb opgehaald is de kleinste 6,9
+KB XML en de grootste 385 KB, met een mediaan van 122 KB. Dat is nog het
+gunstige geval: de MvT bij de Omgevingswet (kst-33962-3) is 2,7 MB XML. Een
+venster van 2 tot 6k tokens per artikel, zoals RFC-027 het begroot, verdraagt
+daar niets van in zijn geheel.
+
+De fragmentatie volgt de structuur die de bron al heeft. In de XML van officiële
+publicaties staat de artikelsgewijze toelichting als een reeks
+`tussenkop`-elementen met de alinea's ertussen, en die grens is de
+fragmentgrens. Bij oudere documenten heet het element `tuskop`; dat zijn twee
+schema's die allebei voorkomen en die allebei geparsed moeten worden. Het
+algemene deel wordt niet per artikel gefragmenteerd, want het gaat over de wet.
+
+Drie niveaus van aanbieden, in de vorm die RFC-027 al kent:
+
+- **In het venster**: de artikelsgewijze fragmenten die op het doelartikel
+  adresseren, gepind volgens de vorige sectie, met een harde bovengrens per venster
+  (voorstel: 1500 tokens, jongste laag eerst afkappend).
+- **Opvraagbaar**: het algemene deel, de fragmenten van naburige artikelen, en de
+  oudere lagen. De agent vraagt per adres, zoals hij ook een extern artikel opvraagt.
+- **Alleen als index**: alles wat groter is dan het budget, met kop, documentnummer
+  en positie, zodat een gerichte vraag mogelijk blijft.
+
+Zonder koppeling per artikel valt het eerste niveau weg en blijft het tweede
+over. Dan krijgt de agent een index van tussenkoppen van de documenten die
+volgens de WTI dit artikel geraakt hebben, en mag hij er één opvragen. Dat is
+aanzienlijk minder waard dan gerichte fragmenten, en het is aanzienlijk meer
+waard dan niets, en het is de reden dat de bouwvolgorde hieronder de koppeling
+niet als voorwaarde neemt.
+
+Het samenvatten van een lange toelichting door een model, om de samenvatting in
+het venster te leggen, valt buiten dit ontwerp. Dat maakt van een citeerbare
+bron een afgeleide waarvan niemand de herkomst kan nalopen, en dat is het
+probleem dat hier opgelost wordt.
+
+## Dekking en gaten
+
+Niet elke bepaling heeft een vindbare toelichting.
+
+Van de 26 dossiernummers in de wijzigingsgeschiedenis van de zorgtoeslag
+leverden er 24 een MvT op. Van de 99 wijzigingsregels per artikel dragen er 53
+een dossiernummer; de rest is ministeriële bijstelling of een oudere registratie
+zonder dossier. Voor een wet uit 2005 is dat een gunstig geval. Slechtere
+gevallen zijn er genoeg: wetten van voor de digitalisering van de kamerstukken
+(de elektronische reeks gaat niet ver genoeg terug voor negentiende-eeuwse
+wetgeving), initiatiefwetten waar de toelichting anders heet en anders genummerd
+is, novelles, en ministeriële regelingen waar de toelichting in de Staatscourant
+onder de regeling staat in plaats van als apart stuk.
+
+Elk van die gevallen wordt een gemarkeerd gat en geen stilte. Het onderscheid
+van RFC-026 tussen een bekend en een stil gat is hier het hele ontwerp. Een
+`history_gap` op een artikelversie zegt: deze wijziging bestaat, hij komt uit
+deze bekendmaking, en er is geen toelichting bij gevonden. Dat is een afgerond
+resultaat en gaat naar dezelfde tweede werkvoorraad als de `norm_gap`, met
+dezelfde afhandeling: iemand zoekt gericht, of niemand doet dat en het gat
+blijft zichtbaar staan.
+
+De stille variant die vermeden moet worden is een venster dat drie lagen
+aanbiedt terwijl er vijf zijn, zonder te zeggen dat er twee ontbreken. De agent
+leest dan een volledig ogende geschiedenis. Elk venster draagt daarom de
+telling: hoeveel wijzigingen deze artikelversie heeft, hoeveel toelichtingen
+daarvan zijn gevonden, en hoeveel er in dit venster zitten.
+
+## Bronnen en harvesten
+
+Alles komt uit twee KOOP-repositories die de harvester al kent, en er is geen
+dienst van buiten bij nodig.
+
+**Wat de harvester al ophaalt.** `repository.officiele-overheidspublicaties.nl/bwb`
+levert per BWB-id het manifest, de WTI en de toestand-XML. De WTI wordt vandaag
+gebruikt voor citeertitel, soort-regeling en publicatiedatum; het
+`wijzigingen`-blok en het per-artikel `regelingelement` worden niet gelezen. Dat
+blok bevat de hele chronologie inclusief dossiernummers. Dit is geen nieuw
+netwerkpad maar een uitbreiding van een parser op een bestand dat al binnenkomt.
+
+**Wat erbij komt.** De SRU-dienst op `repository.overheid.nl/sru` (SRU 2.0) doorzoekt
+de collectie officiële publicaties. `w.dossiernummer==29762` geeft 46 records
+voor het zorgtoeslagdossier, waaronder de MvT, de amendementen en de brieven van
+de minister. Elk record draagt een `gzd:itemUrl` per manifestatie, en daar zit
+een XML-variant bij:
+
+```
+https://repository.overheid.nl/frbr/officielepublicaties/kst/29762/kst-29762-3/1/xml/kst-29762-3.xml
+```
+
+De XML is de vorm die we willen. PDF komt in dezelfde reeks voor en wordt niet
+gebruikt; er is geen document waarvoor alleen PDF beschikbaar is dat we in de
+eerste fase nodig hebben.
+
+**Wat er mis is met het pad in de skill.** `law-mvt-research` gebruikt
+`zoekservice.overheid.nl/sru/Search` met `x-connection=officielepublicaties`.
+Die combinatie geeft vandaag `Unsupported parameter value` op de x-connection,
+ook bij `operation=explain`. Het endpoint werkt wel voor CVDR, wat de harvester
+ervoor gebruikt. De skill beschrijft dus, naast een netwerkroute die de runtime
+niet heeft, ook een query die niet meer bestaat. Dat is een tweede reden om deze
+stap uit de agent te halen en in de harvester te leggen, waar een gebroken
+endpoint een falende oogstopdracht oplevert in plaats van een stille stap.
+
+**Parsekosten.** Twee XML-schema's voor kamerstukken (`tuskop` en `tussenkop`),
+plus een derde vorm voor Staatsblad-besluiten met een nota van toelichting. De
+documentsoort staat niet in `dcterms:type`, dat alleen "Kamerstuk" zegt; de
+soort zit in de titel, achter een puntkomma ("Wet op de zorgtoeslag; Memorie van
+toelichting"). Classificatie op een titelconventie is broos en moet dus een
+gemarkeerd resultaat opleveren en geen aanname. Ik schat de parser op
+vergelijkbare omvang als de bestaande WTI- en manifest-parsers samen, met de
+tussenkop-heuristiek als het deel dat onderhoud gaat vragen.
+
+Opslag is lokaal en gepind. Een document wordt één keer opgehaald, met een hash,
+en daarna nooit opnieuw over het netwerk gelezen tijdens een verrijking. Dat is
+dezelfde regel als voor de wetteksten en hij heeft hier een extra reden: een
+citaat moet reproduceerbaar zijn, ook wanneer KOOP een document herpubliceert.
+
+## Plaats in het corpus
+
+Wetshistorie staat niet onder `corpus/regulation/`, want het is geen regeling en
+de engine leest het niet. Het staat naast `regulation/` en `annotations/`, in
+een eigen boom die de FRBR-structuur van de bron volgt:
+
+```
+corpus/wetshistorie/
+  kst/29762/kst-29762-3/
+    document.xml          # zoals opgehaald, ongewijzigd
+    document.yaml         # metadata: soort, dossier, ondernummer, datum, hash, bron-URL
+    fragments/
+      0007.yaml           # kop, tekst, adres, bereik
+  stb/2011/620/
+    ...
+```
+
+Het ruwe document blijft naast de fragmenten staan. De fragmentatie is een
+afleiding met een parserversie erbij, en die parser gaat veranderen; het
+origineel is wat een citaat verifieerbaar maakt.
+
+Een toestand verwijst er niet zelf naar. De wet-YAML is het contract dat de
+engine leest, en daar hoort geen bibliografie in, om dezelfde reden dat RFC-026
+de status per artikel in een sidecar legt en niet in de wet. De verwijzing staat
+in diezelfde sidecar bij de toestandsdatum: per artikel de wijzigingen met hun
+bron, en per wijziging de fragmenten die eraan hangen.
+
+Eén document hoort geregeld bij meerdere toestanden en soms bij meerdere wetten.
+Dat is de normale situatie en niet de uitzondering: een verzamelwet wijzigt tien
+wetten in één dossier, en de gemeten koppen laten dat zien ("Artikel IV,
+onderdeel A (artikel 3.139 van de Wet IB 2001)" naast "Artikel XV (artikel 4 van
+de Wet op de zorgtoeslag)" in hetzelfde stuk). Daarom is de opslag per document
+en per fragment, en zijn de verwijzingen kanten. Een fragment wordt niet
+gekopieerd naar de wetten waar het bij hoort.
+
+De traversal van RFC-026 volgt `explained-by` niet. Een toelichting is geen
+uitvoerende afhankelijkheid: de sluiting wordt er niet groter of kleiner van, en
+een ontbrekende toelichting houdt de verrijking niet tegen. De kant wordt
+gevolgd bij de contextassemblage en niet bij het bepalen van de werkvoorraad.
+Wel telt hij mee voor invalidatie in de andere richting: verandert een artikel,
+dan verandert zijn stapel, en de sidecar-hash die RFC-026 al bijhoudt dekt dat
+af.
+
+## Wat de enricher ermee kan
+
+**Kwalificatie van bepalingen.** De leesprocedure van RFC-027 stelt vragen die de
+wettekst soms niet beantwoordt: is dit een bevoegdheid of een plicht, is deze
+termijn een fatale termijn of een ordetermijn, is dit besluit vatbaar voor
+bezwaar. De toelichting beantwoordt die vragen geregeld met zoveel woorden,
+omdat de wetgevingsjurist ze bij het schrijven ook moest beantwoorden. Dit is de
+grootste opbrengst en tegelijk de gevaarlijkste, want kwalificatie op basis van
+toelichting is de kortste weg naar bleed. De vier maatregelen hierboven zijn er
+allemaal voor dit gebruik.
+
+**Scenario's.** De rekenvoorbeelden in een MvT en de casus in de nota naar
+aanleiding van het verslag zijn testgevallen met een uitkomst die de wetgever
+zelf heeft opgeschreven. Die scenario's landen in bucket A van RFC-029, naast de
+wet, met een bronverwijzing naar documentnummer en fragment. Dat is waar
+`law-mvt-research` op mikte, en het werkt zodra het materiaal er is.
+
+**Open normen.** Een term als "redelijke termijn" of "passende arbeid" heeft in de
+toelichting vaak een omtrek. Die omtrek is geen norm en mag niet in het model,
+en hij bepaalt wel of een `untranslatable` in de zin van RFC-012 terecht is, en
+welke vraag er aan de uitvoerder gesteld moet worden.
+
+**Verifieerbare citaten.** Een verwijzing naar een gemount fragment is door een
+reviewer na te lopen. Dat is het verschil met ronde 2, waar het nummer klopte en
+niemand dat kon vaststellen.
+
+Wat het niet oplost:
+
+- Een toelichting die zwijgt over de vraag die je hebt. De meeste artikelsgewijze
+  toelichtingen zijn kort en herhalen de tekst.
+- De kloof tussen wet en uitvoeringspraktijk. RFC-027 noemt dat al als
+  onoplosbaar met tekst; toelichting verandert daar niets aan, want de wetgever
+  beschrijft de bedoelde praktijk en niet de bestaande.
+- Het onderscheid tussen mandaat en delegatie, en andere vragen die uit de
+  systematiek van het bestuursrecht komen en niet uit één wetsgeschiedenis. Dat
+  blijft de gecureerde memo uit RFC-027.
+- De onderliggende oorzaak van #1036. Zonder de preflight van RFC-028 kan de
+  volgende instructie weer werk voorschrijven dat de runtime niet kan doen.
+
+## Bouwvolgorde
+
+De opdracht bevatte het vermoeden dat documenten ophalen en pinnen zonder
+koppeling per artikel een fractie van het werk is en al bruikbaar materiaal
+oplevert. Dat vermoeden klopt, en de meting maakt het concreter.
+
+De goedkope eerste stap is kleiner dan gedacht, omdat de koppeling op
+documentniveau er gratis bij zit. De WTI die de harvester al binnenhaalt, bevat
+de wijzigingen per artikel met dossiernummers, en de toestand-XML noemt per
+artikel de bekendmaking die hem opleverde. Wie alleen die twee velden uitleest
+en daarna per dossier de SRU-zoekactie doet, heeft per artikel een lijst
+documenten met een reden waarom ze erbij horen. Dat is geen "alle toelichtingen
+van een wet in één bak", het is al een gerichte selectie.
+
+Daarna wordt het duidelijk duurder. De fragmentatie per tussenkop, de
+adressering van fragment naar artikel, en de versiepinning met oudere
+artikelteksten erbij. Dat is het werk waar de 40 procent uit de meting op slaat
+en waar route 3 nodig wordt.
+
+De volgorde:
+
+1. **WTI-wijzigingen uitlezen en in de sidecar zetten.** Per artikel de reeks
+   wijzigingen met datum, bekendmaking en dossiernummer. Geen netwerkuitbreiding,
+   één parser erbij, en het resultaat is los bruikbaar: de invalidatie van RFC-026
+   wordt er nauwkeuriger van en de `amends`-kanten worden data.
+2. **Documenten oogsten en pinnen.** SRU per dossiernummer, XML ophalen, hashen,
+   wegschrijven onder `corpus/wetshistorie/`. Aanbieden op documentniveau. Vanaf
+   hier kan de agent citeren zonder te gokken, en de citatiepoort kan van
+   "verboden" naar "moet oplossen".
+3. **Fragmenteren per tussenkop.** Twee XML-schema's, een index per document.
+   Levert doorzoekbaarheid en de index voor het venster.
+4. **Adresseren via route 1 en 2.** Kop-parenthese en bron-attribuut. Dekt naar de
+   meting ongeveer de helft van de documenten volledig.
+5. **Versiepinning met oudere artikelteksten.** Nodig voordat oudere lagen in het
+   venster mogen; tot dan gaan die lagen alleen naar laag 2 van RFC-027.
+6. **Route 3, de wijzigingswetparser.** Het restant van de adressering, en het
+   enige onderdeel waarvan de trefkans niet gemeten is.
+
+De poorten uit de sectie over recht en toelichting horen bij stap 2 en niet
+later. Materiaal aanbieden zonder de verankeringspoort is de bleed-faalvorm
+inbouwen.
+
+## Wat ik niet heb kunnen controleren
+
+- Alle metingen komen uit één wet, de Wet op de zorgtoeslag, en de 26 dossiers uit
+  haar wijzigingsgeschiedenis. Dat is een fiscaal-sociale wet uit 2005 met veel
+  ministeriële bijstellingen. Voor omgevingsrecht, strafrecht of oudere wetgeving
+  kunnen de percentages heel anders liggen.
+- De 40 procent uit de koppenmeting telt koppen en geen artikelen. Een kop als
+  "Artikelen VI tot en met IX (...)" telt als één treffer terwijl hij vier
+  artikelen adresseert, en samengestelde koppen komen in de steekproef voor.
+- Route 3 heb ik niet geprobeerd. De schatting van 80 tot 90 procent is een gok op
+  basis van de vormvastheid die de Aanwijzingen voorschrijven en niet op basis van
+  een parser die gedraaid heeft.
+- Ik heb geen nota van toelichting bij een AMvB opgehaald en de XML-vorm daarvan
+  dus niet gezien. De aanname dat het een derde schema is, is een aanname.
+- Van de amendementen en de nota's naar aanleiding van het verslag heb ik alleen
+  de titels in de SRU-resultaten gezien, niet de documentstructuur. Of daar
+  vergelijkbare koppen in staan, weet ik niet.
+- De enricher-archieven van ronde 2 heb ik niet zelf ingezien; het gefabriceerde
+  citaat en zijn vindplaats komen uit de opdracht en uit de doc-comment bij
+  `citations_in_companion_files`. Dat `kst-29762-3` de MvT is, heb ik wel zelf
+  vastgesteld.
+- Ik heb geen token-metingen gedaan. De 1500 tokens per venster is een voorstel
+  afgeleid van de begroting in RFC-027 en geen uitkomst van een proef.
+
+## Open beslissingen
+
+Hoort de wetshistorie in dezelfde repository als het corpus of in een eigen
+repository. De omvang pleit voor scheiding (één verzamelwet-MvT is groter dan
+tien wetten), de reviewbaarheid van een citaat pleit voor bijeenhouden.
+
+Wat is de bovengrens per venster, en snijdt die op tokens of op lagen.
+
+Worden oudere artikelteksten opgeslagen of per keer opgehaald uit BWB. Opslaan
+is sneller en verdubbelt de corpusomvang; ophalen tijdens verrijking gaat in
+tegen de regel dat de agent geen netwerk heeft en zou dus in de assemblagestap
+moeten.
+
+Wie beslist of een fragment "toelichting bij dit artikel" is wanneer de
+heuristiek twijfelt. Dit is dezelfde vraag als bij de kaderwetlijst van RFC-026:
+er is een eigenaar nodig, of het blijft bij een gemarkeerd gat.
+
+Krijgt jurisprudentie een eigen RFC, en zo ja, deelt hij de opslagvorm van deze.
+
+Deze RFC is in het Nederlands, net als RFC-026 en RFC-029, terwijl RFC-027 en
+RFC-028 in het Engels staan. Die keuze moet een keer één kant op.


### PR DESCRIPTION
De verrijkingsprompt opende met een stap die niet kon slagen: de agent moest de memorie van toelichting opzoeken met een skill die WebFetch declareert, terwijl de run alleen bestandstools krijgt. Die stap is inmiddels uit de prompt (#1037), en daarmee is de enige toegestane uitkomst zwijgen over de parlementaire geschiedenis. Dat is het verlies dat deze RFC wil terugdraaien: de kwalificatievragen uit RFC-027 worden in de toelichting met zoveel woorden beantwoord, en de rekenvoorbeelden van de wetgever zijn testgevallen met een uitkomst erbij. De RFC beschrijft welke documenten meegaan en welke niet, hoe de stapel toelichtingen per toestand in elkaar zit, hoe een fragment aan een geconsolideerd artikel gekoppeld wordt, waarom een toelichting nooit een grondslag voor een regel mag zijn, en hoe je omgaat met een toelichting die veroudert ten opzichte van het artikel dat hij beschrijft.

Aanleiding en context staan in https://github.com/MinBZK/regelrecht/issues/1044, de faalvorm in #1036.