### PR TITLE
chore(ci): mutatietesten leveren weer bevindingen op

### DIFF
--- a/.github/workflows/mutation-diff.yml
+++ b/.github/workflows/mutation-diff.yml
@@ -1,0 +1,119 @@
+---
+# Mutatietesten op alleen de gewijzigde regels van een PR. De volledige run
+# (mutation-testing.yml) duurt uren en draait wekelijks; deze poort draait in
+# minuten en meldt een ongetest codepad op het moment dat het geschreven wordt.
+# De twee vervangen elkaar niet: --in-diff kijkt alleen naar productiecode die
+# in de diff staat, en een wijziging hier kan code elders slechter getest maken
+# zonder dat deze job dat ziet.
+name: Mutation Testing (diff)
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packages/engine/**'
+      - '.github/workflows/mutation-diff.yml'
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_MUTANTS_VERSION: 27.1.0
+
+jobs:
+  in-diff:
+    name: Mutation Testing (diff)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          # De diff wordt tegen de base-SHA van de PR gemaakt, dus die commit
+          # moet lokaal bestaan.
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7  # stable
+
+      - name: Install mold linker
+        # Required by packages/.cargo/config.toml (mold linker on x86_64-linux).
+        run: sudo apt-get update && sudo apt-get install -y mold
+
+      - name: Restore cargo registry (shared met CI)
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('packages/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-registry-
+
+      - name: Restore cargo-mutants binary
+        id: mutants-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.cargo/bin/cargo-mutants
+          key: ${{ runner.os }}-cargo-mutants-bin-${{ env.CARGO_MUTANTS_VERSION }}
+
+      - name: Install cargo-mutants
+        if: steps.mutants-cache.outputs.cache-hit != 'true'
+        run: cargo install cargo-mutants --locked --version "$CARGO_MUTANTS_VERSION"
+
+      - name: Save cargo-mutants binary
+        if: steps.mutants-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.cargo/bin/cargo-mutants
+          key: ${{ runner.os }}-cargo-mutants-bin-${{ env.CARGO_MUTANTS_VERSION }}
+
+      - name: Bepaal de gewijzigde regels
+        id: diff
+        working-directory: packages
+        # cargo-mutants noemt bestanden relatief aan de workspace-root
+        # (packages/), dus de diff moet dezelfde prefix hebben: `b/engine/src/…`
+        # en niet `b/packages/engine/src/…`. Vandaar --relative vanuit packages/.
+        run: |
+          git diff --relative "${{ github.event.pull_request.base.sha }}" HEAD \
+            -- engine > "$RUNNER_TEMP/pr.diff"
+          if [ -s "$RUNNER_TEMP/pr.diff" ]; then
+            echo "has-changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-changes=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Draai mutatietesten op de gewijzigde regels
+        if: steps.diff.outputs.has-changes == 'true'
+        working-directory: packages/engine
+        run: |
+          set +e
+          cargo mutants --in-place --timeout-multiplier 3 \
+            --in-diff "$RUNNER_TEMP/pr.diff"
+          code=$?
+          set -e
+          case "$code" in
+            0) echo "Alle mutanten in de gewijzigde regels werden gevangen." ;;
+            2)
+              echo "::error::Er zijn regels gewijzigd waar een mutatie ongemerkt doorheen komt. Zie mutants.out/missed.txt in het artifact."
+              exit 1
+              ;;
+            3)
+              echo "::error::Een test liep vast op een mutatie (mogelijk een oneindige lus, of de timeout staat te krap)."
+              exit 1
+              ;;
+            *) exit "$code" ;;
+          esac
+
+      - name: Geen wijzigingen in de engine
+        if: steps.diff.outputs.has-changes != 'true'
+        run: echo "Geen gewijzigde regels in packages/engine, niets te muteren."
+
+      - name: Upload rapport
+        if: always() && steps.diff.outputs.has-changes == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: mutation-report-diff
+          # cargo-mutants schrijft naar de workspace-root (packages/), ook als
+          # het commando vanuit packages/engine wordt gestart.
+          path: packages/mutants.out/
+          if-no-files-found: ignore

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -1,4 +1,8 @@
 ---
+# De volledige mutatierun over de hele engine. Dit is de tegenhanger van
+# mutation-diff.yml: die bewaakt nieuwe code op de PR waar hij geschreven
+# wordt, deze inventariseert wekelijks wat er al ligt. De uitkomst gaat naar
+# een issue, want een artifact dat niemand opent is geen bevinding.
 name: Mutation Testing
 
 on:
@@ -9,14 +13,28 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: mutation-testing
+  cancel-in-progress: false
+
 env:
   CARGO_TERM_COLOR: always
+  CARGO_MUTANTS_VERSION: 27.1.0
+  # Bij ~1050 mutanten van elk zo'n 18 seconden bouwen-plus-testen (gemeten,
+  # niet geschat) kost de hele run ruim vijf uur. Over twaalf shards is dat
+  # zo'n halfuur per shard en past het ruim binnen de timeout hieronder.
+  # Dit getal moet gelijk lopen met de matrix in de job eronder.
+  SHARD_COUNT: 12
 
 jobs:
   mutants:
-    name: Mutation Testing
+    name: Mutation Testing (shard ${{ matrix.shard }})
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
     defaults:
       run:
         working-directory: packages/engine
@@ -30,27 +48,214 @@ jobs:
         # Required by packages/.cargo/config.toml (mold linker on x86_64-linux).
         run: sudo apt-get update && sudo apt-get install -y mold
 
-      - name: Cache cargo registry
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      - name: Restore cargo registry (shared met CI)
+        # Alleen restore, geen save: acht shards die dezelfde sleutel wegschrijven
+        # leveren zeven waarschuwingen op. De CI-run op main vult deze cache.
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            ~/.cargo/bin/cargo-mutants
-            packages/engine/target
-          key: ${{ runner.os }}-cargo-mutants-${{ hashFiles('packages/engine/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-mutants-
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('packages/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-registry-
+
+      - name: Restore cargo-mutants binary
+        id: mutants-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.cargo/bin/cargo-mutants
+          key: ${{ runner.os }}-cargo-mutants-bin-${{ env.CARGO_MUTANTS_VERSION }}
 
       - name: Install cargo-mutants
-        run: cargo install cargo-mutants --locked || true
+        if: steps.mutants-cache.outputs.cache-hit != 'true'
+        run: cargo install cargo-mutants --locked --version "$CARGO_MUTANTS_VERSION"
+
+      - name: Save cargo-mutants binary
+        # Alleen shard 0 schrijft, om dezelfde reden als bij de registry-cache.
+        if: matrix.shard == 0 && steps.mutants-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.cargo/bin/cargo-mutants
+          key: ${{ runner.os }}-cargo-mutants-bin-${{ env.CARGO_MUTANTS_VERSION }}
 
       - name: Run mutation testing
-        run: cargo mutants --in-place --timeout-multiplier 3
+        # Overlevende mutanten (2) en vastgelopen tests (3) zijn de bevinding
+        # zelf, niet een storing: die horen in het issue terecht te komen en
+        # mogen de job dus niet laten falen. Alles daarboven is wel een storing.
+        run: |
+          set +e
+          cargo mutants --in-place --timeout-multiplier 3 \
+            --shard "${{ matrix.shard }}/${SHARD_COUNT}"
+          code=$?
+          set -e
+          case "$code" in
+            0|2|3) exit 0 ;;
+            *) exit "$code" ;;
+          esac
 
-      - name: Upload mutation report
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+      - name: Upload shard-rapport
         if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: mutants-out-shard-${{ matrix.shard }}
+          # cargo-mutants schrijft naar de workspace-root (packages/), ook als
+          # het commando vanuit packages/engine wordt gestart. De oude workflow
+          # wees naar packages/engine/mutants.out en leverde daardoor een leeg
+          # artifact op, los van de timeout die de upload nooit bereikte.
+          path: packages/mutants.out/
+          if-no-files-found: warn
+          retention-days: 90
+
+  report:
+    name: Rapporteren
+    needs: mutants
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Download shard-rapporten
+        # Faalt als geen enkele shard iets heeft opgeleverd; dat geval wordt
+        # hieronder afgevangen en als storing gemeld in plaats van als "nul
+        # overlevende mutanten".
+        continue-on-error: true
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7
+        with:
+          pattern: mutants-out-shard-*
+          path: shards
+
+      - name: Geen enkele shard leverde een rapport op
+        if: hashFiles('shards/**/missed.txt') == ''
+        run: |
+          echo "::error::Geen enkele shard heeft een rapport opgeleverd. De mutatierun is gestrand voordat er iets te melden viel; zie de shard-jobs."
+          exit 1
+
+      - name: Voeg de shards samen
+        id: merge
+        run: |
+          mkdir -p report
+          for f in missed.txt caught.txt timeout.txt unviable.txt; do
+            touch "report/$f"
+            cat shards/*/"$f" 2>/dev/null | sort -u > "report/$f" || true
+          done
+          # Acht losse outcomes.json'en zijn geen geldige JSON als je ze achter
+          # elkaar plakt, dus ze blijven per shard staan.
+          for d in shards/*/; do
+            shard=$(basename "$d" | sed 's/.*-//')
+            if [ -f "$d/outcomes.json" ]; then
+              cp "$d/outcomes.json" "report/outcomes-shard-$shard.json"
+            fi
+          done
+
+          missed=$(wc -l < report/missed.txt)
+          caught=$(wc -l < report/caught.txt)
+          timeout=$(wc -l < report/timeout.txt)
+          unviable=$(wc -l < report/unviable.txt)
+          total=$((missed + caught + timeout + unviable))
+
+          {
+            echo "missed=$missed"
+            echo "caught=$caught"
+            echo "timeout=$timeout"
+            echo "unviable=$unviable"
+            echo "total=$total"
+          } >> "$GITHUB_OUTPUT"
+
+          # De tien bestanden met de meeste overlevende mutanten, als
+          # markdown-tabel voor in het issue.
+          {
+            echo '| Bestand | Overlevende mutanten |'
+            echo '| --- | ---: |'
+            cut -d: -f1 report/missed.txt | sort | uniq -c | sort -rn | head -10 \
+              | while read -r count file; do echo "| \`$file\` | $count |"; done
+          } > report/top-files.md
+
+          # Het overzicht hoort ook in het artifact zelf te staan, zodat het
+          # buiten het issue om leesbaar blijft.
+          {
+            echo "# Mutatietesten, run van $(date -u +%Y-%m-%d)"
+            echo
+            echo "- overleefd: $missed"
+            echo "- gevangen: $caught"
+            echo "- vastgelopen: $timeout"
+            echo "- niet compileerbaar: $unviable"
+            echo
+            cat report/top-files.md
+          } > report/README.md
+
+      - name: Upload samengevoegd rapport
+        id: upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: mutation-report
-          path: packages/engine/mutants.out/
+          path: report/
+          retention-days: 90
+
+      - name: Meld de bevindingen als issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MISSED: ${{ steps.merge.outputs.missed }}
+          CAUGHT: ${{ steps.merge.outputs.caught }}
+          TIMEOUT: ${{ steps.merge.outputs.timeout }}
+          UNVIABLE: ${{ steps.merge.outputs.unviable }}
+          TOTAL: ${{ steps.merge.outputs.total }}
+          ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh label create mutation-testing \
+            --color FBCA04 \
+            --description "Overlevende mutanten uit de wekelijkse mutatierun" \
+            --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
+
+          today=$(date -u +%Y-%m-%d)
+          {
+            echo "De wekelijkse volledige mutatierun is klaar. Van de ${TOTAL} geteste"
+            echo "mutanten kwamen er **${MISSED}** ongemerkt door de tests heen."
+            echo
+            echo "| | |"
+            echo "| --- | ---: |"
+            echo "| Overleefd (\`missed\`) | ${MISSED} |"
+            echo "| Gevangen (\`caught\`) | ${CAUGHT} |"
+            echo "| Vastgelopen (\`timeout\`) | ${TIMEOUT} |"
+            echo "| Niet compileerbaar (\`unviable\`) | ${UNVIABLE} |"
+            echo
+            echo "**[Volledig rapport downloaden](${ARTIFACT_URL})** — \`missed.txt\` bevat"
+            echo "elke overlevende mutatie met bestand, regel en de doorgevoerde wijziging."
+            echo "De [run](${RUN_URL}) bewaart het artifact negentig dagen."
+            echo
+            echo "### Waar ze zitten"
+            echo
+            cat report/top-files.md
+            echo
+            echo "### Wat een regel betekent"
+            echo
+            echo "Elke regel in \`missed.txt\` is een wijziging in de engine die geen enkele"
+            echo "test rood maakt. Dat is een testgat of dode code. Niet elke regel is het"
+            echo "oplossen waard: een mutatie op een debug-helper zegt weinig. Zet die"
+            echo "gevallen vast met \`#[mutants::skip]\` bij de functie, of met \`exclude_re\`"
+            echo "in \`packages/.cargo/mutants.toml\`. Dan zakt het getal hierboven ook als"
+            echo "het antwoord \"dit hoeft niet\" is, en blijft het signaal scherp."
+            echo
+            echo "Nieuwe code wordt sinds \`mutation-diff.yml\` op de PR zelf bewaakt; dit"
+            echo "issue gaat over de voorraad die daarvoor al bestond."
+          } > body.md
+
+          new_issue=$(gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "Mutatietesten: ${MISSED} overlevende mutanten (${today})" \
+            --label mutation-testing \
+            --body-file body.md)
+          echo "Aangemaakt: $new_issue"
+
+          # Het vorige issue is een momentopname van dezelfde voorraad en wordt
+          # door dit issue vervangen. Wat er nog in stond, staat er opnieuw in.
+          gh issue list --repo "$GITHUB_REPOSITORY" --label mutation-testing \
+            --state open --json number --jq '.[].number' \
+            | while read -r n; do
+                if [ "${new_issue##*/}" != "$n" ]; then
+                  gh issue close "$n" --repo "$GITHUB_REPOSITORY" \
+                    --comment "Vervangen door de run van ${today}: ${new_issue}"
+                fi
+              done

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -3,12 +3,26 @@
 # mutation-diff.yml: die bewaakt nieuwe code op de PR waar hij geschreven
 # wordt, deze inventariseert wekelijks wat er al ligt. De uitkomst gaat naar
 # een issue, want een artifact dat niemand opent is geen bevinding.
