### PR TITLE
test(engine): dek de annotatieresolver en de annotatiepoort af

### DIFF
--- a/.github/workflows/mutation-diff.yml
+++ b/.github/workflows/mutation-diff.yml
@@ -77,8 +77,13 @@ jobs:
         # cargo-mutants noemt bestanden relatief aan de workspace-root
         # (packages/), dus de diff moet dezelfde prefix hebben: `b/engine/src/…`
         # en niet `b/packages/engine/src/…`. Vandaar --relative vanuit packages/.
+        #
+        # Driepunts (`base...HEAD`), niet tweepunts: tweepunts vergelijkt twee
+        # bomen, dus alles wat main na de aftakking veranderde telt mee als
+        # wijziging van deze PR. Dan muteert de poort regels die de auteur niet
+        # heeft aangeraakt, en kan hij rood worden op andermans werk.
         run: |
-          git diff --relative "${{ github.event.pull_request.base.sha }}" HEAD \
+          git diff --relative "${{ github.event.pull_request.base.sha }}...HEAD" \
             -- engine > "$RUNNER_TEMP/pr.diff"
           if [ -s "$RUNNER_TEMP/pr.diff" ]; then
             echo "has-changes=true" >> "$GITHUB_OUTPUT"

--- a/Justfile
+++ b/Justfile
@@ -198,11 +198,15 @@ mutants *ARGS:
 # relatief aan de workspace-root (packages/), dus de diff moet `b/engine/src/…`
 # bevatten en niet `b/packages/engine/src/…`. Voer je een diff met de verkeerde
 # prefix in, dan vindt hij nul mutanten en lijkt alles in orde.
+#
+# Driepunts (`BASE...HEAD`), niet tweepunts: tweepunts vergelijkt twee bomen,
+# dus alles wat main na jouw aftakking veranderde komt in de diff terecht als
+# jouw wijziging. Op een branch die achterloopt muteer je dan andermans regels.
 mutants-diff BASE="origin/main":
     #!/usr/bin/env bash
     set -euo pipefail
     diff_file="$(mktemp -t mutants-diff-XXXXXX.diff)"
-    git -C packages diff --relative "{{BASE}}" -- engine > "$diff_file"
+    git -C packages diff --relative "{{BASE}}...HEAD" -- engine > "$diff_file"
     if [ ! -s "$diff_file" ]; then
         echo "Geen gewijzigde regels in packages/engine ten opzichte van {{BASE}}."
         exit 0

