### PR TITLE
fix(ci): bouw x86_64-apple-darwin op een Intel-runner

### DIFF
--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -26,8 +26,12 @@ jobs:
             binary: evaluate
             asset: evaluate-linux-amd64
 
+          # macos-latest is arm64, waar dit target alleen gecross-compileerd kan
+          # worden. macos-15-intel is de Intel-runner die macos-13 opvolgt en
+          # bouwt dit target native. GitHub biedt x86_64-macOS aan tot het
+          # macOS 15-image in het najaar van 2027 vervalt.
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-15-intel
             binary: evaluate
             asset: evaluate-macos-amd64
 


### PR DESCRIPTION
Het x86_64-apple-darwin-been van `release-engine.yml` draaide op `macos-latest`, dat arm64 is. Bij tag `engine-v0.2.0` faalde dat been, waardoor de release-job werd overgeslagen en er geen release verscheen.

Dit been draait nu op `macos-15-intel`, de Intel-runner die `macos-13` opvolgt en het target native bouwt. GitHub biedt x86_64-macOS aan tot het macOS 15-image in het najaar van 2027 vervalt; daarna moet het target opnieuw tegen het licht.