+#
+# De run heeft geheugen: het artifact van de vorige week is de invoer van deze.
+# Daaruit volgt de vergelijking in het issue (wat is nieuw, wat is opgelost,
+# wat verschoof tussen caught en timeout) en de keuze van de timeout-multiplier.
+# Zolang de voorraad boven VARIATION_THRESHOLD ligt blijft die vast, zodat de
+# weken vergelijkbaar zijn; daaronder rouleert hij, om zichtbaar te maken welke
+# mutanten alleen door de klok sneuvelen in plaats van door een assertie.
 name: Mutation Testing
 
 on:
   schedule:
     - cron: '0 6 * * 1'  # Monday 06:00 UTC
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      timeout_multiplier:
+        description: >-
+          Overschrijf de timeout-multiplier voor deze run. Leeg laten is de
+          normale gang van zaken: dan kiest de plan-job hem.
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -25,9 +39,94 @@ env:
   # zo'n halfuur per shard en past het ruim binnen de timeout hieronder.
   # Dit getal moet gelijk lopen met de matrix in de job eronder.
   SHARD_COUNT: 12
+  # Zolang er meer dan dit aantal mutanten overleeft, is de opdracht simpel:
+  # dat getal omlaag, elke week met dezelfde multiplier zodat de cijfers
+  # vergelijkbaar blijven. Zakt het eronder, dan is de voorraad weggewerkt en
+  # wordt de vraag interessanter: welke mutanten worden alleen door de klok
+  # gevangen in plaats van door een assertie? Vanaf dat moment rouleert de
+  # multiplier wekelijks over VARIATION_MULTIPLIERS.
+  VARIATION_THRESHOLD: 25
+  VARIATION_MULTIPLIERS: "3 2 5"
+  DEFAULT_MULTIPLIER: 3
 
 jobs:
