### PR TITLE
docs(docs): reserveer de nummers rfc-026 tot en met rfc-030

### DIFF
--- a/docs/src/content/rfcs/rfc-026.md
+++ b/docs/src/content/rfcs/rfc-026.md
@@ -1,0 +1,17 @@
+---
+title: "RFC-026: De werkvoorraad van de enricher"
+status: Draft
+implementation: Not implemented
+date: '2026-08-01'
+authors:
+  - Eelco Hotting
+short_title: Werkvoorraad
+---
+
+## Context
+
+Dit nummer is gereserveerd. Welke artikelen verrijkt moeten worden en in welke volgorde. De afhankelijkheden tussen wetten vormen een keten die afgelopen moet worden zonder dat de sluiting openklapt: knopen op artikelniveau, een hot path per scenario, delegatie die de traversal beëindigt, en kaderwetten die worden aangewezen in plaats van opgespoord.
+
+De uitwerking wordt apart aangeboden en vervangt deze tekst. Tot dat moment
+bestaat er geen vastgesteld ontwerp onder dit nummer, en is de enige uitspraak
+die eruit volgt dat het nummer bezet is.

--- a/docs/src/content/rfcs/rfc-027.md
+++ b/docs/src/content/rfcs/rfc-027.md
@@ -1,0 +1,17 @@
+---
+title: "RFC-027: Enrichment a Legal Expert Can Check"
+status: Draft
+implementation: Not implemented
+date: '2026-08-01'
+authors:
+  - Eelco Hotting
+short_title: Enrichment Quality
+---
+
+## Context
+
+Dit nummer is gereserveerd. De rollen, de poorten en de faalvormen die bepalen of één artikel goed verrijkt is. Een kwalificeerder die leest en classificeert, een producent die binnen die classificatie vertaalt, een tegenspreker die de vertaling probeert onderuit te halen, en een arbiter die beslist.
+
+De uitwerking wordt apart aangeboden en vervangt deze tekst. Tot dat moment
+bestaat er geen vastgesteld ontwerp onder dit nummer, en is de enige uitspraak
+die eruit volgt dat het nummer bezet is.

--- a/docs/src/content/rfcs/rfc-028.md
+++ b/docs/src/content/rfcs/rfc-028.md
@@ -1,0 +1,17 @@
+---
+title: "RFC-028: Steps and Runtimes for the Enrichment Chain"
+status: Draft
+implementation: Not implemented
+date: '2026-08-01'
+authors:
+  - Eelco Hotting
+short_title: Agent Steps
+---
+
+## Context
+
+Dit nummer is gereserveerd. Hoe één stap uit de keten draait. Een stap is data die zegt wat er moet gebeuren en wat hij nodig heeft, een runtime voert zo'n stap uit en vertaalt die behoeften naar zijn eigen vlaggen, en de keuze van runtime, model en budget per stap is configuratie.
+
+De uitwerking wordt apart aangeboden en vervangt deze tekst. Tot dat moment
+bestaat er geen vastgesteld ontwerp onder dit nummer, en is de enige uitspraak
+die eruit volgt dat het nummer bezet is.

--- a/docs/src/content/rfcs/rfc-029.md
+++ b/docs/src/content/rfcs/rfc-029.md
@@ -1,0 +1,17 @@
+---
+title: "RFC-029: Test Fixtures"
+status: Draft
+implementation: Not implemented
+date: '2026-08-01'
+authors:
+  - Eelco Hotting
+short_title: Test Fixtures
+---
+
+## Context
+
+Dit nummer is gereserveerd. Waaraan het geheel gemeten wordt. Drie soorten fixtures met drie locaties en drie toelatingseisen, een gouden set uit het echte corpus gepind op toestandsdatum, en één engine die alle uitgebrachte schemaversies leest.
+
+De uitwerking wordt apart aangeboden en vervangt deze tekst. Tot dat moment
+bestaat er geen vastgesteld ontwerp onder dit nummer, en is de enige uitspraak
+die eruit volgt dat het nummer bezet is.

--- a/docs/src/content/rfcs/rfc-030.md
+++ b/docs/src/content/rfcs/rfc-030.md
@@ -1,0 +1,17 @@
+---
+title: "RFC-030: Wetshistorie in het corpus"
+status: Draft
+implementation: Not implemented
+date: '2026-08-01'
+authors:
+  - Eelco Hotting
+short_title: Wetshistorie
+---
+
+## Context
+
+Dit nummer is gereserveerd. Welke parlementaire documenten meegeoogst worden en hoe een fragment aan een geconsolideerd artikel gekoppeld wordt. De enricher krijgt de wetsgeschiedenis nu niet te zien en gokt erover; een toelichting mag daarbij nooit een grondslag voor een regel zijn.
+
+De uitwerking wordt apart aangeboden en vervangt deze tekst. Tot dat moment
+bestaat er geen vastgesteld ontwerp onder dit nummer, en is de enige uitspraak
+die eruit volgt dat het nummer bezet is.


### PR DESCRIPTION
Vijf RFC-nummers vastleggen voordat ze worden uitgewerkt. De uitwerkingen wachten op hun implementatie voordat ze worden vastgesteld, en tot dat moment kan een vrij nummer door een tweede uitwerking gepakt worden. Dat is vandaag bijna gebeurd toen een RFC-bestand meeliftte op een niet-verwante PR.

Elke stub zegt in een paar zinnen wat er onder dat nummer komt en dat er nog geen vastgesteld ontwerp onder ligt. De volledige teksten vervangen ze zodra de bijbehorende implementatie werkt.
