### PR TITLE
test(engine): dek de evaluatiekern af

### DIFF
--- a/packages/engine/src/article.rs
+++ b/packages/engine/src/article.rs
@@ -1118,4 +1118,272 @@ articles:
             );
         }
     }
+
+    /// The size limits are inclusive: a document that is exactly at the limit
+    /// still loads, one element or byte over it is refused. Every test here
+    /// pins both sides of that boundary, because a limit that silently rejects
+    /// a legitimate law is as much a defect as one that lets a YAML bomb past.
+    mod limits {
+        use super::*;
+        use std::io::Write;
+
+        const HEADER: &str =
+            "$id: limits_test\nregulatory_layer: WET\npublication_date: '2025-01-01'\n";
+
+        /// A law with `count` articles and nothing else.
+        fn law_with_articles(count: usize) -> String {
+            let mut yaml = String::from(HEADER);
+            yaml.push_str("articles:\n");
+            for i in 0..count {
+                yaml.push_str(&format!("  - number: '{i}'\n    text: Artikel\n"));
+            }
+            yaml
+        }
+
+        /// A law with a single article whose `machine_readable` section is
+        /// `body` (indented six spaces, i.e. one level under `machine_readable:`).
+        fn law_with_machine_readable(body: &str) -> String {
+            format!(
+                "{HEADER}articles:\n  - number: '1'\n    text: Artikel\n    machine_readable:\n{body}"
+            )
+        }
+
+        fn law_with_open_terms(count: usize) -> String {
+            let mut body = String::from("      open_terms:\n");
+            for i in 0..count {
+                body.push_str(&format!("        - id: term_{i}\n          type: amount\n"));
+            }
+            law_with_machine_readable(&body)
+        }
+
+        fn law_with_implements(count: usize) -> String {
+            let mut body = String::from("      implements:\n");
+            for i in 0..count {
+                body.push_str(&format!(
+                    "        - law: andere_wet\n          article: '1'\n          open_term: term_{i}\n"
+                ));
+            }
+            law_with_machine_readable(&body)
+        }
+
+        fn law_with_parameters(count: usize) -> String {
+            let mut body = String::from("      execution:\n        parameters:\n");
+            for i in 0..count {
+                body.push_str(&format!(
+                    "          - name: parameter_{i}\n            type: number\n"
+                ));
+            }
+            law_with_machine_readable(&body)
+        }
+
+        fn law_with_inputs(count: usize) -> String {
+            let mut body = String::from("      execution:\n        input:\n");
+            for i in 0..count {
+                body.push_str(&format!(
+                    "          - name: invoer_{i}\n            type: number\n"
+                ));
+            }
+            law_with_machine_readable(&body)
+        }
+
+        fn law_with_outputs(count: usize) -> String {
+            let mut body = String::from("      execution:\n        output:\n");
+            for i in 0..count {
+                body.push_str(&format!(
+                    "          - name: uitvoer_{i}\n            type: number\n"
+                ));
+            }
+            law_with_machine_readable(&body)
+        }
+
+        fn law_with_actions(count: usize) -> String {
+            let mut body = String::from("      execution:\n        actions:\n");
+            for i in 0..count {
+                body.push_str(&format!(
+                    "          - output: uitvoer_{i}\n            value: 0\n"
+                ));
+            }
+            law_with_machine_readable(&body)
+        }
+
+        fn law_with_action_values(count: usize) -> String {
+            let mut body = String::from(
+                "      execution:\n        actions:\n          - output: resultaat\n            operation: ADD\n            values:\n",
+            );
+            for _ in 0..count {
+                body.push_str("              - 0\n");
+            }
+            law_with_machine_readable(&body)
+        }
+
+        fn law_with_action_conditions(count: usize) -> String {
+            let mut body = String::from(
+                "      execution:\n        actions:\n          - output: resultaat\n            operation: AND\n            conditions:\n",
+            );
+            for _ in 0..count {
+                body.push_str("              - true\n");
+            }
+            law_with_machine_readable(&body)
+        }
+
+        /// Assert that `yaml` is refused with a message mentioning `fragment`.
+        fn assert_rejected(yaml: &str, fragment: &str) {
+            let err = ArticleBasedLaw::from_yaml_str(yaml)
+                .expect_err("law over the array limit should be refused");
+            let message = err.to_string();
+            assert!(
+                message.contains(fragment),
+                "error should mention '{fragment}', got: {message}"
+            );
+        }
+
+        /// Assert that `yaml` loads.
+        fn assert_accepted(yaml: &str) {
+            ArticleBasedLaw::from_yaml_str(yaml)
+                .unwrap_or_else(|e| panic!("law exactly at the array limit should load: {e}"));
+        }
+
+        #[test]
+        fn test_articles_at_and_over_limit() {
+            assert_accepted(&law_with_articles(config::MAX_ARRAY_SIZE));
+            assert_rejected(
+                &law_with_articles(config::MAX_ARRAY_SIZE + 1),
+                "Too many articles",
+            );
+        }
+
+        #[test]
+        fn test_open_terms_at_and_over_limit() {
+            assert_accepted(&law_with_open_terms(config::MAX_ARRAY_SIZE));
+            assert_rejected(
+                &law_with_open_terms(config::MAX_ARRAY_SIZE + 1),
+                "Too many open_terms",
+            );
+        }
+
+        #[test]
+        fn test_implements_at_and_over_limit() {
+            assert_accepted(&law_with_implements(config::MAX_ARRAY_SIZE));
+            assert_rejected(
+                &law_with_implements(config::MAX_ARRAY_SIZE + 1),
+                "Too many implements",
+            );
+        }
+
+        #[test]
+        fn test_parameters_at_and_over_limit() {
+            assert_accepted(&law_with_parameters(config::MAX_ARRAY_SIZE));
+            assert_rejected(
+                &law_with_parameters(config::MAX_ARRAY_SIZE + 1),
+                "Too many parameters",
+            );
+        }
+
+        #[test]
+        fn test_inputs_at_and_over_limit() {
+            assert_accepted(&law_with_inputs(config::MAX_ARRAY_SIZE));
+            assert_rejected(
+                &law_with_inputs(config::MAX_ARRAY_SIZE + 1),
+                "Too many inputs",
+            );
+        }
+
+        #[test]
+        fn test_outputs_at_and_over_limit() {
+            assert_accepted(&law_with_outputs(config::MAX_ARRAY_SIZE));
+            assert_rejected(
+                &law_with_outputs(config::MAX_ARRAY_SIZE + 1),
+                "Too many outputs",
+            );
+        }
+
+        #[test]
+        fn test_actions_at_and_over_limit() {
+            assert_accepted(&law_with_actions(config::MAX_ARRAY_SIZE));
+            assert_rejected(
+                &law_with_actions(config::MAX_ARRAY_SIZE + 1),
+                "Too many actions",
+            );
+        }
+
+        #[test]
+        fn test_action_values_at_and_over_limit() {
+            assert_accepted(&law_with_action_values(config::MAX_ARRAY_SIZE));
+            assert_rejected(
+                &law_with_action_values(config::MAX_ARRAY_SIZE + 1),
+                "Too many values in action",
+            );
+        }
+
+        #[test]
+        fn test_action_conditions_at_and_over_limit() {
+            assert_accepted(&law_with_action_conditions(config::MAX_ARRAY_SIZE));
+            assert_rejected(
+                &law_with_action_conditions(config::MAX_ARRAY_SIZE + 1),
+                "Too many conditions in action",
+            );
+        }
+
+        /// A valid law padded with a trailing YAML comment to exactly `size` bytes.
+        fn law_of_exact_size(size: usize) -> String {
+            let base = format!("{HEADER}articles: []\n# ");
+            assert!(size > base.len(), "padding target must exceed the header");
+            let mut yaml = String::with_capacity(size);
+            yaml.push_str(&base);
+            yaml.push_str(&"x".repeat(size - base.len()));
+            debug_assert_eq!(yaml.len(), size);
+            yaml
+        }
+
+        #[test]
+        fn test_yaml_string_exactly_at_size_limit_is_accepted() {
+            let yaml = law_of_exact_size(config::MAX_YAML_SIZE);
+            assert_eq!(yaml.len(), config::MAX_YAML_SIZE);
+            let law = ArticleBasedLaw::from_yaml_str(&yaml)
+                .unwrap_or_else(|e| panic!("YAML exactly at MAX_YAML_SIZE should load: {e}"));
+            assert_eq!(law.id, "limits_test");
+        }
+
+        /// Write `content` to a uniquely named file under `OUT_DIR` (writable,
+        /// inside the build directory) and return the path.
+        fn write_temp_law(name: &str, content: &str) -> std::path::PathBuf {
+            let path = std::path::PathBuf::from(env!("OUT_DIR")).join(name);
+            let mut file = std::fs::File::create(&path).expect("should create temp law file");
+            file.write_all(content.as_bytes())
+                .expect("should write temp law file");
+            file.flush().expect("should flush temp law file");
+            path
+        }
+
+        #[test]
+        fn test_file_exactly_at_size_limit_is_accepted() {
+            let yaml = law_of_exact_size(config::MAX_YAML_SIZE);
+            let path = write_temp_law("law_at_size_limit.yaml", &yaml);
+
+            let law = ArticleBasedLaw::from_yaml_file(&path)
+                .unwrap_or_else(|e| panic!("file exactly at MAX_YAML_SIZE should load: {e}"));
+            assert_eq!(law.id, "limits_test");
+
+            let _ = std::fs::remove_file(&path);
+        }
+
+        #[test]
+        fn test_file_one_byte_over_size_limit_is_refused() {
+            let yaml = law_of_exact_size(config::MAX_YAML_SIZE + 1);
+            let path = write_temp_law("law_over_size_limit.yaml", &yaml);
+
+            let err = ArticleBasedLaw::from_yaml_file(&path)
+                .expect_err("file over MAX_YAML_SIZE should be refused");
+            let message = err.to_string();
+
+            let _ = std::fs::remove_file(&path);
+
+            // The file-size check must fire before the file is read, so the
+            // message is the file one, not the parsed-content one.
+            assert!(
+                message.contains("File exceeds maximum size limit"),
+                "size check should reject before reading, got: {message}"
+            );
+        }
+    }
 }