+  plan:
+    name: Plannen
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      multiplier: ${{ steps.decide.outputs.multiplier }}
+      prev-run: ${{ steps.decide.outputs.prev-run }}
+    steps:
+      - name: Kies de timeout-multiplier voor deze run
+        id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OVERRIDE: ${{ inputs.timeout_multiplier }}
+        # Het geheugen van deze workflow is het artifact van de vorige run.
+        # Daar staat in run-meta.json welke multiplier toen gebruikt is en
+        # hoeveel mutanten er overleefden. Dat is genoeg om te beslissen, en
+        # het scheelt een bot die in de repo moet schrijven.
+        run: |
+          multiplier=""
+          prev_run=""
+
+          candidates=$(gh run list --repo "$GITHUB_REPOSITORY" \
+            --workflow mutation-testing.yml --status completed --limit 10 \
+            --json databaseId --jq '.[].databaseId')
+
+          for id in $candidates; do
+            if [ "$id" = "$GITHUB_RUN_ID" ]; then continue; fi
+            if gh run download "$id" --repo "$GITHUB_REPOSITORY" \
+                 -n mutation-report -D prev 2>/dev/null; then
+              prev_run="$id"
+              break
+            fi
+          done
+
+          if [ -n "$prev_run" ] && [ -f prev/run-meta.json ]; then
+            prev_missed=$(jq -r '.missed // empty' prev/run-meta.json)
+            prev_mult=$(jq -r '.multiplier // empty' prev/run-meta.json)
+            echo "Vorige run $prev_run: $prev_missed overlevers bij multiplier $prev_mult."
+
+            if [ -n "$prev_missed" ] && [ "$prev_missed" -le "$VARIATION_THRESHOLD" ]; then
+              # Onder de drempel: pak de volgende multiplier uit de reeks, zodat
+              # opeenvolgende weken elkaars tegenhanger zijn.
+              set -- $VARIATION_MULTIPLIERS
+              first="$1"
+              found=""
+              for m in "$@"; do
+                if [ -n "$found" ]; then multiplier="$m"; break; fi
+                if [ "$m" = "$prev_mult" ]; then found=1; fi
+              done
+              # Geen `[ … ] && …`: onder `bash -e` laat dat de stap vallen zodra
+              # de test onwaar is.
+              if [ -z "$multiplier" ]; then multiplier="$first"; fi
+              echo "Onder de drempel van $VARIATION_THRESHOLD: variatie aan, multiplier $multiplier."
+            else
+              multiplier="$DEFAULT_MULTIPLIER"
+              echo "Boven de drempel: vaste multiplier $multiplier, zodat de weken vergelijkbaar blijven."
+            fi
+          else
+            multiplier="$DEFAULT_MULTIPLIER"
+            echo "Geen bruikbaar rapport van een vorige run; multiplier $multiplier."
+          fi
+
+          # Een handmatige run wint altijd, zodat een variatie ook los te
+          # proberen is zonder op de drempel te wachten.
+          if [ -n "$OVERRIDE" ]; then
+            multiplier="$OVERRIDE"
+            echo "Handmatig overschreven naar multiplier $multiplier."
+          fi
+
+          echo "multiplier=$multiplier" >> "$GITHUB_OUTPUT"
+          echo "prev-run=$prev_run" >> "$GITHUB_OUTPUT"
+
   mutants:
