### PR TITLE
test(engine): dek de servicelaag, de resolver en de context af

### DIFF
--- a/packages/engine/src/context.rs
+++ b/packages/engine/src/context.rs
@@ -820,6 +820,194 @@ mod tests {
         assert_eq!(x, Value::Int(200));
     }
 
+    // -------------------------------------------------------------------------
+    // Accessor Tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_get_output_returns_stored_value() {
+        let mut ctx = make_context();
+        ctx.set_output("amount", Value::Int(1000));
+
+        assert_eq!(ctx.get_output("amount"), Some(&Value::Int(1000)));
+        assert_eq!(ctx.get_output("never_set"), None);
+    }
+
+    #[test]
+    fn test_reference_date_matches_calculation_date() {
+        let ctx = make_context();
+
+        assert_eq!(
+            ctx.reference_date(),
+            NaiveDate::from_ymd_opt(2025, 6, 15).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_get_calculation_date_returns_the_iso_date() {
+        let ctx = make_context();
+
+        assert_eq!(ctx.get_calculation_date(), "2025-06-15");
+    }
+
+    // -------------------------------------------------------------------------
+    // Trace Tests
+    // -------------------------------------------------------------------------
+
+    fn traced_context() -> (RuleContext, Rc<RefCell<TraceBuilder>>) {
+        let mut ctx = make_context();
+        let trace = Rc::new(RefCell::new(TraceBuilder::new_untimed()));
+        ctx.set_trace(Rc::clone(&trace));
+        (ctx, trace)
+    }
+
+    /// Resolve `path` with tracing on and return the value plus the resolve node
+    /// that was recorded for it.
+    fn traced_resolve(path: &str) -> (Result<Value>, crate::trace::PathNode) {
+        let (ctx, trace) = traced_context();
+        // A parent node, so the resolve node is kept as its child on pop.
+        trace.borrow_mut().push("root", PathNodeType::Action);
+
+        let value = ctx.resolve(path);
+
+        let root = trace.borrow_mut().pop().expect("root node should pop");
+        let node = root
+            .children
+            .into_iter()
+            .next()
+            .expect("resolving should record a node");
+        (value, node)
+    }
+
+    #[test]
+    fn test_trace_is_absent_until_set() {
+        let ctx = make_context();
+        assert!(ctx.trace().is_none());
+        assert!(!ctx.has_trace());
+        assert!(!ValueResolver::has_trace(&ctx));
+
+        let (traced, trace) = traced_context();
+        assert!(traced.has_trace());
+        assert!(ValueResolver::has_trace(&traced));
+        let held = traced.trace().expect("trace should be set");
+        assert!(
+            Rc::ptr_eq(held, &trace),
+            "context must hand back the builder it was given"
+        );
+    }
+
+    #[test]
+    fn test_child_context_shares_the_trace_builder() {
+        let (ctx, trace) = traced_context();
+
+        let child = ctx.create_child();
+
+        let held = child.trace().expect("child should inherit the trace");
+        assert!(
+            Rc::ptr_eq(held, &trace),
+            "child must write into the same trace as its parent"
+        );
+    }
+
+    #[test]
+    fn test_value_resolver_records_result_on_current_node() {
+        let (ctx, trace) = traced_context();
+
+        ValueResolver::trace_push(&ctx, "operation", PathNodeType::Operation);
+        ValueResolver::trace_set_result(&ctx, Value::Int(42));
+
+        let node = trace.borrow_mut().pop().expect("pushed node should pop");
+        assert_eq!(node.name, "operation");
+        assert_eq!(node.result, Some(Value::Int(42)));
+    }
+
+    #[test]
+    fn test_trace_reports_referencedate_parts_as_context() {
+        let cases = [
+            ("referencedate.year", Value::Int(2025)),
+            ("referencedate.month", Value::Int(6)),
+            ("referencedate.day", Value::Int(15)),
+            ("referencedate.iso", Value::String("2025-06-15".to_string())),
+        ];
+
+        for (path, expected) in cases {
+            let (value, node) = traced_resolve(path);
+            assert_eq!(value.unwrap(), expected, "value for {}", path);
+            assert_eq!(node.name, path);
+            assert_eq!(
+                node.resolve_type,
+                Some(ResolveType::Context),
+                "{} should be reported as resolved from the context",
+                path
+            );
+            assert_eq!(node.result, Some(expected), "traced result for {}", path);
+        }
+    }
+
+    #[test]
+    fn test_date_like_properties_come_from_their_own_object() {
+        let mut ctx = make_context();
+
+        let mut period = BTreeMap::new();
+        period.insert("year".to_string(), Value::Int(1999));
+        period.insert("month".to_string(), Value::Int(1));
+        period.insert("day".to_string(), Value::Int(2));
+        period.insert("iso".to_string(), Value::String("1999-01-02".to_string()));
+        ctx.set_output("period", Value::Object(period));
+
+        // Only `referencedate` gets the built-in date parts; any other object
+        // keeps its own values.
+        assert_eq!(ctx.resolve("period.year").unwrap(), Value::Int(1999));
+        assert_eq!(ctx.resolve("period.month").unwrap(), Value::Int(1));
+        assert_eq!(ctx.resolve("period.day").unwrap(), Value::Int(2));
+        assert_eq!(
+            ctx.resolve("period.iso").unwrap(),
+            Value::String("1999-01-02".to_string())
+        );
+    }
+
+    #[test]
+    fn test_property_depth_limit_boundary() {
+        // `levels` wrappers of "n" around {"end": 999}, reached by a path with
+        // `levels + 1` property segments after the base variable.
+        fn nested(levels: usize) -> Value {
+            let mut inner = BTreeMap::new();
+            inner.insert("end".to_string(), Value::Int(999));
+            let mut value = Value::Object(inner);
+            for _ in 0..levels {
+                let mut wrapper = BTreeMap::new();
+                wrapper.insert("n".to_string(), value);
+                value = Value::Object(wrapper);
+            }
+            value
+        }
+        fn path(levels: usize) -> String {
+            let mut p = String::from("root");
+            for _ in 0..levels {
+                p.push_str(".n");
+            }
+            p.push_str(".end");
+            p
+        }
+
+        let max = config::MAX_PROPERTY_DEPTH;
+
+        // Exactly MAX_PROPERTY_DEPTH property segments is still allowed.
+        let mut ctx = make_context();
+        ctx.set_output("root", nested(max - 1));
+        assert_eq!(ctx.resolve(&path(max - 1)).unwrap(), Value::Int(999));
+
+        // One segment more is refused.
+        let mut ctx = make_context();
+        ctx.set_output("root", nested(max));
+        let result = ctx.resolve(&path(max));
+        assert!(
+            matches!(result, Err(EngineError::InvalidOperation(ref msg)) if msg.contains("depth exceeds")),
+            "Expected InvalidOperation error one level past the limit, got: {:?}",
+            result
+        );
+    }
+
     #[test]
     fn test_recursion_depth_limit() {
         let mut ctx = make_context();

--- a/packages/engine/src/context.rs
+++ b/packages/engine/src/context.rs
@@ -457,10 +457,16 @@ fn get_property(value: &Value, property_path: &str, depth: usize) -> Result<Valu
         )));
     }
 
-    // Handle nested paths recursively
+    // Handle nested paths recursively. Beide aanroepen krijgen dezelfde,
+    // eenmaal opgehoogde diepte. Twee losse `depth + 1`-uitdrukkingen leverden
+    // twee mutanten op met exact dezelfde omschrijving, waarvan alleen die op
+    // de `rest`-tak te doden is: de `first`-tak stopt altijd meteen, want daar
+    // zit per definitie geen punt meer in. Eén uitdrukking, één mutant, en die
+    // wordt gedood door test_property_depth_limit_boundary.
     if let Some((first, rest)) = property_path.split_once('.') {
-        let intermediate = get_property(value, first, depth + 1)?;
-        return get_property(&intermediate, rest, depth + 1);
+        let deeper = depth + 1;
+        let intermediate = get_property(value, first, deeper)?;
+        return get_property(&intermediate, rest, deeper);
     }
 
     match value {

--- a/packages/engine/src/resolver.rs
+++ b/packages/engine/src/resolver.rs
@@ -1748,4 +1748,726 @@ articles:
         assert!(resolver.has_law("regeling_standaardpremie"));
         assert!(resolver.has_law("participatiewet"));
     }