--- a/packages/engine/src/operations.rs
+++ b/packages/engine/src/operations.rs
@@ -1836,6 +1836,23 @@ mod tests {
             let result = execute_operation(&op, &resolver, 0).unwrap();
             assert_eq!(result, Value::String("hello world".to_string()));
         }
+
+        #[test]
+        fn test_add_propagates_an_untranslatable_operand() {
+            // RFC-012: a sum in which one term could not be translated has no
+            // number as its answer. The taint travels on as a value; it is not a
+            // type error and not a silent zero.
+            let tainted = Value::Untranslatable {
+                article: "12".to_string(),
+                construct: "naar redelijkheid".to_string(),
+            };
+            let resolver = TestResolver::new().with_var("onvertaalbaar", tainted.clone());
+            let op = ActionOperation::Add {
+                values: vec![lit(100i64), var("onvertaalbaar"), lit(1i64)],
+            };
+
+            assert_eq!(execute_operation(&op, &resolver, 0).unwrap(), tainted);
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -1887,6 +1904,23 @@ mod tests {
 
             let result = execute_operation(&op, &resolver, 0).unwrap();
             assert_eq!(result, Value::Int(0));
+        }
+
+        #[test]
+        fn test_max_propagates_an_untranslatable_operand() {
+            // RFC-012: the highest of a set that contains an untranslatable is
+            // itself untranslatable — picking the largest of the rest would
+            // silently drop the value that could not be determined.
+            let tainted = Value::Untranslatable {
+                article: "12".to_string(),
+                construct: "naar redelijkheid".to_string(),
+            };
+            let resolver = TestResolver::new().with_var("onvertaalbaar", tainted.clone());
+            let op = ActionOperation::Max {
+                values: vec![lit(10i64), var("onvertaalbaar")],
+            };
+
+            assert_eq!(execute_operation(&op, &resolver, 0).unwrap(), tainted);
         }
     }
 