+    needs: plan
     name: Mutation Testing (shard ${{ matrix.shard }})
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -84,7 +183,8 @@ jobs:
         # mogen de job dus niet laten falen. Alles daarboven is wel een storing.
         run: |
           set +e
-          cargo mutants --in-place --timeout-multiplier 3 \
+          cargo mutants --in-place \
+            --timeout-multiplier "${{ needs.plan.outputs.multiplier }}" \
             --shard "${{ matrix.shard }}/${SHARD_COUNT}"
           code=$?
           set -e
@@ -108,13 +208,14 @@ jobs:
 
   report:
     name: Rapporteren
-    needs: mutants
+    needs: [plan, mutants]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: read
       issues: write
+      actions: read
     steps:
       - name: Download shard-rapporten
         # Faalt als geen enkele shard iets heeft opgeleverd; dat geval wordt
@@ -134,6 +235,8 @@ jobs:
 
       - name: Voeg de shards samen
         id: merge
+        env:
+          MULTIPLIER: ${{ needs.plan.outputs.multiplier }}
         run: |
           mkdir -p report
           for f in missed.txt caught.txt timeout.txt unviable.txt; do
@@ -172,11 +275,26 @@ jobs:
               | while read -r count file; do echo "| \`$file\` | $count |"; done
           } > report/top-files.md
 