--- a/packages/.cargo/mutants.toml
+++ b/packages/.cargo/mutants.toml
@@ -1,0 +1,152 @@
+# Configuratie voor cargo-mutants. De workspace-root is `packages/`, dus dit is
+# het bestand dat alle vier de ingangen lezen: `just mutants`, `just
+# mutants-diff`, de wekelijkse run (mutation-testing.yml) en de poort op een PR
+# (mutation-diff.yml). Wat hier staat geldt dus overal hetzelfde.
+#
+# Twee soorten regels staan hieronder, en ze doen iets verschillends.
+#
+# `additional_cargo_args` bepaalt WELKE code de mutatierun überhaupt te zien
+# krijgt. `exclude_re` bepaalt welke mutanten we bewust laten leven. Alleen het
+# tweede is een oordeel; het eerste is een gelijkstelling met de testsuite.
+#
+# Elke uitsluiting heeft een reden. Een uitsluiting zonder reden is geen
+# antwoord maar een weggeklikte vraag, en telt niet.
+
+# Muteer met dezelfde features waarmee de suite draait. `just test` is
+# `cargo test --workspace --all-features`; een kale `cargo mutants` bouwt zonder
+# features, en dan valt alles achter een `#[cfg(feature = ...)]` buiten de
+# build: schema.rs (validate), wasm.rs (wasm), telemetry.rs (otel) en de
+# binaries met `required-features`. Die code wordt niet gecompileerd, de
+# mutatie verandert dus niets, de tests blijven groen en de mutant "overleeft"
+# zonder dat er ooit iets is gedraaid. In de weekrun van 2026-08-01 waren dat
+# 46 van de 353 overlevers.
+#
+# Bewust `--all-features` en geen opsomming als `--features validate,wasm`: een
+# met de hand bijgehouden lijst van wat meetelt loopt achter zodra er een
+# feature bijkomt. Dat is dezelfde rot die #1061 uit de testrecepten haalde.
+additional_cargo_args = ["--all-features"]
+
+exclude_re = [
+    # --- annotation/resolver.rs -------------------------------------------
+
+    # similarity(): strsim::normalized_levenshtein geeft voor een paar waarvan
+    # precies één string leeg is zelf al 0.0 (1 - n/n). De vroege return is een
+    # kortere route naar hetzelfde getal; met && ernaast loopt de aanroep door
+    # naar strsim en komt er hetzelfde uit. Het randgeval zelf ligt vast in
+    # similarity_treats_a_missing_side_as_no_similarity.
+    'annotation/resolver\.rs.*replace \|\| with && in similarity',
+
+    # find_fuzzy_matches(): beide helften van de guard leiden ook zonder guard
+    # tot nul kandidaten. Zonder exact-tekst is max_w 0 en is het vensterbereik
+    # leeg; zonder artikeltekst breekt de eerste iteratie meteen af op
+    # `window > chars.len()`. De guard scheelt werk, geen uitkomst.
+    'annotation/resolver\.rs.*replace \|\| with && in find_fuzzy_matches',
+
+    # shares_significant_content(): de lengtecheck op het kandidaatwoord is een
+    # goedkope voorfilter vóór de hash-lookup. exact_words komt altijd uit
+    # significant_words(), die alleen woorden langer dan drie tekens overhoudt,
+    # dus een woord van drie tekens zit er nooit in en >= 3 kan geen ander
+    # antwoord geven dan > 3.
+    'annotation/resolver\.rs.*replace > with >= in shares_significant_content',
+
+    # --- service.rs --------------------------------------------------------
+
+    # evaluate_article_with_service: `taints.len() > 1` bewaakt uitsluitend een
+    # tracing::warn. De taint die daarna op de outputs terechtkomt is in beide
+    # takken dezelfde waarde, dus geen assertie kan het verschil zien. Dit is nu
+    # de enige `>`-vergelijking in die functie; komt er een tweede bij, dan is
+    # deze regel te breed en hoort hij aangescherpt te worden.
+    'service\.rs.*replace > with (<|==|>=) in LawExecutionService::evaluate_article_with_service',
+
+    # evaluate_law_multi_internal: `article_numbers.len() > 1` met >= is
+    # equivalent. Bij precies één artikel levert join(", ") exact het
+    # artikelnummer op dat al in het samengevoegde resultaat stond, dus de
+    # toewijzing is dan een no-op. De varianten < en == veranderen wel gedrag en
+    # worden gedood door test_evaluate_law_reports_every_producing_article.
+    'service\.rs.*replace > with >= in LawExecutionService::evaluate_law_multi_internal',
+
+    # --- operations.rs -----------------------------------------------------
+
+    # values_equal herhaalt in deze twee armen bewust wat de PartialEq van
+    # law-model's Value al doet: gemengd untranslatable is nooit gelijk, en twee
+    # Decimals vergelijken numeriek. De arm weghalen laat de vergelijking naar
+    # `_ => a == b` vallen, wat exact hetzelfde antwoord geeft. De armen staan
+    # er om de bedoeling in dit bestand vast te leggen, los van een andere crate.
+    'operations\.rs.*delete match arm \(Value::Untranslatable\{\.\.\}, _\) \|\(_, Value::Untranslatable\{\.\.\}\) in values_equal',
+    'operations\.rs.*delete match arm \(Value::Decimal\(d1\), Value::Decimal\(d2\)\) in values_equal',
+
+    # iso_object altijd waar maken verandert geen enkele uitkomst: de
+    # datum-terugval in EQUALS vraagt daarna alsnog parse_date, en die slaagt
+    # precies voor dezelfde waarden (een ISO-string of een object met een
+    # `iso`-string). Niet-canonieke datumstrings worden sowieso geweigerd, dus
+    # er bestaat geen paar dat structureel ongelijk is maar chronologisch gelijk.
+    'operations\.rs.*replace is_mixed_date_pair::iso_object -> bool with true',
+
+    # Trait-default van een trace-hook. De enige resolver die echt traceert
+    # (RuleContext) overschrijft hem; de default bestaat zodat een resolver
+    # zonder tracing compileert. Een assertie hierop legt alleen de vorm van een
+    # diagnostische tekst vast.
+    'operations\.rs.*replace ValueResolver::trace_get_message -> Option<String> with Some',
+
+    # --- data_source.rs ----------------------------------------------------
+
+    # De handgeschreven `Debug for DataSourceRegistry` bestaat alleen omdat
+    # `Box<dyn DataSource>` geen Debug afleidt en de omliggende structs dat wel
+    # willen. De uitvoer is diagnostisch: niets in de engine leest hem, geen
+    # juridische uitkomst hangt ervan af. Een test zou het letterlijke formaat
+    # vastleggen, en dat is precies het willekeurige implementatiedetail dat we
+    # niet willen vastpinnen.
+    'data_source\.rs.*impl std::fmt::Debug for DataSourceRegistry',
+
+    # --- error.rs ----------------------------------------------------------
+
+    # `impl From<EngineError> for JsValue` is één regel
+    # `JsValue::from_str(&err.to_string())` over de JS-grens. Ook met de
+    # wasm-feature aan is dat native niet uit te voeren: wasm-bindgen aborteert
+    # buiten wasm32 met een panic die niet af te wikkelen is. Het gedrag dat
+    # ertoe doet is de tekst van de fout, en die ligt vast in de Display-tests
+    # in dit bestand.
+    'error\.rs.*impl From<EngineError> for wasm_bindgen::JsValue',
+
+    # --- telemetry.rs ------------------------------------------------------
+
+    # De hele module is OTLP-bedrading. `init_otel_subscriber` installeert via
+    # `try_init` een procesbrede subscriber, die per testbinary maar één keer te
+    # zetten is en daarna alle andere tests beïnvloedt; `Drop for OtelGuard`
+    # roept `shutdown()` op de OTel-SDK aan en print een eventuele fout naar
+    # stderr. Beide zijn gedrag van de SDK en van de afsluitvolgorde van het
+    # proces, niet van de wetsuitvoering.
+    '^engine/src/telemetry\.rs:',
+
+    # --- bin/evaluate.rs ---------------------------------------------------
+
+    # De OTLP-endpointcheck (`!v.is_empty()`) bepaalt alleen of er een collector
+    # wordt aangesloten. Het verschil is uitsluitend zichtbaar tegen een
+    # draaiende OTLP-collector, en dat is geen unit-test. De afloopcodes van het
+    # binary zelf worden wel gedood.
+    'engine/src/bin/evaluate\.rs.*delete ! in main',
+
+    # --- wasm.rs -----------------------------------------------------------
+
+    # Alles in de WASM-bindings dat een JsValue aanraakt (aanmaken, parsen of
+    # serialiseren) is alleen in een JavaScript-runtime uit te voeren. Buiten
+    # wasm32 aborteert wasm-bindgen het proces met een non-unwinding panic, dus
+    # een native test kan dit gedrag niet vastleggen, ook niet negatief. Deze
+    # functies zijn bovendien doorgeefluiken: de beslislogica die ze aanroepen
+    # (service.rs, annotation/) wordt daar gemuteerd en gemeten.
+    #
+    # Wat in wasm.rs zelf aan regels leeft staat hier NIET in en wordt gedood:
+    # de 1 MB-grens op loadLaw, de boekhouding van geladen wetten, en het filter
+    # dat notities van een andere wet overslaat (note_targets_another_law).
+    'engine/src/wasm\.rs.*js_serializer',
+    'engine/src/wasm\.rs.*wasm_error',
+    'engine/src/wasm\.rs.*engine_error_to_wasm',
+    'engine/src/wasm\.rs.*WasmEngine::execute\b',
+    'engine/src/wasm\.rs.*WasmEngine::execute_with_trace',
+    'engine/src/wasm\.rs.*WasmEngine::execute_multiple',
+    'engine/src/wasm\.rs.*WasmEngine::execute_multiple_with_trace',
+    'engine/src/wasm\.rs.*WasmEngine::get_law_info',
+    'engine/src/wasm\.rs.*WasmEngine::resolve_note\b',
+    'engine/src/wasm\.rs.*WasmEngine::resolve_notes',
+    'engine/src/wasm\.rs.*WasmEngine::register_data_source',
+]