+
+    // -------------------------------------------------------------------------
+    // Law count limit (memory-exhaustion guard)
+    // -------------------------------------------------------------------------
+
+    /// A minimal law with its own `$id`, so the registry can be filled to the limit.
+    fn make_numbered_law(n: usize, valid_from: Option<&str>) -> String {
+        let valid_from_line = match valid_from {
+            Some(d) => format!("valid_from: '{d}'\n"),
+            None => String::new(),
+        };
+        format!(
+            r#"
+$id: filler_law_{n}
+regulatory_layer: WET
+publication_date: '2025-01-01'
+{valid_from_line}articles:
+  - number: '1'
+    text: Filler article {n}
+    machine_readable:
+      execution:
+        output:
+          - name: filler_output
+            type: number
+        actions:
+          - output: filler_output
+            value: {n}
+"#
+        )
+    }
+
+    fn resolver_at_law_limit() -> RuleResolver {
+        let mut resolver = RuleResolver::new();
+        for n in 0..config::MAX_LOADED_LAWS {
+            resolver
+                .load_from_yaml(&make_numbered_law(n, None))
+                .unwrap();
+        }
+        assert_eq!(resolver.version_count(), config::MAX_LOADED_LAWS);
+        resolver
+    }
+
+    #[test]
+    fn test_resolver_limit_rejects_new_version_of_existing_law() {
+        // A second version of an already-loaded law is a *new* law in the
+        // registry: it adds memory, so it must hit the limit like any other.
+        let mut resolver = resolver_at_law_limit();
+
+        let result = resolver.load_from_yaml(&make_numbered_law(0, Some("2030-01-01")));
+
+        assert!(
+            matches!(result, Err(EngineError::LoadError(_))),
+            "adding a new version at the limit must be rejected, got {result:?}"
+        );
+        assert_eq!(resolver.version_count(), config::MAX_LOADED_LAWS);
+        assert_eq!(resolver.version_count_for_law("filler_law_0"), 1);
+    }
+
+    #[test]
+    fn test_resolver_limit_allows_replacing_existing_version() {
+        // Replacing a version (same law id, same valid_from) does not grow the
+        // registry, so the limit must not block it — otherwise a full resolver
+        // could never be corrected.
+        let mut resolver = resolver_at_law_limit();
+
+        resolver
+            .load_from_yaml(&make_numbered_law(0, None))
+            .expect("replacing an existing version at the limit must be allowed");
+
+        assert_eq!(resolver.version_count(), config::MAX_LOADED_LAWS);
+    }
+
+    #[test]
+    fn test_resolver_law_count_counts_unique_ids() {
+        let mut resolver = RuleResolver::new();
+        assert_eq!(resolver.law_count(), 0);
+
+        resolver
+            .load_from_yaml(&make_numbered_law(1, None))
+            .unwrap();
+        resolver
+            .load_from_yaml(&make_numbered_law(2, None))
+            .unwrap();
+        assert_eq!(resolver.law_count(), 2);
+
+        // A second version of law 1 adds a version, not a law id.
+        resolver
+            .load_from_yaml(&make_numbered_law(1, Some("2030-01-01")))
+            .unwrap();
+        assert_eq!(resolver.law_count(), 2);
+        assert_eq!(resolver.version_count(), 3);
+    }
+
+    #[test]
+    fn test_resolver_all_law_versions_yields_every_version() {
+        let mut resolver = RuleResolver::new();
+        resolver
+            .load_from_yaml(&make_test_law_with_valid_from("2024-01-01", 100))
+            .unwrap();
+        resolver
+            .load_from_yaml(&make_test_law_with_valid_from("2025-01-01", 200))
+            .unwrap();
+        resolver
+            .load_from_yaml(&make_numbered_law(7, None))
+            .unwrap();
+
+        let mut seen: Vec<(&str, Option<&str>)> = resolver
+            .all_law_versions()
+            .map(|law| (law.id.as_str(), law.valid_from.as_deref()))
+            .collect();
+        seen.sort();
+
+        assert_eq!(
+            seen,
+            vec![
+                ("filler_law_7", None),
+                ("test_law", Some("2024-01-01")),
+                ("test_law", Some("2025-01-01")),
+            ]
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Version unloading
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_resolver_unload_version_removes_only_the_named_version() {
+        let mut resolver = RuleResolver::new();
+        resolver
+            .load_from_yaml(&make_test_law_with_valid_from("2024-01-01", 100))
+            .unwrap();
+        resolver
+            .load_from_yaml(&make_test_law_with_valid_from("2025-01-01", 200))
+            .unwrap();
+
+        assert!(resolver.unload_law_version("test_law", Some("2024-01-01")));
+
+        // The version that was *not* named must survive.
+        assert_eq!(resolver.version_count(), 1);
+        let remaining = resolver.get_law("test_law").unwrap();
+        assert_eq!(remaining.valid_from, Some("2025-01-01".to_string()));
+    }
+
+    #[test]
+    fn test_resolver_unload_unknown_version_is_a_no_op() {
+        let mut resolver = RuleResolver::new();
+        resolver
+            .load_from_yaml(&make_test_law_with_valid_from("2024-01-01", 100))
+            .unwrap();
+
+        // Nothing matches, so nothing was removed — the caller must be told so.
+        assert!(!resolver.unload_law_version("test_law", Some("1999-01-01")));
+        assert!(!resolver.unload_law_version("test_law", None));
+        assert_eq!(resolver.version_count(), 1);
+        assert!(resolver.has_law("test_law"));
+
+        // Unknown law id likewise.
+        assert!(!resolver.unload_law_version("nonexistent", Some("2024-01-01")));
+    }
+
+    // -------------------------------------------------------------------------
+    // Scope filtering (gemeentelijke / waterschaps-verordeningen)
+    // -------------------------------------------------------------------------
+
+    fn make_law_with_open_term_scoped() -> &'static str {
+        r#"
+$id: kaderwet
+regulatory_layer: WET
+publication_date: '2025-01-01'
+valid_from: '2025-01-01'
+articles:
+  - number: '1'
+    text: Het tarief wordt vastgesteld bij verordening
+    machine_readable:
+      open_terms:
+        - id: tarief
+          type: amount
+          required: true
+          delegated_to: waterschap
+          delegation_type: WATERSCHAPS_VERORDENING
+      execution:
+        output:
+          - name: tarief
+            type: number
+        actions:
+          - output: tarief
+            value: 0
+"#
+    }
+
+    fn make_scoped_implementation(id: &str, scope_line: &str, value: i32) -> String {
+        format!(
+            r#"
+$id: {id}
+regulatory_layer: WATERSCHAPS_VERORDENING
+publication_date: '2025-01-01'
+valid_from: '2025-01-01'
+{scope_line}
+articles:
+  - number: '1'
+    text: Het tarief bedraagt {value}
+    machine_readable:
+      implements:
+        - law: kaderwet
+          article: '1'
+          open_term: tarief
+          gelet_op: "Gelet op artikel 1 van de Kaderwet"
+      execution:
+        output:
+          - name: tarief
+            type: number
+        actions:
+          - output: tarief
+            value: {value}
+"#
+        )
+    }
+
+    fn scope_of(field: &str, code: &str) -> HashMap<String, Value> {
+        let mut scope = HashMap::new();
+        scope.insert(field.to_string(), Value::String(code.to_string()));
+        scope
+    }
+
+    /// A waterschapsverordening only implements an open term for its own
+    /// waterschap; another waterschap (or a national run) must not inherit it.
+    #[test]
+    fn test_find_implementations_filters_on_waterschap_code() {
+        let mut resolver = RuleResolver::new();
+        resolver
+            .load_from_yaml(make_law_with_open_term_scoped())
+            .unwrap();
+        resolver
+            .load_from_yaml(&make_scoped_implementation(
+                "keur_ws0653",
+                "waterschap_code: 'WS0653'",
+                42,
+            ))
+            .unwrap();
+
+        let find = |scope: &HashMap<String, Value>| {
+            resolver
+                .find_implementations("kaderwet", "1", "tarief", None, scope)
+                .unwrap()
+        };
+
+        // Own waterschap: applies.
+        let matching = find(&scope_of("waterschap_code", "WS0653"));
+        assert_eq!(matching.len(), 1);
+        assert_eq!(matching[0].0.id, "keur_ws0653");
+
+        // Different waterschap: does not apply.
+        assert!(find(&scope_of("waterschap_code", "WS0999")).is_empty());
+
+        // No waterschap in scope at all: does not apply.
+        assert!(find(&HashMap::new()).is_empty());
+
+        // A gemeente in scope does not satisfy a waterschap requirement.
+        assert!(find(&scope_of("gemeente_code", "WS0653")).is_empty());
+    }
+
+    /// The gemeente branch of the same rule, so both scope fields are pinned.
+    #[test]
+    fn test_find_implementations_filters_on_gemeente_code() {
+        let mut resolver = RuleResolver::new();
+        resolver
+            .load_from_yaml(make_law_with_open_term_scoped())
+            .unwrap();
+        resolver
+            .load_from_yaml(&make_scoped_implementation(
+                "verordening_g0363",
+                "gemeente_code: 'GM0363'",
+                7,
+            ))
+            .unwrap();
+
+        let find = |scope: &HashMap<String, Value>| {
+            resolver
+                .find_implementations("kaderwet", "1", "tarief", None, scope)
+                .unwrap()
+        };
+
+        assert_eq!(find(&scope_of("gemeente_code", "GM0363")).len(), 1);
+        assert!(find(&scope_of("gemeente_code", "GM0599")).is_empty());
+        assert!(find(&HashMap::new()).is_empty());
+    }
+
+    // -------------------------------------------------------------------------
+    // Index bookkeeping: hooks, overrides, procedures
+    // -------------------------------------------------------------------------
+
+    fn make_law_with_hook(id: &str, article: &str, decision_type: Option<&str>) -> String {
+        let decision_type_line = match decision_type {
+            Some(dt) => format!("            decision_type: {dt}\n"),
+            None => String::new(),
+        };
+        format!(
+            r#"
+$id: {id}
+regulatory_layer: WET
+publication_date: '2025-01-01'
+articles:
+  - number: '{article}'
+    text: Hook article
+    machine_readable:
+      hooks:
+        - hook_point: post_actions
+          applies_to:
+            legal_character: BESCHIKKING
+            stage: BESLUIT
+{decision_type_line}      execution:
+        output:
+          - name: hook_output_{id}
+            type: number
+        actions:
+          - output: hook_output_{id}
+            value: 1
+"#
+        )
+    }
+
+    fn make_law_with_override(id: &str, output: &str) -> String {
+        format!(
+            r#"
+$id: {id}
+regulatory_layer: WET
+publication_date: '2025-01-01'
+articles:
+  - number: '69'
+    text: In afwijking van artikel 1 van de doelwet
+    machine_readable:
+      overrides:
+        - law: doelwet
+          article: '1'
+          output: {output}
+      execution:
+        output:
+          - name: {output}
+            type: number
+        actions:
+          - output: {output}
+            value: 4
+"#
+        )
+    }
+
+    fn make_override_target() -> &'static str {
+        r#"
+$id: doelwet
+regulatory_layer: WET
+publication_date: '2025-01-01'
+articles:
+  - number: '1'
+    text: De termijn bedraagt zes weken
+    machine_readable:
+      execution:
+        output:
+          - name: bezwaartermijn_weken
+            type: number
+        actions:
+          - output: bezwaartermijn_weken
+            value: 6
+"#
+    }
+
+    fn make_law_with_procedure(id: &str, legal_character: &str, proc_id: &str) -> String {
+        format!(
+            r#"
+$id: {id}
+regulatory_layer: WET
+publication_date: '2025-01-01'
+procedure:
+  - id: {proc_id}
+    default: true
+    applies_to:
+      legal_character: {legal_character}
+    stages:
+      - name: AANVRAAG
+        description: Belanghebbende dient aanvraag in
+      - name: BESLUIT
+        description: Bestuursorgaan neemt besluit
+articles:
+  - number: '1'
+    text: Procedure-artikel
+    machine_readable:
+      execution:
+        output:
+          - name: proc_output_{proc_id}
+            type: number
+        actions:
+          - output: proc_output_{proc_id}
+            value: 1
+"#
+        )
+    }
+
+    /// Loading an unrelated law rebuilds only *its own* index entries. It must
+    /// not evict the hooks, overrides and procedures other laws registered.
+    #[test]
+    fn test_loading_a_law_keeps_other_laws_indexes() {
+        let mut resolver = RuleResolver::new();
+        resolver.load_from_yaml(make_override_target()).unwrap();
+        resolver
+            .load_from_yaml(&make_law_with_override(
+                "afwijkingswet",
+                "bezwaartermijn_weken",
+            ))
+            .unwrap();
+        resolver
+            .load_from_yaml(&make_law_with_hook("hookwet", "3:46", None))
+            .unwrap();
+        resolver
+            .load_from_yaml(&make_law_with_procedure(
+                "procedurewet",
+                "BESCHIKKING",
+                "beschikking",
+            ))
+            .unwrap();
+
+        // Now load something entirely unrelated.
+        resolver.load_from_yaml(make_test_law()).unwrap();
+
+        let overrides = resolver.find_overrides("doelwet", "1", "bezwaartermijn_weken");
+        assert_eq!(overrides.len(), 1);
+        assert_eq!(overrides[0].law_id, "afwijkingswet");
+
+        let hooks = resolver.find_hooks(HookPoint::PostActions, "BESCHIKKING", None, "BESLUIT");
+        assert_eq!(hooks.len(), 1);
+        assert_eq!(hooks[0].law_id, "hookwet");
+
+        assert!(resolver.find_procedure("BESCHIKKING", None).is_some());
+        assert!(resolver
+            .find_procedure("BESCHIKKING", Some("beschikking"))
+            .is_some());
+    }
+
+    /// Unloading one law must remove exactly that law's index entries and leave
+    /// every other law's entries intact.
+    #[test]
+    fn test_unloading_a_law_leaves_other_laws_indexes_intact() {
+        let mut resolver = RuleResolver::new();
+        resolver.load_from_yaml(make_override_target()).unwrap();
+        resolver
+            .load_from_yaml(&make_law_with_override(
+                "afwijkingswet_a",
+                "bezwaartermijn_weken",
+            ))
+            .unwrap();
+        resolver
+            .load_from_yaml(&make_law_with_override(
+                "afwijkingswet_b",
+                "bezwaartermijn_weken",
+            ))
+            .unwrap();
+        resolver
+            .load_from_yaml(&make_law_with_hook("hookwet_a", "3:46", None))
+            .unwrap();
+        resolver
+            .load_from_yaml(&make_law_with_hook("hookwet_b", "3:47", None))
+            .unwrap();
+        resolver
+            .load_from_yaml(&make_law_with_procedure(
+                "procedurewet_a",
+                "BESCHIKKING",
+                "beschikking",
+            ))
+            .unwrap();
+        resolver
+            .load_from_yaml(&make_law_with_procedure(
+                "procedurewet_b",
+                "ALGEMEEN_VERBINDEND_VOORSCHRIFT",
+                "avv",
+            ))
+            .unwrap();
+
+        assert!(resolver.unload_law("afwijkingswet_a"));
+        assert!(resolver.unload_law("hookwet_a"));
+        assert!(resolver.unload_law("procedurewet_a"));
+
+        // Overrides: only b survives, and it is really b.
+        let overrides = resolver.find_overrides("doelwet", "1", "bezwaartermijn_weken");
+        assert_eq!(overrides.len(), 1);
+        assert_eq!(overrides[0].law_id, "afwijkingswet_b");
+
+        // Hooks: only b survives, and it is really b.
+        let hooks = resolver.find_hooks(HookPoint::PostActions, "BESCHIKKING", None, "BESLUIT");
+        assert_eq!(hooks.len(), 1);
+        assert_eq!(hooks[0].law_id, "hookwet_b");
+
+        // Procedures: the unloaded law's procedure is gone, the other remains.
+        assert!(resolver.find_procedure("BESCHIKKING", None).is_none());
+        assert!(resolver
+            .find_procedure("ALGEMEEN_VERBINDEND_VOORSCHRIFT", None)
+            .is_some());
+    }
+
+    /// The output index must lose exactly the unloaded law's outputs.
+    #[test]
+    fn test_unloading_a_law_leaves_other_laws_outputs_indexed() {
+        let mut resolver = RuleResolver::new();
+        resolver.load_from_yaml(make_test_law()).unwrap();
+        resolver
+            .load_from_yaml(&make_numbered_law(3, None))
+            .unwrap();
+
+        assert!(resolver.unload_law("test_law"));
+
+        assert_eq!(
+            resolver.list_all_outputs(),
+            vec![("filler_law_3", "filler_output")]
+        );
+        assert_eq!(resolver.output_count(), 1);
+    }
+
+    /// Unloading one implementing regulation must not take its siblings with it.
+    #[test]
+    fn test_unloading_one_implementor_keeps_the_others() {
+        let mut resolver = RuleResolver::new();
+        resolver.load_from_yaml(make_law_with_open_term()).unwrap();
+        resolver
+            .load_from_yaml(make_implementing_regulation_older())
+            .unwrap();
+        resolver
+            .load_from_yaml(make_implementing_regulation())
+            .unwrap();
+        assert_eq!(resolver.implements_count(), 2);
+
+        resolver.unload_law("regeling_standaardpremie_2024");
+
+        assert_eq!(resolver.implements_count(), 1);
+        let results = resolver
+            .find_implementations(
+                "wet_op_de_zorgtoeslag",
+                "4",
+                "standaardpremie",
+                None,
+                &HashMap::new(),
+            )
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0.id, "regeling_standaardpremie");
+    }
+
+    // -------------------------------------------------------------------------
+    // Hook filtering
+    // -------------------------------------------------------------------------
+
+    /// A hook narrowed to one decision type fires for that type only — never for
+    /// another type, and never for a decision without a type.
+    #[test]
+    fn test_find_hooks_filters_on_decision_type() {
+        let mut resolver = RuleResolver::new();
+        resolver
+            .load_from_yaml(&make_law_with_hook("hookwet", "3:46", Some("TOEKENNING")))
+            .unwrap();
+
+        let find = |dt: Option<&str>| {
+            resolver
+                .find_hooks(HookPoint::PostActions, "BESCHIKKING", dt, "BESLUIT")
+                .len()
+        };
+
+        assert_eq!(find(Some("TOEKENNING")), 1);
+        assert_eq!(find(Some("AFWIJZING")), 0);
+        assert_eq!(find(None), 0);
+    }
+
+    /// A hook without a decision-type filter fires regardless of decision type.
+    #[test]
+    fn test_find_hooks_without_decision_type_filter_matches_all() {
+        let mut resolver = RuleResolver::new();
+        resolver
+            .load_from_yaml(&make_law_with_hook("hookwet", "3:46", None))
+            .unwrap();
+
+        for dt in [Some("TOEKENNING"), Some("AFWIJZING"), None] {
+            assert_eq!(
+                resolver
+                    .find_hooks(HookPoint::PostActions, "BESCHIKKING", dt, "BESLUIT")
+                    .len(),
+                1,
+                "unfiltered hook should fire for decision_type {dt:?}"
+            );
+        }
+
+        // Stage still filters.
+        assert_eq!(
+            resolver
+                .find_hooks(HookPoint::PostActions, "BESCHIKKING", None, "BEKENDMAKING")
+                .len(),
+            0
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Procedure lookup
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_find_procedure_by_default_and_by_id() {
+        let mut resolver = RuleResolver::new();
+        resolver
+            .load_from_yaml(&make_law_with_procedure(
+                "procedurewet",
+                "BESCHIKKING",
+                "beschikking",
+            ))
+            .unwrap();
+
+        let by_default = resolver.find_procedure("BESCHIKKING", None).unwrap();
+        assert_eq!(by_default.id, "beschikking");
+        assert_eq!(by_default.stages.len(), 2);
+
+        let by_id = resolver
+            .find_procedure("BESCHIKKING", Some("beschikking"))
+            .unwrap();
+        assert_eq!(by_id.id, "beschikking");
+
+        // Unknown procedure id, and unknown legal character.
+        assert!(resolver
+            .find_procedure("BESCHIKKING", Some("nope"))
+            .is_none());
+        assert!(resolver.find_procedure("ONBEKEND", None).is_none());
+    }
+
+    // -------------------------------------------------------------------------
+    // Override target validation
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_validate_override_targets_accepts_a_resolvable_override() {
+        let mut resolver = RuleResolver::new();
+        resolver.load_from_yaml(make_override_target()).unwrap();
+        resolver
+            .load_from_yaml(&make_law_with_override(
+                "afwijkingswet",
+                "bezwaartermijn_weken",
+            ))
+            .unwrap();
+
+        assert_eq!(resolver.validate_override_targets(), Vec::<String>::new());
+    }
+
+    #[test]
+    fn test_validate_override_targets_reports_missing_law() {
+        let mut resolver = RuleResolver::new();
+        // The target law 'doelwet' is never loaded.
+        resolver
+            .load_from_yaml(&make_law_with_override(
+                "afwijkingswet",
+                "bezwaartermijn_weken",
+            ))
+            .unwrap();
+
+        let errors = resolver.validate_override_targets();
+        assert_eq!(errors.len(), 1);
+        assert!(
+            errors[0].contains("non-existent law 'doelwet'"),
+            "unexpected error: {}",
+            errors[0]
+        );
+        assert!(errors[0].contains("afwijkingswet:69"));
+    }
+
+    #[test]
+    fn test_validate_override_targets_reports_missing_article() {
+        let mut resolver = RuleResolver::new();
+        resolver.load_from_yaml(make_override_target()).unwrap();
+        // Overrides article '99', which 'doelwet' does not have.
+        let yaml = r#"
+$id: afwijkingswet
+regulatory_layer: WET
+publication_date: '2025-01-01'
+articles:
+  - number: '69'
+    text: In afwijking van artikel 99 van de doelwet
+    machine_readable:
+      overrides:
+        - law: doelwet
+          article: '99'
+          output: bezwaartermijn_weken
+      execution:
+        output:
+          - name: bezwaartermijn_weken
+            type: number
+        actions:
+          - output: bezwaartermijn_weken
+            value: 4
+"#;
+        resolver.load_from_yaml(yaml).unwrap();
+
+        let errors = resolver.validate_override_targets();
+        assert_eq!(errors.len(), 1);
+        assert!(
+            errors[0].contains("non-existent article '99'"),
+            "unexpected error: {}",
+            errors[0]
+        );
+    }
+
+    #[test]
+    fn test_validate_override_targets_reports_missing_output() {
+        let mut resolver = RuleResolver::new();
+        resolver.load_from_yaml(make_override_target()).unwrap();
+        // The article exists, but does not produce 'beroepstermijn_weken'.
+        resolver
+            .load_from_yaml(&make_law_with_override(
+                "afwijkingswet",
+                "beroepstermijn_weken",
+            ))
+            .unwrap();
+
+        let errors = resolver.validate_override_targets();
+        assert_eq!(errors.len(), 1);
+        assert!(
+            errors[0].contains("non-existent output 'beroepstermijn_weken'"),
+            "unexpected error: {}",
+            errors[0]
+        );
+        assert!(errors[0].contains("doelwet:1"));
+    }
 }

--- a/packages/engine/src/service.rs
+++ b/packages/engine/src/service.rs
@@ -67,6 +67,23 @@ struct CacheEntry {
     parameters: BTreeMap<String, Value>,
 }
 
+impl CacheEntry {
+    /// Whether this entry was stored for exactly this law, output and parameter set.
+    ///
+    /// Cache keys are `u64` hashes, so two different evaluations can in theory
+    /// land on the same key. For legally binding decisions a wrong hit is never
+    /// acceptable, so every read re-checks the full identity: all three fields
+    /// must match, a difference in any one of them means "not this entry".
+    fn matches(
+        &self,
+        law_id: &str,
+        output_name: &str,
+        parameters: &BTreeMap<String, Value>,
+    ) -> bool {
+        self.law_id == law_id && self.output_name == output_name && self.parameters == *parameters
+    }
+}
+
 /// Uses a scoped push/pop pattern for the visited set to avoid
 /// cloning the HashSet on every cross-law descent.
 struct ResolutionContext<'a> {
@@ -1093,10 +1110,7 @@ impl LawExecutionService {
             // Runtime collision check: hash keys are u64 so collisions are
             // theoretically possible. For legally binding decisions, we must
             // never silently return wrong results.
-            if cached.law_id != law_id
-                || cached.output_name != output_name
-                || cached.parameters != parameters
-            {
+            if !cached.matches(law_id, output_name, &parameters) {
                 tracing::warn!(
                     cached_law = cached.law_id,
                     cached_output = cached.output_name,
@@ -1997,29 +2011,28 @@ impl LawExecutionService {
                 continue;
             }
 
-            // Check DataSourceRegistry before cross-law resolution
-            if self.data_registry.source_count() > 0 {
-                if let Some(data_match) = self.data_registry.resolve(&input.name, parameters) {
-                    tracing::debug!(
-                        input = %input.name,
-                        source = %data_match.source_name,
-                        "Resolved input from data registry"
-                    );
+            // Check DataSourceRegistry before cross-law resolution.
+            // An empty registry resolves to None, so no separate guard is needed.
+            if let Some(data_match) = self.data_registry.resolve(&input.name, parameters) {
+                tracing::debug!(
+                    input = %input.name,
+                    source = %data_match.source_name,
+                    "Resolved input from data registry"
+                );
 
-                    // Trace the data source resolution
-                    {
-                        let _guard = res_ctx.trace_guard(&input.name, PathNodeType::Resolve);
-                        res_ctx.trace_set_resolve_type(ResolveType::DataSource);
-                        res_ctx.trace_set_result(data_match.value.clone());
-                        res_ctx.trace_set_message(format!(
-                            "Resolving from SOURCE {}: {}",
-                            data_match.source_name, data_match.value
-                        ));
-                    }
-
-                    context.set_resolved_input(&input.name, data_match.value);
-                    continue;
+                // Trace the data source resolution
+                {
+                    let _guard = res_ctx.trace_guard(&input.name, PathNodeType::Resolve);
+                    res_ctx.trace_set_resolve_type(ResolveType::DataSource);
+                    res_ctx.trace_set_result(data_match.value.clone());
+                    res_ctx.trace_set_message(format!(
+                        "Resolving from SOURCE {}: {}",
+                        data_match.source_name, data_match.value
+                    ));
                 }
+
+                context.set_resolved_input(&input.name, data_match.value);
+                continue;
             }
 
             // For cross-law resolution, output defaults to input name
@@ -2755,11 +2768,19 @@ articles:
         let result =
             service.evaluate_law_output("law_a", "output_a", BTreeMap::new(), "2025-01-01");
 
-        assert!(
-            matches!(result, Err(EngineError::CircularReference(_))),
-            "Expected CircularReference error, got: {:?}",
-            result
-        );
+        match result {
+            Err(EngineError::CircularReference(msg)) => {
+                // The cycle guard has to catch this on re-entry. Reporting an
+                // exhausted depth budget instead would send the reader looking
+                // for a long chain that is not there.
+                assert!(
+                    msg.contains("already being resolved"),
+                    "Expected the cycle itself to be reported, got: {}",
+                    msg
+                );
+            }
+            other => panic!("Expected CircularReference error, got: {:?}", other),
+        }
     }
 
     #[test]
@@ -4106,5 +4127,869 @@ articles:
             Some(&Value::Int(220000)),
             "2026 calculation should use 2026 version"
         );
+    }
+
+    // -------------------------------------------------------------------------
+    // Memoization cache identity
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_cache_key_depends_on_parameter_values() {
+        // The per-execution memo cache is keyed on a hash of law, output and
+        // parameters. The parameter *values* must reach that hash: without
+        // them every call with the same parameter names lands on one key and
+        // the identity check has to reject nearly every hit.
+        let key_of = |value: Value| {
+            let mut params = BTreeMap::new();
+            params.insert("bsn".to_string(), value);
+            cache_key("zorgtoeslag", "recht_op_zorgtoeslag", &params)
+        };
+
+        assert_ne!(key_of(Value::Int(1)), key_of(Value::Int(2)));
+        assert_ne!(key_of(Value::Bool(true)), key_of(Value::Bool(false)));
+        assert_ne!(
+            key_of(Value::String("111".to_string())),
+            key_of(Value::String("222".to_string()))
+        );
+        assert_ne!(
+            key_of(Value::Array(vec![Value::Int(1)])),
+            key_of(Value::Array(vec![Value::Int(2)]))
+        );
+        let obj = |v: i64| {
+            let mut map = BTreeMap::new();
+            map.insert("field".to_string(), Value::Int(v));
+            Value::Object(map)
+        };
+        assert_ne!(key_of(obj(1)), key_of(obj(2)));
+
+        // Equal decimals hash equally, matching PartialEq (1.0 == 1.00).
+        assert_eq!(
+            key_of(Value::Decimal("1.0".parse().unwrap())),
+            key_of(Value::Decimal("1.00".parse().unwrap()))
+        );
+
+        // Law and output are part of the identity too.
+        let empty = BTreeMap::new();
+        assert_ne!(
+            cache_key("law_a", "output", &empty),
+            cache_key("law_b", "output", &empty)
+        );
+        assert_ne!(
+            cache_key("law_a", "output_x", &empty),
+            cache_key("law_a", "output_y", &empty)
+        );
+    }
+
+    #[test]
+    fn test_cache_entry_matches_requires_every_identity_field() {
+        // A cache hit is only honoured when law, output *and* parameters match.
+        // The key is a u64 hash, so a collision must never hand one decision
+        // the outputs of another.
+        let mut params = BTreeMap::new();
+        params.insert("bsn".to_string(), Value::String("111".to_string()));
+
+        let entry = CacheEntry {
+            law_id: "law_a".to_string(),
+            output_name: "output_x".to_string(),
+            outputs: BTreeMap::new(),
+            output_provenance: BTreeMap::new(),
+            parameters: params.clone(),
+        };
+
+        assert!(entry.matches("law_a", "output_x", &params));
+        assert!(
+            !entry.matches("law_b", "output_x", &params),
+            "another law must never reuse this entry"
+        );
+        assert!(
+            !entry.matches("law_a", "output_y", &params),
+            "another output must never reuse this entry"
+        );
+
+        let mut other_params = params.clone();
+        other_params.insert("bsn".to_string(), Value::String("222".to_string()));
+        assert!(
+            !entry.matches("law_a", "output_x", &other_params),
+            "other parameters must never reuse this entry"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Resolution depth accounting
+    // -------------------------------------------------------------------------
+
+    /// Build `links` laws where `chain_law_{i}` sources `chain_law_{i+1}`, plus
+    /// a terminal law with a literal value. Each link costs one depth level.
+    fn cross_law_chain(links: usize) -> Vec<String> {
+        let mut laws = Vec::new();
+        for i in 0..links {
+            let next = i + 1;
+            laws.push(format!(
+                r#"
+$id: chain_law_{i}
+regulatory_layer: WET
+publication_date: '2025-01-01'
+articles:
+  - number: '1'
+    text: Chain link {i}
+    machine_readable:
+      execution:
+        input:
+          - name: from_next
+            type: number
+            source:
+              regulation: chain_law_{next}
+              output: value_{next}
+        output:
+          - name: value_{i}
+            type: number
+        actions:
+          - output: value_{i}
+            value: $from_next
+"#
+            ));
+        }
+        laws.push(format!(
+            r#"
+$id: chain_law_{links}
+regulatory_layer: WET
+publication_date: '2025-01-01'
+articles:
+  - number: '1'
+    text: Chain terminal
+    machine_readable:
+      execution:
+        output:
+          - name: value_{links}
+            type: number
+        actions:
+          - output: value_{links}
+            value: 7
+"#
+        ));
+        laws
+    }
+
+    #[test]
+    fn test_service_cross_law_depth_limit_boundary() {
+        // The depth limit exists to stop runaway recursion, not to reject
+        // chains the configuration declares admissible: exactly
+        // MAX_CROSS_LAW_DEPTH hops must resolve, one hop more must not.
+        let mut service = LawExecutionService::new();
+        for law in cross_law_chain(config::MAX_CROSS_LAW_DEPTH) {
+            service.load_law(&law).unwrap();
+        }
+        let result = service
+            .evaluate_law_output("chain_law_0", "value_0", BTreeMap::new(), "2025-01-01")
+            .expect("a chain of exactly MAX_CROSS_LAW_DEPTH hops must resolve");
+        assert_eq!(result.outputs.get("value_0"), Some(&Value::Int(7)));
+
+        let mut service = LawExecutionService::new();
+        for law in cross_law_chain(config::MAX_CROSS_LAW_DEPTH + 1) {
+            service.load_law(&law).unwrap();
+        }
+        let result =
+            service.evaluate_law_output("chain_law_0", "value_0", BTreeMap::new(), "2025-01-01");
+        match result {
+            Err(EngineError::CircularReference(msg)) => {
+                assert!(
+                    msg.contains("depth exceeded"),
+                    "Expected depth-exceeded error, got: {}",
+                    msg
+                );
+            }
+            other => panic!("Expected CircularReference depth error, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_service_internal_depth_limit_boundary() {
+        // Same boundary for same-law (internal) references: a chain of exactly
+        // MAX_CROSS_LAW_DEPTH links stays within budget.
+        let links = config::MAX_CROSS_LAW_DEPTH;
+        let mut yaml = String::from(
+            "$id: internal_max_chain_law\n\
+             regulatory_layer: WET\n\
+             publication_date: '2025-01-01'\n\
+             articles:\n",
+        );
+        for i in 0..links {
+            yaml.push_str(&format!(
+                r#"  - number: '{num}'
+    text: Chain link {num}
+    machine_readable:
+      execution:
+        input:
+          - name: from_next
+            type: number
+            source:
+              output: value_{next}
+        output:
+          - name: value_{num}
+            type: number
+        actions:
+          - output: value_{num}
+            value: $from_next
+"#,
+                num = i,
+                next = i + 1
+            ));
+        }
+        yaml.push_str(&format!(
+            r#"  - number: '{links}'
+    text: Chain terminal
+    machine_readable:
+      execution:
+        output:
+          - name: value_{links}
+            type: number
+        actions:
+          - output: value_{links}
+            value: 3
+"#
+        ));
+
+        let mut service = LawExecutionService::new();
+        service.load_law(&yaml).unwrap();
+
+        let result = service
+            .evaluate_law_output(
+                "internal_max_chain_law",
+                "value_0",
+                BTreeMap::new(),
+                "2025-01-01",
+            )
+            .expect("a chain of exactly MAX_CROSS_LAW_DEPTH internal links must resolve");
+        assert_eq!(result.outputs.get("value_0"), Some(&Value::Int(3)));
+    }
+
+    #[test]
+    fn test_service_sibling_cross_law_references_do_not_consume_depth() {
+        // Breadth is not depth. Every sibling reference of one article resolves
+        // at depth one, so leaving a resolution scope has to hand the budget
+        // back; otherwise a wide article trips the recursion guard.
+        let siblings = config::MAX_CROSS_LAW_DEPTH + 5;
+        let mut service = LawExecutionService::new();
+        for i in 0..siblings {
+            service
+                .load_law(&format!(
+                    r#"
+$id: leaf_law_{i}
+regulatory_layer: WET
+publication_date: '2025-01-01'
+articles:
+  - number: '1'
+    text: Leaf {i}
+    machine_readable:
+      execution:
+        output:
+          - name: leaf_value
+            type: number
+        actions:
+          - output: leaf_value
+            value: 1
+"#
+                ))
+                .unwrap();
+        }
+
+        let mut yaml = String::from(
+            "$id: wide_law\n\
+             regulatory_layer: WET\n\
+             publication_date: '2025-01-01'\n\
+             articles:\n  \
+             - number: '1'\n    \
+             text: References many laws side by side\n    \
+             machine_readable:\n      \
+             execution:\n        \
+             input:\n",
+        );
+        for i in 0..siblings {
+            yaml.push_str(&format!(
+                "          - name: leaf_{i}\n            type: number\n            source:\n              regulation: leaf_law_{i}\n              output: leaf_value\n"
+            ));
+        }
+        yaml.push_str(
+            "        output:\n          - name: total\n            type: number\n        actions:\n          - output: total\n            operation: ADD\n            values:\n",
+        );
+        for i in 0..siblings {
+            yaml.push_str(&format!("              - $leaf_{i}\n"));
+        }
+        service.load_law(&yaml).unwrap();
+
+        let result = service
+            .evaluate_law_output("wide_law", "total", BTreeMap::new(), "2025-01-01")
+            .expect("sibling references must not consume the depth budget");
+        assert_eq!(
+            result.outputs.get("total"),
+            Some(&Value::Int(siblings as i64))
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Multi-output evaluation
+    // -------------------------------------------------------------------------
+
+    fn make_two_article_law() -> &'static str {
+        r#"
+$id: two_article_law
+regulatory_layer: WET
+publication_date: '2025-01-01'
+articles:
+  - number: '1'
+    text: Produces the first output
+    machine_readable:
+      execution:
+        output:
+          - name: out_a
+            type: number
+        actions:
+          - output: out_a
+            value: 1
+  - number: '2'
+    text: Produces the second output
+    machine_readable:
+      execution:
+        output:
+          - name: out_b
+            type: number
+        actions:
+          - output: out_b
+            value: 2
+"#
+    }
+
+    #[test]
+    fn test_evaluate_law_reports_every_producing_article() {
+        // Outputs from two articles are merged into one result. The result then
+        // names both articles: a single number would tell the reader the
+        // decision rests on an article that produced only half of it.
+        let mut service = LawExecutionService::new();
+        service.load_law(make_two_article_law()).unwrap();
+
+        let result = service
+            .evaluate_law(
+                "two_article_law",
+                &["out_a", "out_b"],
+                BTreeMap::new(),
+                "2025-01-01",
+            )
+            .unwrap();
+
+        assert_eq!(result.outputs.get("out_a"), Some(&Value::Int(1)));
+        assert_eq!(result.outputs.get("out_b"), Some(&Value::Int(2)));
+        assert_eq!(result.article_number, "1, 2");
+
+        // A single article keeps its own number.
+        let result = service
+            .evaluate_law("two_article_law", &["out_b"], BTreeMap::new(), "2025-01-01")
+            .unwrap();
+        assert_eq!(result.article_number, "2");
+    }
+
+    // -------------------------------------------------------------------------
+    // Lex specialis overrides
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_conflicting_overrides_from_one_law_are_rejected() {
+        // Two articles of the same law both claim to replace the same output.
+        // There is no rule that picks between them, so the engine must refuse
+        // rather than silently apply whichever came first.
+        let target = r#"
+$id: override_target_law
+regulatory_layer: WET
+publication_date: '2025-01-01'
+articles:
+  - number: '1'
+    text: Provides the amount
+    machine_readable:
+      execution:
+        output:
+          - name: bedrag
+            type: number
+        actions:
+          - output: bedrag
+            value: 100
+"#;
+        let specialis = r#"
+$id: override_specialis_law
+regulatory_layer: WET
+publication_date: '2025-01-01'
+articles:
+  - number: '1'
+    text: Uses the amount from the target law
+    machine_readable:
+      execution:
+        input:
+          - name: bedrag
+            type: number
+            source:
+              regulation: override_target_law
+              output: bedrag
+        output:
+          - name: result
+            type: number
+        actions:
+          - output: result
+            value: $bedrag
+  - number: '2'
+    text: In afwijking van het bedrag
+    machine_readable:
+      overrides:
+        - law: override_target_law
+          article: '1'
+          output: bedrag
+      execution:
+        output:
+          - name: bedrag
+            type: number
+        actions:
+          - output: bedrag
+            value: 200
+  - number: '3'
+    text: Eveneens in afwijking van hetzelfde bedrag
+    machine_readable:
+      overrides:
+        - law: override_target_law
+          article: '1'
+          output: bedrag
+      execution:
+        output:
+          - name: bedrag
+            type: number
+        actions:
+          - output: bedrag
+            value: 300
+"#;
+        let mut service = LawExecutionService::new();
+        service.load_law(target).unwrap();
+        service.load_law(specialis).unwrap();
+
+        let result = service.evaluate_law_output(
+            "override_specialis_law",
+            "result",
+            BTreeMap::new(),
+            "2025-01-01",
+        );
+
+        match result {
+            Err(EngineError::InvalidOperation(msg)) => {
+                assert!(
+                    msg.contains("Multiple overrides"),
+                    "Expected a conflicting-overrides error, got: {}",
+                    msg
+                );
+            }
+            other => panic!("Expected conflicting overrides to be rejected, got: {other:?}"),
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Procedure stages (RFC-008)
+    // -------------------------------------------------------------------------
+
+    /// Build a procedure-bearing law: one article producing a TEST_BESCHIKKING
+    /// with `outputs`, governed by a procedure whose stages are given as
+    /// `(stage name, required external inputs)` pairs.
+    fn make_stage_law(law_id: &str, stages: &[(&str, &[&str])], outputs: &[&str]) -> String {
+        let mut yaml = String::new();
+        yaml.push_str(&format!("$id: {law_id}\n"));
+        yaml.push_str("regulatory_layer: WET\n");
+        yaml.push_str("publication_date: '2025-01-01'\n");
+        yaml.push_str("procedure:\n");
+        yaml.push_str("  - id: test_procedure\n");
+        yaml.push_str("    default: true\n");
+        yaml.push_str("    applies_to:\n");
+        yaml.push_str("      legal_character: TEST_BESCHIKKING\n");
+        yaml.push_str("    stages:\n");
+        for (name, requires) in stages {
+            yaml.push_str(&format!("      - name: {name}\n"));
+            if !requires.is_empty() {
+                yaml.push_str("        requires:\n");
+                for req in *requires {
+                    yaml.push_str(&format!("          - name: {req}\n"));
+                    yaml.push_str("            type: string\n");
+                }
+            }
+        }
+        yaml.push_str("articles:\n");
+        yaml.push_str("  - number: '1'\n");
+        yaml.push_str("    text: Neemt een beschikking\n");
+        yaml.push_str("    machine_readable:\n");
+        yaml.push_str("      execution:\n");
+        yaml.push_str("        produces:\n");
+        yaml.push_str("          legal_character: TEST_BESCHIKKING\n");
+        yaml.push_str("        parameters:\n");
+        yaml.push_str("          - name: bedrag\n");
+        yaml.push_str("            type: number\n");
+        yaml.push_str("            required: true\n");
+        yaml.push_str("        output:\n");
+        for out in outputs {
+            yaml.push_str(&format!("          - name: {out}\n"));
+            yaml.push_str("            type: number\n");
+        }
+        yaml.push_str("        actions:\n");
+        for out in outputs {
+            yaml.push_str(&format!("          - output: {out}\n"));
+            yaml.push_str("            value: $bedrag\n");
+        }
+        yaml
+    }
+
+    fn stage_params(pairs: &[(&str, &str)]) -> BTreeMap<String, Value> {
+        let mut params = BTreeMap::new();
+        params.insert("bedrag".to_string(), Value::Int(100));
+        for (name, value) in pairs {
+            params.insert(name.to_string(), Value::String(value.to_string()));
+        }
+        params
+    }
+
+    #[test]
+    fn test_execute_stage_yields_on_a_missing_input_of_the_current_stage() {
+        // The first stage needs an external input the caller did not supply, so
+        // the procedure must stop there and name exactly that input.
+        let law = make_stage_law(
+            "stage_law_yield",
+            &[("AANVRAAG", &["aanvraag_datum"]), ("BESLUIT", &[])],
+            &["toekenning"],
+        );
+        let mut service = LawExecutionService::new();
+        service.load_law(&law).unwrap();
+
+        let outcome = service
+            .execute_stage(
+                "stage_law_yield",
+                "toekenning",
+                None,
+                stage_params(&[]),
+                "2025-01-01",
+            )
+            .unwrap();
+
+        match outcome {
+            ExecutionOutcome::Yielded {
+                state,
+                outputs,
+                pending_inputs,
+            } => {
+                assert_eq!(
+                    state.current_stage, "AANVRAAG",
+                    "execution must halt in the stage whose input is missing"
+                );
+                assert_eq!(state.procedure_id, "test_procedure");
+                assert_eq!(state.contextual_law, "stage_law_yield");
+                assert_eq!(pending_inputs, vec!["aanvraag_datum".to_string()]);
+                assert!(
+                    outputs.is_empty(),
+                    "nothing is decided before the stage has run"
+                );
+            }
+            other => panic!("Expected a yield on the missing stage input, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_execute_stage_runs_the_stage_and_yields_on_the_next_one() {
+        // With the first stage's input supplied, that stage runs and its
+        // outputs travel with the yield for the next stage's missing input.
+        let law = make_stage_law(
+            "stage_law_advance",
+            &[
+                ("AANVRAAG", &["aanvraag_datum"]),
+                ("BESLUIT", &["besluit_datum"]),
+            ],
+            &["toekenning"],
+        );
+        let mut service = LawExecutionService::new();
+        service.load_law(&law).unwrap();
+
+        let outcome = service
+            .execute_stage(
+                "stage_law_advance",
+                "toekenning",
+                None,
+                stage_params(&[("aanvraag_datum", "2025-01-05")]),
+                "2025-01-01",
+            )
+            .unwrap();
+
+        match outcome {
+            ExecutionOutcome::Yielded {
+                state,
+                outputs,
+                pending_inputs,
+            } => {
+                assert_eq!(
+                    state.current_stage, "BESLUIT",
+                    "the first stage ran, so the state moved on"
+                );
+                assert_eq!(pending_inputs, vec!["besluit_datum".to_string()]);
+                assert_eq!(
+                    outputs.get("toekenning"),
+                    Some(&Value::Int(100)),
+                    "the completed stage's outputs travel with the yield"
+                );
+            }
+            other => panic!("Expected a yield awaiting the next stage's input, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_execute_stage_next_stage_input_from_an_earlier_stage_output() {
+        // A stage may require what an earlier stage produced. That value is in
+        // the accumulated outputs, so the procedure runs on to the end instead
+        // of asking the caller for it.
+        let law = make_stage_law(
+            "stage_law_accumulated",
+            &[
+                ("AANVRAAG", &["aanvraag_datum"]),
+                ("BESLUIT", &["beschikking_nummer"]),
+            ],
+            &["toekenning", "beschikking_nummer"],
+        );
+        let mut service = LawExecutionService::new();
+        service.load_law(&law).unwrap();
+
+        let outcome = service
+            .execute_stage(
+                "stage_law_accumulated",
+                "toekenning",
+                None,
+                stage_params(&[("aanvraag_datum", "2025-01-05")]),
+                "2025-01-01",
+            )
+            .unwrap();
+
+        match outcome {
+            ExecutionOutcome::Complete(result) => {
+                assert_eq!(result.outputs.get("toekenning"), Some(&Value::Int(100)));
+                assert_eq!(
+                    result.outputs.get("beschikking_nummer"),
+                    Some(&Value::Int(100)),
+                    "the final result carries the outputs of every stage"
+                );
+            }
+            other => panic!("Expected the procedure to run to completion, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_execute_stage_resume_asks_only_for_what_is_still_missing() {
+        // An input supplied with the first call stays available across the
+        // yield: on resuming, the engine asks only for what it does not have.
+        let law = make_stage_law(
+            "stage_law_resume",
+            &[
+                ("AANVRAAG", &["aanvraag_datum"]),
+                ("BESLUIT", &["besluit_datum"]),
+                ("BEKENDMAKING", &["zienswijze", "bekendmaking_datum"]),
+            ],
+            &["toekenning"],
+        );
+        let mut service = LawExecutionService::new();
+        service.load_law(&law).unwrap();
+
+        let first = service
+            .execute_stage(
+                "stage_law_resume",
+                "toekenning",
+                None,
+                stage_params(&[("aanvraag_datum", "2025-01-05"), ("zienswijze", "geen")]),
+                "2025-01-01",
+            )
+            .unwrap();
+
+        let state = match first {
+            ExecutionOutcome::Yielded {
+                state,
+                pending_inputs,
+                ..
+            } => {
+                assert_eq!(state.current_stage, "BESLUIT");
+                assert_eq!(pending_inputs, vec!["besluit_datum".to_string()]);
+                state
+            }
+            other => panic!("Expected a yield awaiting besluit_datum, got: {other:?}"),
+        };
+
+        let mut resume = BTreeMap::new();
+        resume.insert(
+            "besluit_datum".to_string(),
+            Value::String("2025-02-01".to_string()),
+        );
+
+        let second = service
+            .execute_stage(
+                "stage_law_resume",
+                "toekenning",
+                Some(state),
+                resume,
+                "2025-01-01",
+            )
+            .unwrap();
+
+        match second {
+            ExecutionOutcome::Yielded {
+                state,
+                pending_inputs,
+                ..
+            } => {
+                assert_eq!(state.current_stage, "BEKENDMAKING");
+                assert_eq!(
+                    pending_inputs,
+                    vec!["bekendmaking_datum".to_string()],
+                    "zienswijze was supplied on the first call and must not be asked again"
+                );
+            }
+            other => panic!("Expected a yield awaiting bekendmaking_datum, got: {other:?}"),
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Law loading, provenance and inventory
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_load_law_with_source_records_provenance() {
+        let mut service = LawExecutionService::new();
+
+        let law_id = service
+            .load_law_with_source(make_base_law(), "bwb-corpus", "BWB corpus")
+            .unwrap();
+        assert_eq!(law_id, "base_law");
+
+        assert_eq!(
+            service.get_law_source("base_law"),
+            Some(("bwb-corpus", "BWB corpus")),
+            "a receipt must be able to name where a law came from"
+        );
+        assert_eq!(
+            service.get_law_source("unknown_law"),
+            None,
+            "an unknown law has no provenance"
+        );
+
+        // A law loaded without provenance keeps none.
+        service.load_law(make_dependent_law()).unwrap();
+        assert_eq!(service.get_law_source("dependent_law"), None);
+    }
+
+    #[test]
+    fn test_law_inventory_and_unloading() {
+        let mut service = LawExecutionService::new();
+        assert_eq!(service.law_count(), 0);
+        assert!(!service.has_law("base_law"));
+
+        service.load_law(make_base_law()).unwrap();
+        service.load_law(make_dependent_law()).unwrap();
+        assert_eq!(service.law_count(), 2);
+        assert!(service.has_law("base_law"));
+        assert!(service.has_law("dependent_law"));
+        assert!(!service.has_law("unknown_law"));
+
+        assert!(
+            service.unload_law("base_law"),
+            "unloading a loaded law reports success"
+        );
+        assert_eq!(service.law_count(), 1);
+        assert!(!service.has_law("base_law"));
+        assert!(
+            !service.unload_law("base_law"),
+            "unloading a law that is not there reports failure"
+        );
+    }
+
+    #[test]
+    fn test_resolver_exposes_the_loaded_laws() {
+        let mut service = LawExecutionService::new();
+        service.load_law(make_base_law()).unwrap();
+
+        let resolver = service.resolver();
+        assert!(
+            resolver.has_law("base_law"),
+            "the exposed resolver must be the service's own, not an empty one"
+        );
+        assert_eq!(resolver.law_count(), 1);
+    }
+
+    // -------------------------------------------------------------------------
+    // Data source management
+    // -------------------------------------------------------------------------
+
+    fn dict_record(field: &str, value: i64) -> BTreeMap<String, BTreeMap<String, Value>> {
+        let mut fields = BTreeMap::new();
+        fields.insert(field.to_string(), Value::Int(value));
+        let mut data = BTreeMap::new();
+        data.insert("123".to_string(), fields);
+        data
+    }
+
+    #[test]
+    fn test_data_source_registration_and_removal() {
+        let mut service = LawExecutionService::new();
+        assert_eq!(service.data_source_count(), 0);
+        assert!(service.list_data_sources().is_empty());
+
+        service.add_dict_source("hoge_prioriteit", 10, dict_record("inkomen", 1));
+        assert_eq!(service.data_source_count(), 1);
+        assert_eq!(service.list_data_sources(), vec!["hoge_prioriteit"]);
+
+        service.add_data_source(Box::new(DictDataSource::new(
+            "lage_prioriteit",
+            5,
+            dict_record("vermogen", 2),
+        )));
+        assert_eq!(service.data_source_count(), 2);
+        assert_eq!(
+            service.list_data_sources(),
+            vec!["hoge_prioriteit", "lage_prioriteit"],
+            "sources are ordered by priority, highest first"
+        );
+        assert_eq!(
+            service.data_registry().source_count(),
+            2,
+            "the exposed registry must be the service's own, not an empty one"
+        );
+
+        assert!(service.remove_data_source("lage_prioriteit"));
+        assert_eq!(service.list_data_sources(), vec!["hoge_prioriteit"]);
+        assert!(
+            !service.remove_data_source("lage_prioriteit"),
+            "removing a source that is not there reports failure"
+        );
+
+        service.clear_data_sources();
+        assert_eq!(service.data_source_count(), 0);
+        assert!(service.list_data_sources().is_empty());
+    }
+
+    // -------------------------------------------------------------------------
+    // ServiceProvider trait surface
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_service_provider_get_law() {
+        let mut service = LawExecutionService::new();
+        service.load_law(make_base_law()).unwrap();
+
+        let law = ServiceProvider::get_law(&service, "base_law")
+            .expect("a loaded law must be reachable through the trait");
+        assert_eq!(law.id, "base_law");
+        assert!(ServiceProvider::get_law(&service, "unknown_law").is_none());
+    }
+
+    #[test]
+    fn test_service_provider_resolve_external_input() {
+        let mut service = LawExecutionService::new();
+        service.load_law(make_base_law()).unwrap();
+
+        let context = RuleContext::new(BTreeMap::new(), "2025-01-01").unwrap();
+        let value = service
+            .resolve_external_input("base_law", "base_value", None, &context, "2025-01-01")
+            .expect("the referenced law must be executed");
+
+        assert_eq!(value, Value::Int(100));
     }
 }


### PR DESCRIPTION
104 overlevers uit #1052: `service.rs`, `resolver.rs` en `context.rs`. Nieuw afgedekt in de servicelaag zijn onder meer de cachesleutel en de identiteitscontrole daarop, de dieptelimiet op zijn grens, een cyclus die als cyclus gemeld wordt en niet als opgebruikt dieptebudget, conflicterende lex-specialis-overrides en de procedurestadia van RFC-008. In de resolver: dat laden en lossen alleen de eigen indexregels raakt, dat een verordening alleen binnen het eigen gebied geldt, en dat de bovengrens op het aantal geladen wetten een nieuwe versie blokkeert maar niet het vervangen van een bestaande.

Drie ingrepen in de productiecode, alle drie gedragsbehoudend. De identiteitscontrole van een cache-entry staat nu in `CacheEntry::matches`. De guard `source_count() > 0` is weg, omdat `resolve()` over nul bronnen al `None` geeft. En `get_property` heeft één `deeper` in plaats van twee losse `depth + 1`; dat leverde twee mutanten met dezelfde omschrijving op waarvan er één niet te doden is, want de `first`-tak stopt altijd meteen. Eén uitsluiting had ze allebei stilgezet.