+          # Het geheugen voor de volgende run: hiermee weet de plan-job welke
+          # multiplier er gebruikt is en hoe groot de voorraad was.
+          cat > report/run-meta.json <<META
+          {
+            "multiplier": ${MULTIPLIER},
+            "missed": ${missed},
+            "caught": ${caught},
+            "timeout": ${timeout},
+            "unviable": ${unviable},
+            "run_id": "${GITHUB_RUN_ID}",
+            "date": "$(date -u +%Y-%m-%d)"
+          }
+          META
+
           # Het overzicht hoort ook in het artifact zelf te staan, zodat het
           # buiten het issue om leesbaar blijft.
           {
             echo "# Mutatietesten, run van $(date -u +%Y-%m-%d)"
             echo
+            echo "- timeout-multiplier: $MULTIPLIER"
             echo "- overleefd: $missed"
             echo "- gevangen: $caught"
             echo "- vastgelopen: $timeout"
@@ -184,6 +302,73 @@ jobs:
             echo
             cat report/top-files.md
           } > report/README.md
+
+      - name: Vergelijk met de vorige run
+        id: compare
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PREV_RUN: ${{ needs.plan.outputs.prev-run }}
+          MULTIPLIER: ${{ needs.plan.outputs.multiplier }}
+        # Dit draait elke week, ook als de multiplier niet verandert. Zo is het
+        # mechanisme in gebruik lang voordat de variatie aangaat, in plaats van
+        # een tak die maanden ligt te wachten op zijn eerste beurt.
+        run: |
+          if [ -z "$PREV_RUN" ] || \
+             ! gh run download "$PREV_RUN" --repo "$GITHUB_REPOSITORY" \
+                 -n mutation-report -D prev 2>/dev/null; then
+            echo "_Geen vorige run om mee te vergelijken; dit is het startpunt._" \
+              > report/vergelijking.md
+            exit 0
+          fi
+
+          prev_mult=$(jq -r '.multiplier // "?"' prev/run-meta.json 2>/dev/null || echo "?")
+          prev_date=$(jq -r '.date // "?"' prev/run-meta.json 2>/dev/null || echo "?")
+
+          for f in missed caught timeout; do
+            sort -u "prev/$f.txt" > "prev-$f.sorted" 2>/dev/null || : > "prev-$f.sorted"
+            sort -u "report/$f.txt" > "now-$f.sorted"
+          done
+
+          comm -13 prev-missed.sorted now-missed.sorted > nieuw.txt
+          comm -23 prev-missed.sorted now-missed.sorted > opgelost.txt
+          comm -12 prev-caught.sorted now-timeout.sorted > caught-naar-timeout.txt
+          comm -12 prev-timeout.sorted now-caught.sorted > timeout-naar-caught.txt
+
+          section() {
+            title="$1"; file="$2"
+            count=$(wc -l < "$file")
+            if [ "$count" -eq 0 ]; then return; fi
+            echo "**$title ($count)**"
+            echo
+            echo '```'
+            head -20 "$file"
+            if [ "$count" -gt 20 ]; then echo "… en nog $((count - 20)); zie het artifact."; fi
+            echo '```'
+            echo
+          }
+
+          {
+            echo "Vergeleken met de run van ${prev_date} (multiplier ${prev_mult}, deze run ${MULTIPLIER})."
+            echo
+            if [ "$prev_mult" != "$MULTIPLIER" ]; then
+              echo "> De multiplier verschilt van vorige week. Verschuivingen tussen"
+              echo "> \`caught\` en \`timeout\` komen dan waarschijnlijk door de klok en niet"
+              echo "> door een wijziging in de code. Dat is precies wat deze variatie moet"
+              echo "> blootleggen: een mutant die alleen door een timeout sneuvelt, wordt"
+              echo "> door geen enkele assertie gevangen."
+              echo
+            fi
+            section "Nieuw overlevend sinds de vorige run" nieuw.txt
+            section "Opgelost sinds de vorige run" opgelost.txt
+            section "Was gevangen, nu een timeout" caught-naar-timeout.txt
+            section "Was een timeout, nu gevangen" timeout-naar-caught.txt
+            if [ ! -s nieuw.txt ] && [ ! -s opgelost.txt ] && \
+               [ ! -s caught-naar-timeout.txt ] && [ ! -s timeout-naar-caught.txt ]; then
+              echo "Geen enkel verschil met de vorige run."
+            fi
+          } > report/vergelijking.md
+
+          cp nieuw.txt opgelost.txt caught-naar-timeout.txt timeout-naar-caught.txt report/
 
       - name: Upload samengevoegd rapport
         id: upload