--- a/packages/engine/src/annotation/mod.rs
+++ b/packages/engine/src/annotation/mod.rs
@@ -24,3 +24,37 @@ pub fn law_id_from_source(source: &str) -> Option<&str> {
     let rest = source.strip_prefix("regelrecht://")?;
     Some(rest.split('/').next().unwrap_or(rest))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::law_id_from_source;
+
+    #[test]
+    fn bare_law_uri_yields_the_law_id() {
+        assert_eq!(
+            law_id_from_source("regelrecht://wet_op_de_zorgtoeslag"),
+            Some("wet_op_de_zorgtoeslag")
+        );
+    }
+
+    #[test]
+    fn path_and_fragment_are_stripped_from_the_law_id() {
+        assert_eq!(
+            law_id_from_source("regelrecht://wet_op_de_zorgtoeslag/hoogte_zorgtoeslag#field"),
+            Some("wet_op_de_zorgtoeslag")
+        );
+    }
+
+    #[test]
+    fn non_regelrecht_uri_has_no_law_id() {
+        assert_eq!(law_id_from_source("https://example.com/wet"), None);
+        assert_eq!(law_id_from_source("wet_op_de_zorgtoeslag"), None);
+    }
+
+    #[test]
+    fn empty_authority_yields_an_empty_law_id_rather_than_none() {
+        // `regelrecht://` without a law is malformed input; it must not be
+        // mistaken for "not a regelrecht reference at all".
+        assert_eq!(law_id_from_source("regelrecht://"), Some(""));
+    }
+}

--- a/packages/engine/src/annotation/resolver.rs
+++ b/packages/engine/src/annotation/resolver.rs
@@ -112,13 +112,27 @@ fn finalize_fuzzy(matches: Vec<TextMatch>) -> MatchResult {
         return MatchResult::orphaned();
     }
     let deduped = deduplicate_overlapping(matches);