@@ -2135,6 +2169,98 @@ mod tests {
             let result2 = execute_operation(&op2, &resolver, 0).unwrap();
             assert_eq!(result2, Value::Bool(true));
         }
+
+        /// Build an Untranslatable value for the taint tests.
+        fn untranslatable(article: &str) -> Value {
+            Value::Untranslatable {
+                article: article.to_string(),
+                construct: "open norm".to_string(),
+            }
+        }
+
+        /// The article an untranslatable result points at. Asserted explicitly
+        /// because `Value`'s equality treats *any* two untranslatables as equal,
+        /// so `assert_eq!` alone would not see which one came back.
+        fn untranslatable_article(value: &Value) -> &str {
+            match value {
+                Value::Untranslatable { article, .. } => article,
+                other => panic!("expected an untranslatable value, got {:?}", other),
+            }
+        }
+
+        #[test]
+        fn test_and_reports_the_first_untranslatable_condition() {
+            // RFC-012: when nothing is definitively false, AND hands back the
+            // taint. Which one matters for the explanation shown to the citizen:
+            // the first untranslatable condition is the one that blocked the
+            // evaluation, so its article is the one that gets reported.
+            let resolver = TestResolver::new()
+                .with_var("eerste", untranslatable("5"))
+                .with_var("tweede", untranslatable("9"));
+            let op = ActionOperation::And {
+                conditions: vec![lit(true), var("eerste"), var("tweede")],
+            };
+
+            let result = execute_operation(&op, &resolver, 0).unwrap();
+            assert_eq!(untranslatable_article(&result), "5");
+        }
+
+        #[test]
+        fn test_and_definitive_false_beats_a_taint() {
+            // A condition that is certainly false decides the whole AND, whatever
+            // order it appears in — an untranslatable elsewhere cannot revive it.
+            let resolver = TestResolver::new().with_var("onvertaalbaar", untranslatable("5"));
+            let op = ActionOperation::And {
+                conditions: vec![var("onvertaalbaar"), lit(false)],
+            };
+
+            assert_eq!(
+                execute_operation(&op, &resolver, 0).unwrap(),
+                Value::Bool(false)
+            );
+        }
+
+        #[test]
+        fn test_or_propagates_a_taint_over_a_plain_false() {
+            // A false condition does not settle an OR: as long as another
+            // condition could not be evaluated, the outcome is untranslatable
+            // rather than a hard "no".
+            let resolver = TestResolver::new().with_var("onvertaalbaar", untranslatable("7"));
+            let op = ActionOperation::Or {
+                conditions: vec![lit(false), var("onvertaalbaar")],
+            };
+
+            let result = execute_operation(&op, &resolver, 0).unwrap();
+            assert_eq!(untranslatable_article(&result), "7");
+        }
+
+        #[test]
+        fn test_or_reports_the_first_untranslatable_condition() {
+            // Same provenance rule as AND: the explanation points at the first
+            // condition that could not be evaluated, not at the last one seen.
+            let resolver = TestResolver::new()
+                .with_var("eerste", untranslatable("5"))
+                .with_var("tweede", untranslatable("9"));
+            let op = ActionOperation::Or {
+                conditions: vec![lit(false), var("eerste"), var("tweede")],
+            };
+
+            let result = execute_operation(&op, &resolver, 0).unwrap();
+            assert_eq!(untranslatable_article(&result), "5");
+        }
+
+        #[test]
+        fn test_or_definitive_true_beats_a_taint() {
+            let resolver = TestResolver::new().with_var("onvertaalbaar", untranslatable("7"));
+            let op = ActionOperation::Or {
+                conditions: vec![var("onvertaalbaar"), lit(true)],
+            };
+
+            assert_eq!(
+                execute_operation(&op, &resolver, 0).unwrap(),
+                Value::Bool(true)
+            );
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -2382,6 +2508,51 @@ mod tests {
         }
 
         #[test]
+        fn test_depth_guard_allows_the_maximum_depth() {
+            // The guard rejects nesting *deeper* than MAX_OPERATION_DEPTH, so a
+            // law that nests exactly that deep still evaluates. Pinning the
+            // boundary keeps the limit from silently shifting by one.
+            let resolver = TestResolver::new();
+
+            assert_eq!(
+                evaluate_value(&lit(42i64), &resolver, MAX_OPERATION_DEPTH).unwrap(),
+                Value::Int(42)
+            );
+
+            let op = ActionOperation::List { items: vec![] };
+            assert_eq!(
+                execute_operation(&op, &resolver, MAX_OPERATION_DEPTH).unwrap(),
+                Value::Array(vec![])
+            );
+        }
+
+        #[test]
+        fn test_depth_guard_rejects_beyond_the_maximum_depth() {
+            // One step past the limit is refused, and so is anything deeper —
+            // the guard is a threshold, not an equality check on one depth.
+            let resolver = TestResolver::new();
+
+            for depth in [MAX_OPERATION_DEPTH + 1, MAX_OPERATION_DEPTH + 2] {
+                assert!(
+                    matches!(
+                        evaluate_value(&lit(42i64), &resolver, depth),
+                        Err(EngineError::MaxDepthExceeded(_))
+                    ),
+                    "evaluate_value accepted depth {depth}"
+                );
+
+                let op = ActionOperation::List { items: vec![] };
+                assert!(
+                    matches!(
+                        execute_operation(&op, &resolver, depth),
+                        Err(EngineError::MaxDepthExceeded(_))
+                    ),
+                    "execute_operation accepted depth {depth}"
+                );
+            }
+        }
+
+        #[test]
         fn test_decimal_to_i64_safe_rejects_non_integer() {
             // A fractional value is "not an integer" (InvalidOperation), not an overflow.
             assert!(matches!(
@@ -2402,6 +2573,26 @@ mod tests {
                 &Value::Decimal(dec!(1.5))
             ));
             assert!(!values_equal(&Value::Decimal(dec!(42.5)), &Value::Int(42)));
+        }
+
+        #[test]
+        fn test_values_equal_untranslatable() {
+            // RFC-012: untranslatables compare like NaN in this domain. Two of
+            // them count as equal (both are "could not be determined"), and one
+            // never equals a concrete value — so a membership test against a
+            // list can never accidentally match on a taint.
+            let unknown = Value::Untranslatable {
+                article: "5".to_string(),
+                construct: "naar het oordeel van".to_string(),
+            };
+            let other_unknown = Value::Untranslatable {
+                article: "9".to_string(),
+                construct: "in redelijkheid".to_string(),
+            };
+
+            assert!(values_equal(&unknown, &other_unknown));
+            assert!(!values_equal(&unknown, &Value::Int(42)));
+            assert!(!values_equal(&Value::String("ja".to_string()), &unknown));
         }
 
         #[test]
@@ -2506,6 +2697,34 @@ mod tests {
         }
 
         #[test]
+        fn test_not_in_true_when_absent() {
+            // NOT_IN is the complement of IN: absent subject → true.
+            let resolver = TestResolver::new();
+            let op = ActionOperation::NotIn {
+                subject: lit("student"),
+                value: None,
+                values: Some(vec![lit("gehuwd"), lit("samenwonend")]),
+            };
+
+            let result = execute_operation(&op, &resolver, 0).unwrap();
+            assert_eq!(result, Value::Bool(true));
+        }
+
+        #[test]
+        fn test_not_in_false_when_present() {
+            // The exclusion fires: a subject that IS in the list is not "not in" it.
+            let resolver = TestResolver::new();
+            let op = ActionOperation::NotIn {
+                subject: lit("gehuwd"),
+                value: None,
+                values: Some(vec![lit("gehuwd"), lit("samenwonend")]),
+            };
+
+            let result = execute_operation(&op, &resolver, 0).unwrap();
+            assert_eq!(result, Value::Bool(false));
+        }
+
+        #[test]
         fn test_list_construct() {
             let resolver = TestResolver::new();
             let op = ActionOperation::List {
@@ -2535,6 +2754,82 @@ mod tests {
                     Value::Bool(true),
                 ])
             );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Null Checking Tests (IS_NULL / NOT_NULL)
+    // -------------------------------------------------------------------------
+
+    mod null_checks {
+        use super::*;
+
+        #[test]
+        fn test_is_null_on_missing_value() {
+            // A parameter that resolves to Null: "niet opgegeven" is true.
+            let resolver = TestResolver::new().with_var("inkomen", Value::Null);
+            let op = ActionOperation::IsNull {
+                subject: var("inkomen"),
+            };
+
+            assert_eq!(
+                execute_operation(&op, &resolver, 0).unwrap(),
+                Value::Bool(true)
+            );
+        }
+
+        #[test]
+        fn test_is_null_false_on_present_value() {
+            // Zero is a value, not a missing value: IS_NULL must not confuse the two.
+            let resolver = TestResolver::new().with_var("inkomen", 0i64);
+            let op = ActionOperation::IsNull {
+                subject: var("inkomen"),
+            };
+
+            assert_eq!(
+                execute_operation(&op, &resolver, 0).unwrap(),
+                Value::Bool(false)
+            );
+        }
+
+        #[test]
+        fn test_not_null_is_the_complement() {
+            // NOT_NULL answers the opposite question on the same two inputs.
+            let resolver = TestResolver::new()
+                .with_var("leeg", Value::Null)
+                .with_var("gevuld", 0i64);
+
+            let on_null = ActionOperation::NotNull {
+                subject: var("leeg"),
+            };
+            assert_eq!(
+                execute_operation(&on_null, &resolver, 0).unwrap(),
+                Value::Bool(false)
+            );
+
+            let on_value = ActionOperation::NotNull {
+                subject: var("gevuld"),
+            };
+            assert_eq!(
+                execute_operation(&on_value, &resolver, 0).unwrap(),
+                Value::Bool(true)
+            );
+        }
+
+        #[test]
+        fn test_null_check_propagates_untranslatable() {
+            // RFC-012: an untranslatable subject is neither null nor not-null;
+            // the taint flows through instead of collapsing to a boolean.
+            let tainted = Value::Untranslatable {
+                article: "3".to_string(),
+                construct: "naar het oordeel van".to_string(),
+            };
+            let resolver = TestResolver::new().with_var("onvertaalbaar", tainted.clone());
+            let op = ActionOperation::IsNull {
+                subject: var("onvertaalbaar"),
+            };
+
+            assert_eq!(execute_operation(&op, &resolver, 0).unwrap(), tainted);
         }
     }
 
@@ -3319,6 +3614,70 @@ mod tests {
         }
 
         #[test]
+        fn test_diff_in_months_counts_only_complete_months() {
+            // 15 January → 10 April is two whole months plus a bit: the day of
+            // the month has not been reached again, so the third month does not
+            // count. Termijnen in maanden lopen tot dezelfde dag in de maand.
+            let resolver = TestResolver::new();
+            let op = ActionOperation::DateDiff {
+                from: lit("2025-01-15"),
+                to: lit("2025-04-10"),
+                unit: lit("months"),
+            };
+            assert_eq!(execute_operation(&op, &resolver, 0).unwrap(), Value::Int(2));
+        }
+
+        #[test]
+        fn test_diff_in_months_spans_calendar_years() {
+            // Months keep counting across the year boundary: 2 years and 3
+            // months is 27 months, not 3.
+            let resolver = TestResolver::new();
+            let op = ActionOperation::DateDiff {
+                from: lit("2023-01-01"),
+                to: lit("2025-04-01"),
+                unit: lit("months"),
+            };
+            assert_eq!(
+                execute_operation(&op, &resolver, 0).unwrap(),
+                Value::Int(27)
+            );
+        }
+
+        #[test]
+        fn test_diff_in_years_february_start_is_not_treated_as_feb29() {
+            // The Feb-29 rule is for Feb 29 only. A 10 February start reaches its
+            // anniversary on 10 February, so 15 February is past it: 25 whole
+            // years, not 24.
+            let resolver = TestResolver::new();
+            let op = ActionOperation::DateDiff {
+                from: lit("2000-02-10"),
+                to: lit("2025-02-15"),
+                unit: lit("years"),
+            };
+            assert_eq!(
+                execute_operation(&op, &resolver, 0).unwrap(),
+                Value::Int(25)
+            );
+        }
+
+        #[test]
+        fn test_diff_in_years_feb29_anniversary_falls_on_feb29_in_a_leap_year() {
+            // The fallback to 28 February exists only for years that have no 29
+            // February. 2024 has one, so on 28 February 2024 the anniversary has
+            // not been reached yet: 23 whole years.
+            let resolver = TestResolver::new();
+            let op = ActionOperation::DateDiff {
+                from: lit("2000-02-29"),
+                to: lit("2024-02-28"),
+                unit: lit("years"),
+            };
+            assert_eq!(
+                execute_operation(&op, &resolver, 0).unwrap(),
+                Value::Int(23)
+            );
+        }
+
+        #[test]
         fn test_diff_with_variables() {
             let resolver = TestResolver::new()
                 .with_var("start", "2025-01-01")
@@ -3540,6 +3899,50 @@ mod tests {
             assert_eq!(
                 execute_operation(&lt, &resolver, 0).unwrap(),
                 Value::Bool(false)
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Tracing opt-in Tests
+    // -------------------------------------------------------------------------
+
+    mod tracing {
+        use super::*;
+        use std::cell::RefCell;
+
+        /// A resolver that offers a trace hook but never switches tracing on:
+        /// it keeps `has_trace` at the trait's default.
+        #[derive(Default)]
+        struct RecordingResolver {
+            pushed: RefCell<Vec<String>>,
+        }
+
+        impl ValueResolver for RecordingResolver {
+            fn resolve(&self, name: &str) -> Result<Value> {
+                Err(EngineError::VariableNotFound(name.to_string()))
+            }
+
+            fn trace_push(&self, name: &str, _node_type: PathNodeType) {
+                self.pushed.borrow_mut().push(name.to_string());
+            }
+        }
+
+        #[test]
+        fn test_no_tracing_unless_the_resolver_opts_in() {
+            // Tracing is opt-in: a resolver that implements the hooks but leaves
+            // `has_trace` at its default gets none of the trace bookkeeping, and
+            // the operation result is the same either way.
+            let resolver = RecordingResolver::default();
+            let op = ActionOperation::Add {
+                values: vec![lit(1i64), lit(2i64)],
+            };
+
+            assert_eq!(execute_operation(&op, &resolver, 0).unwrap(), Value::Int(3));
+            assert!(
+                resolver.pushed.borrow().is_empty(),
+                "expected no trace nodes, got {:?}",
+                resolver.pushed.borrow()
             );
         }
     }

--- a/packages/engine/src/operations.rs
+++ b/packages/engine/src/operations.rs
@@ -1390,10 +1390,15 @@ fn parse_iso_date(s: &str) -> Result<NaiveDate> {
 ///
 /// Used by DATE_DIFF with `in: months`.
 fn calculate_months_difference(date1: NaiveDate, date2: NaiveDate) -> i64 {
-    let (earlier, later, sign) = if date1 >= date2 {
-        (date2, date1, 1)
+    // Het teken als tak in plaats van als vermenigvuldiging: `total * sign` met
+    // sign in {1, -1} levert een mutant op die per constructie hetzelfde
+    // antwoord geeft (delen door -1 is vermenigvuldigen met -1), en die mutant
+    // deelt zijn omschrijving met `years_diff * 12` een paar regels lager. Eén
+    // uitsluiting zou daarmee ook echte rekenkunde stilzwijgend afdekken.
+    let (earlier, later, negate) = if date1 >= date2 {
+        (date2, date1, false)
     } else {
-        (date1, date2, -1)
+        (date1, date2, true)
     };
 
     let years_diff = later.year() - earlier.year();
@@ -1410,7 +1415,12 @@ fn calculate_months_difference(date1: NaiveDate, date2: NaiveDate) -> i64 {
         total_months -= 1;
     }
 
-    (total_months as i64) * sign
+    let total = total_months as i64;
+    if negate {
+        -total
+    } else {
+        total
+    }
 }
 
 /// Return the number of days in a given month.
@@ -1434,10 +1444,12 @@ fn days_in_month(year: i32, month: u32) -> u32 {
 /// Uses proper calendar arithmetic. A year is counted as complete when
 /// the anniversary date (or Feb 28 for leap year births on Feb 29) is reached.
 fn calculate_years_difference(date1: NaiveDate, date2: NaiveDate) -> i64 {
-    let (earlier, later, sign) = if date1 >= date2 {
-        (date2, date1, 1)
+    // Zie calculate_months_difference: het teken staat als tak, niet als
+    // vermenigvuldiging, zodat er geen gedragsequivalente mutant ontstaat.
+    let (earlier, later, negate) = if date1 >= date2 {
+        (date2, date1, false)
     } else {
-        (date1, date2, -1)
+        (date1, date2, true)
     };
 
     let mut years = later.year() - earlier.year();
@@ -1461,7 +1473,12 @@ fn calculate_years_difference(date1: NaiveDate, date2: NaiveDate) -> i64 {
         years -= 1;
     }
 
-    (years as i64) * sign
+    let years = years as i64;
+    if negate {
+        -years
+    } else {
+        years
+    }
 }
 
 // =============================================================================

--- a/packages/engine/src/schema.rs
+++ b/packages/engine/src/schema.rs
@@ -118,3 +118,158 @@ pub fn validation_errors_for(
         .map(|error| format!("{}: {error}", error.instance_path()))
         .collect())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The repo's `schema/` directory, resolved from this crate's manifest dir.
+    fn schema_dir() -> std::path::PathBuf {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../schema")
+    }
+
+    /// Every `schema/vX.Y.Z/` directory in the repo must be registered in
+    /// `with_schema_versions!`, and nothing else may be. This is the local
+    /// counterpart of the CI guard "Check schema versions registered in
+    /// schema.rs": adding a schema version without wiring it up here means the
+    /// validator silently rejects every document that declares it.
+    #[test]
+    fn every_schema_directory_is_embedded() {
+        let mut on_disk: Vec<String> = std::fs::read_dir(schema_dir())
+            .expect("read schema/ directory")
+            .map(|entry| entry.expect("read schema/ entry").file_name())
+            .map(|name| name.to_string_lossy().into_owned())
+            // `schema/latest` is a symlink to the current version, not a
+            // version of its own.
+            .filter(|name| name.starts_with('v'))
+            .collect();
+        on_disk.sort();
+        assert!(
+            on_disk.len() >= 12,
+            "expected the versioned schema directories, found {on_disk:?}"
+        );
+
+        let schemas = load_schemas().expect("embedded schemas parse as JSON");
+        let mut embedded: Vec<String> = schemas.keys().map(|k| (*k).to_owned()).collect();
+        embedded.sort();
+
+        assert_eq!(
+            embedded, on_disk,
+            "with_schema_versions! is out of sync with the schema/ directory"
+        );
+
+        // Each embedded value is the actual schema document, not a placeholder.
+        for (version, schema) in &schemas {
+            let id = schema
+                .get("$id")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_else(|| panic!("schema {version} has no $id"));
+            assert!(
+                id.contains(version),
+                "schema {version} embedded under the wrong key: $id is {id}"
+            );
+        }
+    }
+
+    #[test]
+    fn detect_version_reads_the_version_out_of_the_schema_url() {
+        let value = serde_json::json!({
+            "$schema": "https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/\
+                        schema-v0.5.6/schema/v0.5.6/schema.json"
+        });
+        assert_eq!(detect_version(&value), Some("v0.5.6"));
+
+        // An older version resolves to itself, not to the newest entry.
+        let older = serde_json::json!({ "$schema": "schema/v0.3.1/schema.json" });
+        assert_eq!(detect_version(&older), Some("v0.3.1"));
+    }
+
+    #[test]
+    fn detect_version_is_none_when_the_version_is_absent_or_unregistered() {
+        assert_eq!(detect_version(&serde_json::json!({})), None);
+        assert_eq!(detect_version(&serde_json::json!({ "$schema": 5 })), None);
+        assert_eq!(
+            detect_version(&serde_json::json!({ "$schema": "schema/v9.9.9/schema.json" })),
+            None,
+        );
+    }
+
+    /// A tiny schema, so the assertions are about `validation_errors` and not
+    /// about the law format.
+    fn tiny_schema() -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "required": ["naam"],
+            "properties": { "naam": { "type": "string" } },
+        })
+    }
+
+    #[test]
+    fn validation_errors_is_empty_for_a_valid_document() {
+        let errors = validation_errors(&tiny_schema(), &serde_json::json!({ "naam": "aow" }))
+            .expect("schema compiles");
+        assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+    }
+
+    #[test]
+    fn validation_errors_reports_each_violation_with_its_instance_path() {
+        let errors = validation_errors(&tiny_schema(), &serde_json::json!({ "naam": 5 }))
+            .expect("schema compiles");
+        assert_eq!(errors.len(), 1, "unexpected errors: {errors:?}");
+        assert!(
+            errors[0].starts_with("/naam: "),
+            "error is not formatted as \"{{instance_path}}: {{message}}\": {}",
+            errors[0]
+        );
+
+        // A violation at the root keeps the empty instance path.
+        let errors = validation_errors(&tiny_schema(), &serde_json::json!({})) //
+            .expect("schema compiles");
+        assert_eq!(errors.len(), 1, "unexpected errors: {errors:?}");
+        assert!(
+            errors[0].starts_with(": "),
+            "root violation lost its instance path: {}",
+            errors[0]
+        );
+    }
+
+    #[test]
+    fn validation_errors_fails_on_an_uncompilable_schema() {
+        let broken = serde_json::json!({ "type": "geen-json-schema-type" });
+        assert!(validation_errors(&broken, &serde_json::json!({})).is_err());
+    }
+
+    #[test]
+    fn validation_errors_for_validates_against_the_cached_validator() {
+        // An empty document misses every required top-level field, so the real
+        // schema must produce errors — and each one formatted with its path.
+        let errors =
+            validation_errors_for("v0.5.6", &serde_json::json!({})).expect("v0.5.6 is embedded");
+        assert!(
+            !errors.is_empty(),
+            "an empty document is not a valid law document"
+        );
+        for error in &errors {
+            assert!(
+                error.starts_with(": "),
+                "error is not formatted as \"{{instance_path}}: {{message}}\": {error}"
+            );
+        }
+
+        // Every embedded version is reachable through the cache, not just the
+        // newest one.
+        for version in load_schemas().expect("embedded schemas parse").keys() {
+            assert!(
+                validation_errors_for(version, &serde_json::json!({})).is_ok(),
+                "version {version} is embedded but has no compiled validator"
+            );
+        }
+    }
+
+    #[test]
+    fn validation_errors_for_fails_on_an_unknown_version() {
+        let error = validation_errors_for("v9.9.9", &serde_json::json!({}))
+            .expect_err("v9.9.9 is not embedded");
+        assert!(error.contains("v9.9.9"), "unhelpful error: {error}");
+    }
+}

--- a/packages/engine/src/units.rs
+++ b/packages/engine/src/units.rs
@@ -493,6 +493,45 @@ mod tests {
     use super::*;
 
     #[test]
+    fn parse_maps_every_schema_unit_name() {
+        // The schema `type_spec.unit` enum (RFC-023) is the contract: every name
+        // in it must land on its own unit. A name that silently falls through to
+        // `Unknown` disables unit checking for every law that uses it.
+        assert_eq!(Unit::parse(Some("euro")), Unit::Euro);
+        assert_eq!(Unit::parse(Some("eurocent")), Unit::Eurocent);
+        assert_eq!(Unit::parse(Some("years")), Unit::Years);
+        assert_eq!(Unit::parse(Some("months")), Unit::Months);
+        assert_eq!(Unit::parse(Some("weeks")), Unit::Weeks);
+        assert_eq!(Unit::parse(Some("days")), Unit::Days);
+        assert_eq!(Unit::parse(Some("ratio")), Unit::Ratio);
+        assert_eq!(Unit::parse(Some("percentage")), Unit::Percentage);
+        // Outside the enum, and absent, are both "no declared unit".
+        assert_eq!(Unit::parse(Some("Euro")), Unit::Unknown);
+        assert_eq!(Unit::parse(Some("kilogram")), Unit::Unknown);
+        assert_eq!(Unit::parse(None), Unit::Unknown);
+    }
+
+    #[test]
+    fn mismatch_error_names_both_units() {
+        // The whole point of RFC-023 is catching euro/eurocent confusion, so the
+        // error must say *which* two units clashed — a message that only says
+        // "unit mismatch" leaves the author hunting for the factor of 100.
+        let err = combine(AlgebraOp::Additive, "ADD", Unit::Euro, Unit::Eurocent).unwrap_err();
+        match err {
+            EngineError::UnitMismatch {
+                operation,
+                left,
+                right,
+            } => {
+                assert_eq!(operation, "ADD");
+                assert_eq!(left, "euro");
+                assert_eq!(right, "eurocent");
+            }
+            other => panic!("expected UnitMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn unknown_never_errors() {
         assert_eq!(
             combine(AlgebraOp::Additive, "ADD", Unit::Eurocent, Unit::Unknown).unwrap(),
@@ -668,5 +707,192 @@ mod tests {
             infer_operation_unit(&op, &symbols()),
             Err(EngineError::UnitMismatch { .. })
         ));
+    }
+
+    #[test]
+    fn plain_string_literal_is_not_a_symbol_reference() {
+        // Only a leading `$` makes a string a symbol reference. A plain string
+        // that happens to spell a symbol name is a value, not a lookup, so it
+        // must not import that symbol's unit.
+        let su = symbols();
+        assert_eq!(infer_unit(&var("dagen"), &su).unwrap(), Unit::Days);
+        assert_eq!(
+            infer_unit(&lit(Value::String("dagen".to_string())), &su).unwrap(),
+            Unit::Unknown
+        );
+
+        // ...and comparing an annotated amount against such a string stays
+        // unit-silent instead of erroring on a unit nobody declared.
+        let op = ActionOperation::Equals {
+            subject: var("inkomen"),
+            value: lit(Value::String("dagen".to_string())),
+        };
+        assert_eq!(infer_operation_unit(&op, &su).unwrap(), Unit::Unknown);
+    }
+
+    #[test]
+    fn nested_mismatch_inside_logical_operand_is_caught() {
+        // AND/OR/LIST have no unit of their own, but a mismatch buried in an
+        // operand must still surface — otherwise a condition subtree is a blind
+        // spot for the whole check.
+        let bad = || {
+            ActionValue::Operation(Box::new(ActionOperation::Add {
+                values: vec![var("inkomen"), var("dagen")],
+            }))
+        };
+
+        let and = ActionOperation::And {
+            conditions: vec![bad()],
+        };
+        assert!(matches!(
+            infer_operation_unit(&and, &symbols()),
+            Err(EngineError::UnitMismatch { .. })
+        ));
+
+        let list = ActionOperation::List { items: vec![bad()] };
+        assert!(matches!(
+            infer_operation_unit(&list, &symbols()),
+            Err(EngineError::UnitMismatch { .. })
+        ));
+    }
+
+    // -------------------------------------------------------------------------
+    // check_law: the static pass over a whole law
+    // -------------------------------------------------------------------------
+
+    fn law(yaml: &str) -> crate::article::ArticleBasedLaw {
+        use crate::article::LawLoad;
+        crate::article::ArticleBasedLaw::from_yaml_str(yaml).unwrap()
+    }
+
+    #[test]
+    fn check_law_reports_mismatch_in_action_value_as_error() {
+        let law = law(r#"
+$id: unit_check_law
+regulatory_layer: WET
+publication_date: '2025-01-01'
+articles:
+  - number: '1'
+    text: Bedrag plus duur
+    machine_readable:
+      execution:
+        input:
+          - name: bedrag
+            type: amount
+            type_spec:
+              unit: eurocent
+          - name: duur
+            type: number
+            type_spec:
+              unit: days
+        output:
+          - name: onzin
+            type: amount
+            type_spec:
+              unit: eurocent
+        actions:
+          - output: onzin
+            value:
+              operation: ADD
+              values:
+                - $bedrag
+                - $duur
+"#);
+
+        let findings = check_law(&law);
+        assert_eq!(findings.len(), 1, "findings: {findings:?}");
+        let f = &findings[0];
+        assert!(f.is_error);
+        assert_eq!(f.article, "1");
+        assert_eq!(f.output, "onzin");
+        assert!(
+            f.message.contains("eurocent") && f.message.contains("days"),
+            "message should name both units: {}",
+            f.message
+        );
+    }
+
+    #[test]
+    fn check_law_warns_on_amount_output_without_unit_in_annotated_article() {
+        let law = law(r#"
+$id: unit_warning_law
+regulatory_layer: WET
+publication_date: '2025-01-01'
+articles:
+  - number: '1'
+    text: Wel geannoteerd, output zonder eenheid
+    machine_readable:
+      execution:
+        input:
+          - name: bedrag
+            type: amount
+            type_spec:
+              unit: eurocent
+        output:
+          - name: uitkomst
+            type: amount
+"#);
+
+        let findings = check_law(&law);
+        assert_eq!(findings.len(), 1, "findings: {findings:?}");
+        let f = &findings[0];
+        assert!(!f.is_error, "missing unit is a warning, not an error");
+        assert_eq!(f.output, "uitkomst");
+        assert_eq!(f.message, "no unit declared");
+    }
+
+    #[test]
+    fn check_law_stays_silent_on_declared_units_and_non_amount_outputs() {
+        // An amount output that *does* declare a unit is exactly what the warning
+        // asks for, and a non-amount output has nothing to declare — neither is a
+        // finding.
+        let law = law(r#"
+$id: unit_silent_law
+regulatory_layer: WET
+publication_date: '2025-01-01'
+articles:
+  - number: '1'
+    text: Netjes geannoteerd
+    machine_readable:
+      execution:
+        input:
+          - name: bedrag
+            type: amount
+            type_spec:
+              unit: eurocent
+        output:
+          - name: uitkomst
+            type: amount
+            type_spec:
+              unit: eurocent
+          - name: toelichting
+            type: string
+"#);
+
+        assert!(check_law(&law).is_empty(), "{:?}", check_law(&law));
+    }
+
+    #[test]
+    fn check_law_stays_silent_on_un_annotated_article() {
+        // The opt-in cornerstone: a law that has not started annotating units at
+        // all must produce no warnings, so `just validate` is not flooded.
+        let law = law(r#"
+$id: unannotated_law
+regulatory_layer: WET
+publication_date: '2025-01-01'
+articles:
+  - number: '1'
+    text: Geen enkele eenheid gedeclareerd
+    machine_readable:
+      execution:
+        input:
+          - name: bedrag
+            type: amount
+        output:
+          - name: uitkomst
+            type: amount
+"#);
+
+        assert!(check_law(&law).is_empty(), "{:?}", check_law(&law));
     }
 }


### PR DESCRIPTION
77 overlevers uit #1052: `operations.rs`, `article.rs`, `schema.rs` en `units.rs`. Nieuw afgedekt zijn de taint-voortplanting, de dieptegrens en de datumverschillen, de grenswaarden van de YAML- en arraylimieten, het laden van schema's met de versiedetectie, en de eenheidparser met de statische unitcheck. `schema.rs` is het schoolvoorbeeld van het probleem dat #1063 oplost: het bestand hangt achter `#[cfg(feature = "validate")]`, dus alle vijftien mutanten overleefden zonder dat er ooit een regel van gecompileerd werd, terwijl `just test` de module wel degelijk dekt.

Eén ingreep in de productiecode. `calculate_months_difference` en `calculate_years_difference` vermenigvuldigden hun uitkomst met een `sign` die per constructie 1 of -1 is, wat een niet te doden mutant oplevert met exact dezelfde omschrijving als een `years_diff * 12` een paar regels hoger; één uitsluiting had beide afgedekt en daarmee een echt testgat verborgen, dus het teken staat nu als tak. Daarnaast vergelijkt `every_schema_directory_is_embedded` de `with_schema_versions!`-tabel met de daadwerkelijke `schema/vX.Y.Z/`-mappen, zodat een niet-geregistreerde schemaversie lokaal omvalt in plaats van pas op de CI-grep.