@@ -201,6 +386,7 @@ jobs:
           TIMEOUT: ${{ steps.merge.outputs.timeout }}
           UNVIABLE: ${{ steps.merge.outputs.unviable }}
           TOTAL: ${{ steps.merge.outputs.total }}
+          MULTIPLIER: ${{ needs.plan.outputs.multiplier }}
           ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
@@ -220,10 +406,15 @@ jobs:
             echo "| Gevangen (\`caught\`) | ${CAUGHT} |"
             echo "| Vastgelopen (\`timeout\`) | ${TIMEOUT} |"
             echo "| Niet compileerbaar (\`unviable\`) | ${UNVIABLE} |"
+            echo "| Timeout-multiplier | ${MULTIPLIER} |"
             echo
             echo "**[Volledig rapport downloaden](${ARTIFACT_URL})** — \`missed.txt\` bevat"
             echo "elke overlevende mutatie met bestand, regel en de doorgevoerde wijziging."
             echo "De [run](${RUN_URL}) bewaart het artifact negentig dagen."
+            echo
+            echo "### Sinds de vorige run"
+            echo
+            cat report/vergelijking.md
             echo
             echo "### Waar ze zitten"
             echo

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -37,7 +37,7 @@ env:
   # Bij ~1050 mutanten van elk zo'n 18 seconden bouwen-plus-testen (gemeten,
   # niet geschat) kost de hele run ruim vijf uur. Over twaalf shards is dat
   # zo'n halfuur per shard en past het ruim binnen de timeout hieronder.
