### PR TITLE
chore(github): haal het PR-template weg

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,0 @@
-## Wat
-
-## Waarom
-
-## Verificatie


### PR DESCRIPTION
Het template schreef bij elke PR dezelfde driedeling voor. Een PR die één ding doet heeft een alinea nodig, en een vast sjabloon leidt tot ingevulde formulieren in plaats van een bericht aan een collega.

Deze commit zat eerder in #1033, tussen de rfc-026-commits. Daar hoorde hij niet: hij staat los van die RFC en verdient een eigen beslissing.