-    if deduped.len() == 1 {
-        return MatchResult::found(deduped);
+    match clear_winner(&deduped) {
+        Some(winner) => MatchResult::found(vec![winner]),
+        None => MatchResult::ambiguous(deduped),
     }
-    if deduped.len() > 1 && deduped[0].confidence - deduped[1].confidence > TIEBREAK_MARGIN {
-        return MatchResult::found(vec![deduped[0].clone()]);
+}
+
+/// The one candidate that stands out, if there is one.
+///
+/// A lone candidate wins by default; with several, the best has to beat the
+/// runner-up by *more* than [`TIEBREAK_MARGIN`]. `None` means the field is
+/// tied, and what a tie means is up to the caller: ambiguous for a full
+/// search, a failed hint for [`resolve_hint`]. Candidates arrive sorted by
+/// confidence descending (both callers dedupe first, which sorts).
+fn clear_winner(deduped: &[TextMatch]) -> Option<TextMatch> {
+    match deduped {
+        [only] => Some(only.clone()),
+        [best, second, ..] if best.confidence - second.confidence > TIEBREAK_MARGIN => {
+            Some(best.clone())
+        }
+        _ => None,
     }
-    MatchResult::ambiguous(deduped)
 }
 
 /// Try the hinted article (optionally a hinted position) before any full
@@ -165,16 +179,12 @@ fn resolve_hint(
     for m in &mut fuzzy {
         m.article_number = article.number.clone();
     }
-    if fuzzy.is_empty() {
-        return MatchResult::orphaned();
-    }
     let deduped = deduplicate_overlapping(fuzzy);
-    if deduped.len() == 1 {
-        MatchResult::found(deduped)
-    } else if deduped.len() > 1 && deduped[0].confidence - deduped[1].confidence > TIEBREAK_MARGIN {
-        MatchResult::found(vec![deduped[0].clone()])
-    } else {
-        MatchResult::orphaned()
+    match clear_winner(&deduped) {
+        Some(winner) => MatchResult::found(vec![winner]),
+        // A tie inside the hinted article is not an answer: the hint is
+        // non-authoritative, so the caller falls back to the full search.
+        None => MatchResult::orphaned(),
     }
 }
 
@@ -425,6 +435,33 @@ mod tests {
         }
     }
 
+    fn hinted(
+        exact: &str,
+        prefix: &str,
+        suffix: &str,
+        article_number: &str,
+        span: Option<(usize, usize)>,
+    ) -> TextQuoteSelector {
+        let mut sel = selector(exact, prefix, suffix);
+        sel.hint = Some(SelectorHint {
+            article_number: article_number.to_string(),
+            start: span.map(|(s, _)| s),
+            end: span.map(|(_, e)| e),
+        });
+        sel
+    }
+
+    /// A candidate as the fuzzy scan produces them, for the collapsing helpers.
+    fn candidate(article_number: &str, start: usize, end: usize, confidence: f64) -> TextMatch {
+        TextMatch {
+            article_number: article_number.to_string(),
+            start,
+            end,
+            confidence,
+            matched_text: String::new(),
+        }
+    }
+
     #[test]
     fn exact_match_single() {
         let arts = vec![article(
@@ -538,6 +575,399 @@ mod tests {
         let r = resolve(&sel, &arts);
         assert!(r.is_found());
         assert_eq!(r.single().unwrap().article_number, "2");
+    }
+
+    // === Exact matching: every occurrence, and the context that filters them ===
+
+    #[test]
+    fn every_occurrence_is_reported_when_the_context_does_not_disambiguate() {
+        // Without prefix/suffix all three occurrences are equally good. They
+        // must all be reported: the number of candidates is what tells the
+        // editor how ambiguous the anchor really is.
+        let arts = vec![article(
+            "2",
+            "de verzekerde en de verzekerde en nog een verzekerde",
+        )];
+        let sel = selector("verzekerde", "", "");
+        let r = resolve(&sel, &arts);
+        assert!(r.is_ambiguous());
+        let starts: Vec<usize> = r.matches.iter().map(|m| m.start).collect();
+        assert_eq!(starts, vec![3, 20, 42]);
+    }
+
+    #[test]
+    fn without_context_a_quote_also_matches_inside_a_longer_word() {
+        // An empty prefix and suffix impose no context at all, so "toeslag"
+        // also matches inside "zorgtoeslagen". That is exactly why an anchor
+        // without context comes back ambiguous instead of found.
+        let arts = vec![article("2", "de zorgtoeslagen en de aanvullende toeslag")];
+        let sel = selector("toeslag", "", "");
+        let r = resolve(&sel, &arts);
+        assert!(r.is_ambiguous());
+        assert_eq!(r.matches.len(), 2);
+    }
+
+    #[test]
+    fn context_matches_across_a_single_whitespace_difference() {
+        // Prefix and suffix are stored without the whitespace that separates
+        // them from the quote in the law text. One character of slack plus
+        // trimming absorbs that, so this stays an exact hit (confidence 1.0)
+        // instead of degrading to a fuzzy one.
+        let arts = vec![article(
+            "2",
+            "heeft recht op een zorgtoeslag ter grootte van dat verschil",
+        )];
+        let sel = selector("zorgtoeslag", "op een", "ter grootte");
+        let r = resolve(&sel, &arts);
+        assert!(r.is_found());
+        let m = r.single().unwrap();
+        assert_eq!(m.start, 19);
+        assert_eq!(
+            m.confidence, 1.0,
+            "a hit on the literal text must not degrade to a fuzzy match"
+        );
+    }
+
+    #[test]
+    fn both_prefix_and_suffix_have_to_match() {
+        // The first occurrence has the right prefix but the wrong suffix. Only
+        // the occurrence that matches both sides is the anchor.
+        let text =
+            "recht op een zorgtoeslag krachtens deze wet en recht op een zorgtoeslag van rechtswege";
+        let arts = vec![article("2", text)];
+        let sel = selector("zorgtoeslag", "op een", "van rechtswege");
+        let r = resolve(&sel, &arts);
+        assert!(r.is_found(), "got {:?}", r.status);
+        let m = r.single().unwrap();
+        assert!(text[m.end..].starts_with(" van rechtswege"));
+    }
+
+    // === Hints: which article, which position, and when to ignore them ===
+
+    #[test]
+    fn a_hint_picks_the_article_when_the_same_text_occurs_twice() {
+        // Both articles carry the quote, so a full search is ambiguous; the
+        // hint records which article the note was written on. No word in the
+        // quote is longer than three characters, so fuzzy matching cannot
+        // rescue this: the exact search inside the hinted article answers it.
+        let arts = vec![
+            article("2", "Deze verplichting vloeit voort uit de wet."),
+            article("3", "De inspecteur handelt overeenkomstig de wet."),
+        ];
+        let sel = hinted("de wet", "", "", "3", None);
+        let r = resolve(&sel, &arts);
+        assert!(r.is_found(), "got {:?}", r.status);
+        assert_eq!(r.single().unwrap().article_number, "3");
+    }
+
+    #[test]
+    fn a_position_hint_picks_one_of_two_identical_occurrences() {
+        // The same phrase occurs twice with identical context, so prefix and
+        // suffix cannot tell them apart and a plain search is ambiguous. The
+        // recorded position says the note sits on the second one. The sentence
+        // runs on after that second occurrence, so the suffix window has to be
+        // bounded by the suffix length instead of by the end of the article.
+        let text = "recht op een zorgtoeslag van rechtswege en recht op een zorgtoeslag van rechtswege, aldus de toelichting";
+        let arts = vec![article("2", text)];
+        let start = text.rfind("zorgtoeslag").unwrap();
+        let sel = hinted(
+            "zorgtoeslag",
+            "op een",
+            "van rechtswege",
+            "2",
+            Some((start, start + "zorgtoeslag".len())),
+        );
+        let r = resolve(&sel, &arts);
+        assert!(r.is_found(), "the position must break the tie, got {:?}", r);
+        assert_eq!(r.single().unwrap().start, start);
+    }
+
+    #[test]
+    fn a_position_hint_with_the_wrong_prefix_is_rejected() {
+        // The article was rewritten and the recorded offsets now land on
+        // another occurrence: same words, different context. The hint is
+        // non-authoritative, so the text search decides.
+        let text =
+            "een voorschot zorgtoeslag van rechtswege; recht op een zorgtoeslag van rechtswege";
+        let arts = vec![article("2", text)];
+        let stale = text.find("zorgtoeslag").unwrap();
+        let sel = hinted(
+            "zorgtoeslag",
+            "op een",
+            "van rechtswege",
+            "2",
+            Some((stale, stale + "zorgtoeslag".len())),
+        );
+        let r = resolve(&sel, &arts);
+        assert!(r.is_found(), "got {:?}", r.status);
+        assert_eq!(
+            r.single().unwrap().start,
+            text.rfind("zorgtoeslag").unwrap(),
+            "the occurrence with the wrong prefix must not win"
+        );
+    }
+
+    #[test]
+    fn a_position_hint_with_the_wrong_suffix_is_rejected() {
+        let text =
+            "recht op een zorgtoeslag krachtens deze wet en recht op een zorgtoeslag van rechtswege";
+        let arts = vec![article("2", text)];
+        let stale = text.find("zorgtoeslag").unwrap();
+        let sel = hinted(
+            "zorgtoeslag",
+            "op een",
+            "van rechtswege",
+            "2",
+            Some((stale, stale + "zorgtoeslag".len())),
+        );
+        let r = resolve(&sel, &arts);
+        assert!(r.is_found(), "got {:?}", r.status);
+        assert_eq!(
+            r.single().unwrap().start,
+            text.rfind("zorgtoeslag").unwrap(),
+            "the occurrence with the wrong suffix must not win"
+        );
+    }
+
+    #[test]
+    fn a_position_hint_past_the_end_of_the_article_is_ignored() {
+        // The article was shortened; the recorded offsets now point beyond it.
+        // That must not panic and must not stop the search.
+        let arts = vec![article("2", "heeft recht op een zorgtoeslag hier")];
+        let sel = hinted("zorgtoeslag", "op een", "hier", "2", Some((120, 131)));
+        let r = resolve(&sel, &arts);
+        assert!(r.is_found());
+        assert_eq!(r.single().unwrap().start, 19);
+    }
+
+    // === Fuzzy matching: which windows, which span, which threshold ===
+
+    #[test]
+    fn a_fuzzy_anchor_covers_the_changed_phrase() {
+        // The note quotes "aanspraak op een zorgtoeslag"; the article now says
+        // "recht op een zorgtoeslag". The anchor has to cover that whole
+        // phrase and nothing else: it is the span the editor highlights.
+        let arts = vec![article(
+            "2",
+            "heeft de verzekerde recht op een zorgtoeslag ter grootte van het verschil",
+        )];
+        let sel = selector(
+            "aanspraak op een zorgtoeslag",
+            "heeft de verzekerde",
+            "ter grootte",
+        );
+        let r = resolve(&sel, &arts);
+        assert!(r.is_found(), "expected a fuzzy match, got {:?}", r.status);
+        let m = r.single().unwrap();
+        assert_eq!(
+            m.matched_text.trim(),
+            "recht op een zorgtoeslag",
+            "the anchor must cover the changed phrase, not an arbitrary window of about the right size"
+        );
+        assert!(m.confidence < 1.0);
+    }
+
+    #[test]
+    fn fuzzy_windows_stay_within_the_length_tolerance() {
+        // Candidates are windows of the quote's length ±30%. A window far off
+        // that length is a different phrase, not a changed one, and scoring it
+        // only invites the resolver to anchor on the wrong text.
+        let sel = selector("zorgtoeslag", "", "");
+        let text = "de zorgtoeslag wordt jaarlijks vastgesteld door de Belastingdienst";
+        let matches = find_fuzzy_matches(text, &sel, DEFAULT_FUZZY_THRESHOLD);
+        assert!(!matches.is_empty());
+        for m in &matches {
+            let len = m.end - m.start;
+            assert!(
+                (8..=14).contains(&len),
+                "window of {len} chars for an 11-char quote: {m:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_fuzzy_window_may_span_the_whole_article() {
+        // The article text is the changed quote and nothing else, so the only
+        // window that covers it is the full text.
+        let arts = vec![article("2", "recht op een zorgtoeslag")];
+        let sel = selector("recht op de zorgtoeslag", "", "");
+        let r = resolve(&sel, &arts);
+        assert!(r.is_found(), "got {:?}", r.status);
+        assert_eq!(r.single().unwrap().matched_text, "recht op een zorgtoeslag");
+    }
+
+    #[test]
+    fn a_rewrite_that_only_shares_a_word_does_not_anchor() {
+        // "belanghebbende" gets these windows past the pre-filter, but none of
+        // them scores at the threshold. The note must orphan rather than
+        // anchor onto text it is not about.
+        let arts = vec![article(
+            "2",
+            "de belanghebbende dient de aanvraag in bij de Belastingdienst",
+        )];
+        let sel = selector(
+            "stelt het verzamelinkomen van de belanghebbende ambtshalve vast",
+            "de inspecteur",
+            "voor het jaar",
+        );
+        let r = resolve(&sel, &arts);
+        assert!(r.is_orphaned(), "got {:?} at {:?}", r.status, r.matches);
+    }
+
+    #[test]
+    fn a_quote_of_only_short_words_does_not_fuzzily_anchor() {
+        // "in de wet" has no word longer than three characters, so there is
+        // nothing to key a fuzzy match on. Once the phrase is replaced the note
+        // orphans instead of drifting onto text that merely looks like it.
+        let arts = vec![article("2", "Deze bevoegdheid is opgenomen in het besluit")];
+        let sel = selector("in de wet", "", "");
+        let r = resolve(&sel, &arts);
+        assert!(r.is_orphaned(), "got {:?} at {:?}", r.status, r.matches);
+    }
+
+    // === Scoring and collapsing helpers ===
+
+    #[test]
+    fn similarity_treats_a_missing_side_as_no_similarity() {
+        // A window at the very start of an article has no text before it. That
+        // scores zero against a non-empty prefix, not a free 1.0.
+        assert_eq!(similarity("op een", ""), 0.0);
+        assert_eq!(similarity("", "op een"), 0.0);
+        assert_eq!(similarity("", ""), 1.0);
+        assert_eq!(similarity("zorgtoeslag", "zorgtoeslag"), 1.0);
+        assert!(similarity("aanspraak", "aanzoek") > 0.0);
+    }
+
+    #[test]
+    fn only_words_longer_than_three_characters_are_significant() {
+        let words = significant_words("Recht op een zorgtoeslag van de wet");
+        assert!(words.contains("recht"), "lowercased: {words:?}");
+        assert!(words.contains("zorgtoeslag"));
+        assert!(
+            !words.contains("wet"),
+            "three characters is too common to key on"
+        );
+        assert!(!words.contains("op"));
+    }
+
+    #[test]
+    fn the_prefilter_needs_a_word_shared_with_the_quote() {
+        let quote = significant_words("aanspraak op zorgtoeslag");
+        assert!(shares_significant_content(&quote, "recht op zorgtoeslag"));
+        assert!(
+            !shares_significant_content(&quote, "vastgesteld bij ministeriële regeling"),
+            "long words that the quote does not use are not shared content"
+        );
+        assert!(!shares_significant_content(&quote, "op de wet"));
+    }
+
+    #[test]
+    fn touching_candidates_are_not_overlapping() {
+        // Two spans that touch (one ends where the next begins) are separate
+        // anchors; only genuinely overlapping spans collapse onto the best one.
+        let kept = deduplicate_overlapping(vec![
+            candidate("2", 0, 10, 0.80),
+            candidate("2", 10, 20, 0.90),
+            candidate("2", 20, 30, 0.85),
+        ]);
+        assert_eq!(kept.len(), 3, "kept {kept:?}");
+    }
+
+    #[test]
+    fn overlapping_candidates_collapse_onto_the_best() {
+        let kept = deduplicate_overlapping(vec![
+            candidate("2", 0, 10, 0.80),
+            candidate("2", 5, 15, 0.90),
+        ]);
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0].confidence, 0.90);
+    }
+
+    #[test]
+    fn the_same_span_in_another_article_is_a_separate_candidate() {
+        let kept = deduplicate_overlapping(vec![
+            candidate("2", 0, 10, 0.90),
+            candidate("3", 0, 10, 0.80),
+        ]);
+        assert_eq!(kept.len(), 2);
+    }
+
+    #[test]
+    fn a_winner_has_to_beat_the_runner_up_by_more_than_the_margin() {
+        assert_eq!(
+            clear_winner(&[candidate("2", 0, 10, 0.80)]).map(|w| w.start),
+            Some(0),
+            "a lone candidate wins by default"
+        );
+        assert_eq!(
+            clear_winner(&[candidate("2", 0, 10, 0.95), candidate("2", 20, 30, 0.80)])
+                .map(|w| w.start),
+            Some(0),
+            "0.15 ahead is a clear winner"
+        );
+
+        // Exactly the margin is not "more than": still a tie. 0.2 and 0.1 are
+        // chosen because their difference is exactly 0.1 in binary floating
+        // point, which is what puts this case on the boundary.
+        let (best, second) = (0.2, 0.1);
+        assert_eq!(best - second, TIEBREAK_MARGIN, "fixture sits on the margin");
+        assert!(
+            clear_winner(&[candidate("2", 0, 10, best), candidate("2", 20, 30, second)]).is_none()
+        );
+
+        assert!(
+            clear_winner(&[candidate("2", 0, 10, 0.75), candidate("2", 20, 30, 0.72)]).is_none(),
+            "within the margin is a tie"
+        );
+        assert!(clear_winner(&[]).is_none());
+    }
+
+    #[test]
+    fn find_subslice_reports_the_first_position() {
+        let hay: Vec<char> = "zorgtoeslag".chars().collect();
+        let needle = |s: &str| s.chars().collect::<Vec<char>>();
+        assert_eq!(find_subslice(&hay, &needle("toeslag")), Some(4));
+        assert_eq!(find_subslice(&hay, &needle("zorgtoeslag")), Some(0));
+        assert_eq!(find_subslice(&hay, &needle("premie")), None);
+        assert_eq!(
+            find_subslice(&hay, &needle("zorgtoeslagen")),
+            None,
+            "a needle longer than the haystack cannot be in it"
+        );
+        assert_eq!(
+            find_subslice(&hay, &[]),
+            None,
+            "an empty quote matches nothing"
+        );
+    }
+
+    // === Resolving against raw text, without articles ===
+
+    #[test]
+    fn raw_text_resolves_a_single_exact_quote() {
+        let sel = selector("de wet", "", "");
+        let r = resolve_in_text(
+            &sel,
+            "Deze verplichting vloeit voort uit de wet.",
+            DEFAULT_FUZZY_THRESHOLD,
+        );
+        assert!(r.is_found(), "got {:?}", r.status);
+        let m = r.single().unwrap();
+        assert_eq!(m.matched_text, "de wet");
+        assert_eq!(m.confidence, 1.0);
+        assert_eq!(m.article_number, "", "raw text has no article to name");
+    }
+
+    #[test]
+    fn raw_text_with_a_repeated_quote_is_ambiguous() {
+        let sel = selector("de wet", "", "");
+        let r = resolve_in_text(
+            &sel,
+            "de wet verwijst naar de wet.",
+            DEFAULT_FUZZY_THRESHOLD,
+        );
+        assert!(r.is_ambiguous(), "got {:?}", r.status);
+        assert_eq!(r.matches.len(), 2);
     }
 
     #[test]

--- a/packages/engine/src/annotation/types.rs
+++ b/packages/engine/src/annotation/types.rs
@@ -214,6 +214,53 @@ regelrecht:hint:
         assert_eq!(hint.end, Some(56));
     }
 
+    fn a_match() -> TextMatch {
+        TextMatch {
+            article_number: "2".to_string(),
+            start: 0,
+            end: 4,
+            confidence: 1.0,
+            matched_text: "test".to_string(),
+        }
+    }
+
+    /// The three predicates classify a result into exactly one bucket: a
+    /// consumer branching on `is_orphaned()`/`is_ambiguous()` (as
+    /// `validate_annotations` does) must not report a resolved note as
+    /// unresolvable.
+    #[test]
+    fn status_predicates_are_mutually_exclusive() {
+        let found = MatchResult::found(vec![a_match()]);
+        assert!(found.is_found());
+        assert!(!found.is_orphaned());
+        assert!(!found.is_ambiguous());
+
+        let orphaned = MatchResult::orphaned();
+        assert!(orphaned.is_orphaned());
+        assert!(!orphaned.is_found());
+        assert!(!orphaned.is_ambiguous());
+
+        let ambiguous = MatchResult::ambiguous(vec![a_match(), a_match()]);
+        assert!(ambiguous.is_ambiguous());
+        assert!(!ambiguous.is_found());
+        assert!(!ambiguous.is_orphaned());
+    }
+
+    /// `single()` is only meaningful for a `Found` result; an ambiguous result
+    /// carries several candidates and must not hand out the first one as if it
+    /// were the answer.
+    #[test]
+    fn single_only_yields_a_match_when_found() {
+        assert_eq!(
+            MatchResult::found(vec![a_match()]).single(),
+            Some(&a_match())
+        );
+        assert!(MatchResult::orphaned().single().is_none());
+        assert!(MatchResult::ambiguous(vec![a_match(), a_match()])
+            .single()
+            .is_none());
+    }
+
     #[test]
     fn selector_without_hint() {
         let yaml = r#"

--- a/packages/engine/src/bin/validate_annotations.rs
+++ b/packages/engine/src/bin/validate_annotations.rs
@@ -269,3 +269,154 @@ fn load_vocabulary() -> HashSet<String> {
         })
         .unwrap_or_default()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn vocabulary_of(ids: &[&str]) -> HashSet<String> {
+        ids.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    fn tag_note(tag: &str) -> serde_json::Value {
+        json!({
+            "body": {"type": "TextualBody", "value": tag, "purpose": "tagging"}
+        })
+    }
+
+    /// A note anchored to a law that is in the corpus, so that the selector is
+    /// really resolved instead of silently skipped.
+    fn zorgtoeslag_note(exact: &str) -> serde_json::Value {
+        json!({
+            "target": {
+                "source": "regelrecht://wet_op_de_zorgtoeslag",
+                "selector": {"type": "TextQuoteSelector", "exact": exact}
+            }
+        })
+    }
+
+    #[test]
+    fn tagging_value_is_read_from_a_single_body() {
+        assert_eq!(
+            tagging_values(&tag_note("open-norm-partial")),
+            vec!["open-norm-partial".to_string()]
+        );
+    }
+
+    #[test]
+    fn every_tagging_body_in_a_list_is_read() {
+        let note = json!({"body": [
+            {"type": "TextualBody", "value": "open-norm-partial", "purpose": "tagging"},
+            {"type": "TextualBody", "value": "een toelichting", "purpose": "commenting"},
+            {"type": "TextualBody", "value": "missing-document", "purpose": "tagging"},
+        ]});
+        assert_eq!(
+            tagging_values(&note),
+            vec![
+                "open-norm-partial".to_string(),
+                "missing-document".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn a_body_without_the_tagging_purpose_is_no_tag() {
+        let note = json!({
+            "body": {"type": "TextualBody", "value": "een toelichting", "purpose": "commenting"}
+        });
+        assert!(tagging_values(&note).is_empty());
+        assert!(tagging_values(&json!({})).is_empty());
+    }
+
+    #[test]
+    fn every_tag_outside_the_vocabulary_gives_one_warning() {
+        let doc = json!({"annotations": [tag_note("staat-er-niet"), tag_note("ook-niet")]});
+        assert_eq!(
+            check_notes(
+                Path::new("notes.yaml"),
+                &doc,
+                &vocabulary_of(&["open-norm-partial"])
+            ),
+            2
+        );
+    }
+
+    #[test]
+    fn a_tag_from_the_vocabulary_gives_no_warning() {
+        let doc = json!({"annotations": [tag_note("open-norm-partial")]});
+        assert_eq!(
+            check_notes(
+                Path::new("notes.yaml"),
+                &doc,
+                &vocabulary_of(&["open-norm-partial"])
+            ),
+            0
+        );
+    }
+
+    #[test]
+    fn a_file_without_annotations_gives_no_warning() {
+        assert_eq!(
+            check_notes(Path::new("notes.yaml"), &json!({}), &vocabulary_of(&[])),
+            0
+        );
+    }
+
+    /// A term from another area of law: no article of the Wet op de
+    /// zorgtoeslag contains it, and it is far enough from anything in the text
+    /// that the fuzzy matcher finds no candidate either.
+    #[test]
+    fn a_selector_that_no_longer_occurs_warns_as_orphaned() {
+        let doc = json!({"annotations": [zorgtoeslag_note("motorrijtuigenbelasting")]});
+        assert_eq!(
+            check_notes(Path::new("notes.yaml"), &doc, &vocabulary_of(&[])),
+            1
+        );
+    }
+
+    #[test]
+    fn a_selector_that_occurs_more_than_once_warns_as_ambiguous() {
+        let doc = json!({"annotations": [zorgtoeslag_note("verzekerde")]});
+        assert_eq!(
+            check_notes(Path::new("notes.yaml"), &doc, &vocabulary_of(&[])),
+            1
+        );
+    }
+
+    #[test]
+    fn a_law_is_found_by_its_id_in_the_corpus() {
+        let law = load_law_by_id("wet_op_de_zorgtoeslag").expect("law is in the corpus");
+        assert_eq!(law.id, "wet_op_de_zorgtoeslag");
+        assert!(!law.articles.is_empty());
+    }
+
+    #[test]
+    fn an_unknown_law_id_resolves_to_no_law_at_all() {
+        assert!(load_law_by_id("wet_die_niet_bestaat").is_none());
+    }
+
+    #[test]
+    fn note_discovery_finds_the_sidecars_and_skips_the_vocabulary() {
+        let files = discover_note_files();
+        assert!(
+            !files.is_empty(),
+            "corpus/annotations holds at least one note file"
+        );
+        for file in &files {
+            assert_eq!(file.extension().and_then(|e| e.to_str()), Some("yaml"));
+            assert!(
+                !file.components().any(|c| c.as_os_str() == "_vocabulary"),
+                "{} is vocabulary, not a note file",
+                file.display()
+            );
+        }
+    }
+
+    #[test]
+    fn the_vocabulary_holds_the_ambiguity_ids() {
+        let vocabulary = load_vocabulary();
+        assert!(vocabulary.contains("open-norm-not-filled"));
+        assert!(vocabulary.contains("needs-uitvoeringsbeleid"));
+    }
+}

--- a/packages/engine/tests/fixtures/annotations/known-tag.yaml
+++ b/packages/engine/tests/fixtures/annotations/known-tag.yaml
@@ -1,0 +1,18 @@
+---
+# Fixture for tests/validate_annotations_cli.rs: schema-valid, and the tag value
+# is in corpus/annotations/_vocabulary/ambiguity.yaml. The target points at a law
+# that is deliberately not in the corpus, so the selector is never resolved and
+# this file produces no warnings at all.
+annotations:
+  - type: Annotation
+    motivation: questioning
+    creator: fictieve-annotator
+    target:
+      source: regelrecht://wet_die_niet_bestaat
+      selector:
+        type: TextQuoteSelector
+        exact: verzekerde
+    body:
+      type: TextualBody
+      value: open-norm-not-filled
+      purpose: tagging

--- a/packages/engine/tests/fixtures/annotations/schema-invalid.yaml
+++ b/packages/engine/tests/fixtures/annotations/schema-invalid.yaml
@@ -1,0 +1,13 @@
+---
+# Fixture for tests/validate_annotations_cli.rs: the note has no `body`, which
+# the annotation schema requires. This is the only defect class that makes
+# `validate-annotations` exit non-zero.
+annotations:
+  - type: Annotation
+    motivation: commenting
+    creator: fictieve-annotator
+    target:
+      source: regelrecht://wet_die_niet_bestaat
+      selector:
+        type: TextQuoteSelector
+        exact: verzekerde

--- a/packages/engine/tests/fixtures/annotations/unknown-tag.yaml
+++ b/packages/engine/tests/fixtures/annotations/unknown-tag.yaml
@@ -1,0 +1,17 @@
+---
+# Fixture for tests/validate_annotations_cli.rs: schema-valid, but the tag value
+# is not in corpus/annotations/_vocabulary/ambiguity.yaml. Exactly one warning,
+# and per RFC-018 Decision 9 a warning must not fail the build.
+annotations:
+  - type: Annotation
+    motivation: questioning
+    creator: fictieve-annotator
+    target:
+      source: regelrecht://wet_die_niet_bestaat
+      selector:
+        type: TextQuoteSelector
+        exact: verzekerde
+    body:
+      type: TextualBody
+      value: deze-tag-staat-niet-in-de-vocabulaire
+      purpose: tagging

--- a/packages/engine/tests/validate_annotations_cli.rs
+++ b/packages/engine/tests/validate_annotations_cli.rs
@@ -1,0 +1,75 @@
+//! End-to-end behaviour of the `validate-annotations` binary.
+//!
+//! The contract this suite pins down is the one RFC-018 gives the tool and the
+//! one `just validate-annotations` relies on in `just check`: a schema
+//! violation fails the build, and nothing else does. Orphaned notes, ambiguous
+//! selectors and tag values outside the controlled vocabulary are reported as
+//! warnings and leave the exit code at zero (RFC-018 Decisions 8 and 9).
+//!
+//! Only built with the `validate` feature, which is what gates the binary.
+#![cfg(feature = "validate")]
+
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+fn fixture(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/annotations")
+        .join(name)
+}
+
+fn run_on(fixture_name: &str) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_validate-annotations"))
+        .arg(fixture(fixture_name))
+        .output()
+        .expect("validate-annotations runs")
+}
+
+fn stderr_of(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+#[test]
+fn a_schema_violation_fails_the_build() {
+    let output = run_on("schema-invalid.yaml");
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "schema violation must exit 1, stderr:\n{}",
+        stderr_of(&output)
+    );
+    let stderr = stderr_of(&output);
+    assert!(stderr.contains("FAIL"), "stderr:\n{stderr}");
+    assert!(stderr.contains("schema"), "stderr:\n{stderr}");
+}
+
+#[test]
+fn a_valid_file_without_findings_passes_silently() {
+    let output = run_on("known-tag.yaml");
+    let stderr = stderr_of(&output);
+    assert_eq!(output.status.code(), Some(0), "stderr:\n{stderr}");
+    assert!(stderr.contains("OK:"), "stderr:\n{stderr}");
+    assert!(
+        !stderr.contains("warning(s)"),
+        "no warning summary expected, stderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn an_unknown_tag_is_reported_as_one_warning_and_does_not_fail() {
+    let output = run_on("unknown-tag.yaml");
+    let stderr = stderr_of(&output);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "a warning must not fail the build (RFC-018), stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("1 warning(s)"),
+        "expected exactly one warning, stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("deze-tag-staat-niet-in-de-vocabulaire"),
+        "the offending tag must be named, stderr:\n{stderr}"
+    );
+}


### PR DESCRIPTION
114 van de 353 overlevende mutanten uit #1052 zaten in de annotatiehoek: `annotation/resolver.rs` (75), `bin/validate_annotations.rs` (34), `annotation/mod.rs` (3) en `annotation/types.rs` (2).

De resolver bepaalt waar een notitie in de wettekst hangt, en dat hing aan een handvol tests die alleen naar de status keken. Je kon de vensterbreedte, de context-check of de tiebreak-marge omzetten zonder dat er iets rood werd. De nieuwe tests leggen het gedrag zelf vast: welke span een fuzzy anker dekt, dat prefix en suffix allebei moeten kloppen, dat een verouderde positie-hint wordt genegeerd in plaats van gevolgd, en dat een gelijkspel ambigu blijft in plaats van willekeurig te winnen.

Eén ingreep in de productiecode: de tiebreak-regel stond twee keer in het bestand, in `finalize_fuzzy` en in `resolve_hint`, met als enige verschil wat een gelijkspel betekent. Dat is nu één `clear_winner()`. De `len > 1`-bewaking die daarbij verdween was aantoonbaar altijd waar, want de regel erboven keert al terug bij lengte 1.

`validate_annotations` is een `bin/`-target, en de skill noemt die als kandidaat om uit te sluiten. Dat is hier niet gedaan: er staat een echte CLI-test met fixtures, die de binary draait en de afloopcodes vastlegt. 33 van de 34 mutanten sterven daaraan.

Onderdeel van #1052. Bouwt voort op #1063.