-  # Dit getal moet gelijk lopen met de matrix in de job eronder.
+  # De matrix wordt hieruit afgeleid, dus dit is de enige plek waar het staat.
   SHARD_COUNT: 12
   # Zolang er meer dan dit aantal mutanten overleeft, is de opdracht simpel:
   # dat getal omlaag, elke week met dezelfde multiplier zodat de cijfers
@@ -60,6 +60,7 @@ jobs:
     outputs:
       multiplier: ${{ steps.decide.outputs.multiplier }}
       prev-run: ${{ steps.decide.outputs.prev-run }}
+      shards: ${{ steps.decide.outputs.shards }}
     steps:
       - name: Kies de timeout-multiplier voor deze run
         id: decide
@@ -125,6 +126,14 @@ jobs:
           echo "multiplier=$multiplier" >> "$GITHUB_OUTPUT"
           echo "prev-run=$prev_run" >> "$GITHUB_OUTPUT"
 
+          # De matrix wordt hieruit afgeleid, zodat SHARD_COUNT de enige plek is
+          # waar dat getal staat. Twee handmatig gelijkgehouden bronnen zouden
+          # stil uit elkaar kunnen lopen: een SHARD_COUNT die hoger is dan het
+          # aantal matrix-entries laat mutanten ongetest zonder één foutmelding.
+          shards=$(seq 0 $((SHARD_COUNT - 1)) | jq -sRc 'split("\n")[:-1] | map(tonumber)')
+          echo "Shards: $shards"
+          echo "shards=$shards" >> "$GITHUB_OUTPUT"
+
   mutants:
     needs: plan
     name: Mutation Testing (shard ${{ matrix.shard }})
@@ -133,7 +142,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+        # Afgeleid van SHARD_COUNT door de plan-job, zodat dat getal maar op
+        # één plek staat.
+        shard: ${{ fromJSON(needs.plan.outputs.shards) }}
     defaults:
       run:
         working-directory: packages/engine
@@ -148,8 +159,9 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y mold
 
       - name: Restore cargo registry (shared met CI)
-        # Alleen restore, geen save: acht shards die dezelfde sleutel wegschrijven
-        # leveren zeven waarschuwingen op. De CI-run op main vult deze cache.
+        # Alleen restore, geen save: alle shards die dezelfde sleutel
+        # wegschrijven leveren op één na allemaal een waarschuwing op. De
+        # CI-run op main vult deze cache.
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: |
@@ -243,7 +255,7 @@ jobs:
             touch "report/$f"
             cat shards/*/"$f" 2>/dev/null | sort -u > "report/$f" || true
           done
-          # Acht losse outcomes.json'en zijn geen geldige JSON als je ze achter
+          # Losse outcomes.json'en zijn geen geldige JSON als je ze achter
           # elkaar plakt, dus ze blijven per shard staan.
           for d in shards/*/; do
             shard=$(basename "$d" | sed 's/.*-//')

--- a/Justfile
+++ b/Justfile
@@ -168,6 +168,25 @@ smoke-preview TARGET="":
 mutants *ARGS:
     cd packages/engine && cargo mutants --in-place --timeout-multiplier 3 {{ARGS}}
 
+# Mutation testing on your own changes only — the local tegenhanger of the
+# mutation-diff CI-poort. De volledige set kost uren, dit een paar minuten.
+#
+# Het pad-detail dat dit recept wegneemt: cargo-mutants noemt bestanden
+# relatief aan de workspace-root (packages/), dus de diff moet `b/engine/src/…`
+# bevatten en niet `b/packages/engine/src/…`. Voer je een diff met de verkeerde
+# prefix in, dan vindt hij nul mutanten en lijkt alles in orde.
+mutants-diff BASE="origin/main":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    diff_file="$(mktemp -t mutants-diff-XXXXXX.diff)"
+    git -C packages diff --relative "{{BASE}}" -- engine > "$diff_file"
+    if [ ! -s "$diff_file" ]; then
+        echo "Geen gewijzigde regels in packages/engine ten opzichte van {{BASE}}."
+        exit 0
+    fi
+    cd packages/engine
+    cargo mutants --in-place --timeout-multiplier 3 --in-diff "$diff_file"
+
 # --- Benchmarks ---
 
 _bench_flags := "--bench uri_parsing --bench variable_resolution --bench operations --bench article_evaluation --bench law_loading --bench priority --bench service_e2e"


### PR DESCRIPTION
De wekelijkse mutatierun liep al maanden tegen de timeout van 120 minuten, terwijl de volledige set van ~1050 mutanten er ruim vijf uur over doet. Elke maandag werd de run afgekapt en stond de badge rood. Twee dingen maakten dat erger: `actions/cache` schrijft alleen weg bij een geslaagde job, dus elke run begon koud, en het artifact wees naar `packages/engine/mutants.out` terwijl cargo-mutants naar de workspace-root schrijft. Ook een geslaagde run had dus een leeg rapport opgeleverd.

De volledige run gaat nu over twaalf shards, en de uitkomst naar een issue met een link naar het samengevoegde rapport, de aantallen en de tien bestanden met de meeste overlevers. Het vorige issue wordt gesloten met een verwijzing naar het nieuwe. Levert geen enkele shard iets op, dan faalt de rapportage hard in plaats van nul overlevers te melden.

Daarnaast een tweede workflow die op elke PR alleen de gewijzigde regels muteert met `cargo mutants --in-diff`. Die draait in minuten en meldt een ongetest codepad op het moment dat het geschreven wordt; die poort staat nog niet in de required checks. Het Actions-specifieke deel blijkt pas bij de eerste run, en is met `workflow_dispatch` handmatig te starten.