### PR TITLE
test(engine): dek de randen van de engine af

### DIFF
--- a/packages/engine/src/priority.rs
+++ b/packages/engine/src/priority.rs
@@ -320,6 +320,223 @@ articles:
         assert!(reason.contains("lex posterior"));
     }
 
+    /// Lex superior beats lex posterior: a lower layer loses even when its
+    /// `valid_from` is later than that of the higher layer.
+    #[test]
+    fn test_compare_lower_layer_loses_despite_newer_date() {
+        let wet = ArticleBasedLaw::from_yaml_str(
+            r#"
+$id: higher_law
+regulatory_layer: WET
+publication_date: '2024-01-01'
+valid_from: '2024-01-01'
+articles:
+  - number: '1'
+    text: Higher law article
+"#,
+        )
+        .unwrap();
+
+        let regeling = ArticleBasedLaw::from_yaml_str(
+            r#"
+$id: lower_regulation
+regulatory_layer: MINISTERIELE_REGELING
+publication_date: '2025-01-01'
+valid_from: '2025-01-01'
+articles:
+  - number: '1'
+    text: Lower regulation article
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            compare_law_priority(&regeling, &wet).unwrap(),
+            std::cmp::Ordering::Less,
+            "the ministerial regulation must lose to the formal law, even though it is newer"
+        );
+        assert_eq!(
+            compare_law_priority(&wet, &regeling).unwrap(),
+            std::cmp::Ordering::Greater,
+            "the formal law must win regardless of argument order"
+        );
+    }
+
+    /// Lex posterior in both directions: the older law loses to the newer one.
+    #[test]
+    fn test_compare_older_date_loses_at_same_layer() {
+        let older = ArticleBasedLaw::from_yaml_str(
+            r#"
+$id: older_regulation
+regulatory_layer: MINISTERIELE_REGELING
+publication_date: '2024-01-01'
+valid_from: '2024-01-01'
+articles:
+  - number: '1'
+    text: Older regulation
+"#,
+        )
+        .unwrap();
+
+        let newer = ArticleBasedLaw::from_yaml_str(
+            r#"
+$id: newer_regulation
+regulatory_layer: MINISTERIELE_REGELING
+publication_date: '2025-01-01'
+valid_from: '2025-01-01'
+articles:
+  - number: '1'
+    text: Newer regulation
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            compare_law_priority(&older, &newer).unwrap(),
+            std::cmp::Ordering::Less,
+            "the older regulation must lose"
+        );
+        assert_eq!(
+            compare_law_priority(&newer, &older).unwrap(),
+            std::cmp::Ordering::Greater,
+            "the newer regulation must win"
+        );
+    }
+
+    /// Same layer plus same `valid_from` has no winner: the engine must refuse
+    /// to pick one rather than silently preferring an argument position.
+    #[test]
+    fn test_compare_same_layer_and_date_is_ambiguous() {
+        let one = ArticleBasedLaw::from_yaml_str(
+            r#"
+$id: regulation_one
+regulatory_layer: MINISTERIELE_REGELING
+publication_date: '2025-01-01'
+valid_from: '2025-01-01'
+articles:
+  - number: '1'
+    text: First regulation
+"#,
+        )
+        .unwrap();
+
+        let two = ArticleBasedLaw::from_yaml_str(
+            r#"
+$id: regulation_two
+regulatory_layer: MINISTERIELE_REGELING
+publication_date: '2025-01-01'
+valid_from: '2025-01-01'
+articles:
+  - number: '1'
+    text: Second regulation
+"#,
+        )
+        .unwrap();
+
+        for (a, b) in [(&one, &two), (&two, &one)] {
+            let err = compare_law_priority(a, b).expect_err(
+                "two regulations at the same layer with the same valid_from must not resolve",
+            );
+            assert!(
+                err.to_string().contains("Ambiguous priority"),
+                "Expected an ambiguity error, got: {err}"
+            );
+        }
+    }
+
+    /// The same ambiguity must surface through `resolve_candidate`, so a caller
+    /// never gets an arbitrary winner from an unresolvable pair.
+    #[test]
+    fn test_resolve_candidate_ambiguous_is_error() {
+        let one = ArticleBasedLaw::from_yaml_str(
+            r#"
+$id: regulation_one
+regulatory_layer: MINISTERIELE_REGELING
+publication_date: '2025-01-01'
+valid_from: '2025-01-01'
+articles:
+  - number: '1'
+    text: First regulation
+"#,
+        )
+        .unwrap();
+
+        let two = ArticleBasedLaw::from_yaml_str(
+            r#"
+$id: regulation_two
+regulatory_layer: MINISTERIELE_REGELING
+publication_date: '2025-01-01'
+valid_from: '2025-01-01'
+articles:
+  - number: '1'
+    text: Second regulation
+"#,
+        )
+        .unwrap();
+
+        let candidates = vec![
+            Candidate {
+                law: &one,
+                article_number: "1".to_string(),
+            },
+            Candidate {
+                law: &two,
+                article_number: "1".to_string(),
+            },
+        ];
+
+        let err = resolve_candidate(&candidates).unwrap_err();
+        assert!(
+            err.to_string().contains("Ambiguous priority"),
+            "Expected an ambiguity error, got: {err}"
+        );
+    }
+
+    /// The winner must not depend on candidate order: the newer regulation wins
+    /// even when it is already the incumbent best.
+    #[test]
+    fn test_resolve_candidate_lex_posterior_newest_first() {
+        let newer = ArticleBasedLaw::from_yaml_str(
+            r#"
+$id: newer_regulation
+regulatory_layer: MINISTERIELE_REGELING
+publication_date: '2025-01-01'
+valid_from: '2025-01-01'
+articles:
+  - number: '1'
+    text: Newer regulation
+"#,
+        )
+        .unwrap();
+
+        let older = ArticleBasedLaw::from_yaml_str(
+            r#"
+$id: older_regulation
+regulatory_layer: MINISTERIELE_REGELING
+publication_date: '2024-01-01'
+valid_from: '2024-01-01'
+articles:
+  - number: '1'
+    text: Older regulation
+"#,
+        )
+        .unwrap();
+
+        let candidates = vec![
+            Candidate {
+                law: &newer,
+                article_number: "1".to_string(),
+            },
+            Candidate {
+                law: &older,
+                article_number: "1".to_string(),
+            },
+        ];
+
+        let (winner, _reason) = resolve_candidate(&candidates).unwrap().unwrap();
+        assert_eq!(winner.id, "newer_regulation");
+    }
+
     #[test]
     fn test_resolve_candidate_missing_valid_from_is_error() {
         let without_date = ArticleBasedLaw::from_yaml_str(

--- a/packages/engine/src/trace.rs
+++ b/packages/engine/src/trace.rs
@@ -213,23 +213,15 @@ impl PathNode {
             let is_last_child = i == child_count - 1;
             let child_str = child.render_internal(0, is_last_child, false);
 
-            // Add proper indentation to each line of the child's output
-            for (j, child_line) in child_str.lines().enumerate() {
-                if j == 0 {
-                    // First line gets the current indentation
-                    lines.push(format!(
-                        "{}{}",
-                        " ".repeat(indent * 4) + &child_indent,
-                        child_line
-                    ));
-                } else {
-                    // Subsequent lines need continued indentation
-                    lines.push(format!(
-                        "{}{}",
-                        " ".repeat(indent * 4) + &child_indent,
-                        child_line
-                    ));
-                }
+            // Add proper indentation to each line of the child's output. The
+            // child already prefixed its own descendants, so every line of its
+            // output gets the same indentation here.
+            for child_line in child_str.lines() {
+                lines.push(format!(
+                    "{}{}",
+                    " ".repeat(indent * 4) + &child_indent,
+                    child_line
+                ));
             }
         }
 
@@ -885,6 +877,64 @@ mod tests {
     }
 
     #[test]
+    fn test_trace_builder_untimed_records_no_durations() {
+        let mut builder = TraceBuilder::new_untimed();
+        assert!(builder.is_enabled(), "untimed builder still traces");
+
+        builder.push("root", PathNodeType::Resolve);
+        builder.push("child", PathNodeType::Operation);
+        builder.set_result(Value::Int(1));
+        builder.pop();
+        builder.set_result(Value::Int(1));
+        let root = builder.build().unwrap();
+
+        assert_eq!(
+            root.duration_us, None,
+            "untimed builder must not record a duration"
+        );
+        assert_eq!(
+            root.children[0].duration_us, None,
+            "untimed builder must not record a duration on nested nodes"
+        );
+    }
+
+    #[test]
+    fn test_trace_builder_depth_follows_stack() {
+        let mut builder = TraceBuilder::new();
+        assert_eq!(builder.depth(), 0, "a fresh builder has no open scopes");
+
+        builder.push("level1", PathNodeType::Action);
+        assert_eq!(builder.depth(), 1);
+
+        builder.push("level2", PathNodeType::Operation);
+        assert_eq!(builder.depth(), 2, "nested push deepens the stack");
+
+        builder.pop();
+        assert_eq!(builder.depth(), 1, "pop leaves the parent open");
+
+        builder.pop();
+        assert_eq!(builder.depth(), 0);
+    }
+
+    #[test]
+    fn test_trace_builder_is_empty_follows_stack() {
+        let mut builder = TraceBuilder::new();
+        assert!(builder.is_empty());
+
+        builder.push("root", PathNodeType::Resolve);
+        assert!(
+            !builder.is_empty(),
+            "a builder with an open scope is not empty"
+        );
+
+        builder.pop();
+        assert!(
+            builder.is_empty(),
+            "popping the last scope empties the stack"
+        );
+    }
+
+    #[test]
     fn test_trace_builder_disabled() {
         let mut builder = TraceBuilder::disabled();
         assert!(!builder.is_enabled());
@@ -996,6 +1046,56 @@ mod tests {
     }
 
     #[test]
+    fn test_render_marks_only_the_last_child_with_a_corner() {
+        let root = PathNode::new(PathNodeType::Operation, "ADD")
+            .with_child(PathNode::new(PathNodeType::Resolve, "first"))
+            .with_child(PathNode::new(PathNodeType::Resolve, "middle"))
+            .with_child(PathNode::new(PathNodeType::Resolve, "last"));
+
+        let rendered = root.render(0, false);
+        let line_for = |name: &str| {
+            rendered
+                .lines()
+                .find(|l| l.contains(name))
+                .unwrap_or_else(|| panic!("no line for {} in:\n{}", name, rendered))
+                .to_string()
+        };
+
+        assert!(
+            line_for("first").starts_with("+-- "),
+            "a non-last child branches with +-- in:\n{}",
+            rendered
+        );
+        assert!(
+            line_for("middle").starts_with("+-- "),
+            "a non-last child branches with +-- in:\n{}",
+            rendered
+        );
+        assert!(
+            line_for("last").starts_with("`-- "),
+            "the last child closes the branch with `-- in:\n{}",
+            rendered
+        );
+    }
+
+    #[test]
+    fn test_render_only_shows_significant_durations() {
+        let quick = PathNode::new(PathNodeType::Operation, "quick").with_duration(99);
+        assert!(
+            !quick.render(0, false).contains("μs"),
+            "durations under 0.1ms are noise and stay out of the trace: {}",
+            quick.render(0, false)
+        );
+
+        let slow = PathNode::new(PathNodeType::Operation, "slow").with_duration(100);
+        assert!(
+            slow.render(0, false).contains("(100μs)"),
+            "durations from 0.1ms up are shown: {}",
+            slow.render(0, false)
+        );
+    }
+
+    #[test]
     fn test_render_complex_tree() {
         // Build a more complex tree
         let resolve_a = PathNode::new(PathNodeType::Resolve, "var_a").with_result(Value::Int(100));
@@ -1042,6 +1142,25 @@ mod tests {
         let formatted = format_value_compact(&Value::String(long_string.to_string()));
         assert!(formatted.len() < long_string.len());
         assert!(formatted.contains("..."));
+    }
+
+    #[test]
+    fn test_format_value_compact_truncation_boundary() {
+        // Exactly 20 characters still fits and is shown in full.
+        let exactly_twenty = "12345678901234567890";
+        assert_eq!(exactly_twenty.chars().count(), 20);
+        assert_eq!(
+            format_value_compact(&Value::String(exactly_twenty.to_string())),
+            "\"12345678901234567890\""
+        );
+
+        // One character more and the value is truncated to 17 characters.
+        let twenty_one = "123456789012345678901";
+        assert_eq!(twenty_one.chars().count(), 21);
+        assert_eq!(
+            format_value_compact(&Value::String(twenty_one.to_string())),
+            "\"12345678901234567...\""
+        );
     }
 
     #[test]

--- a/packages/engine/src/uri.rs
+++ b/packages/engine/src/uri.rs
@@ -392,6 +392,43 @@ mod tests {
         }
 
         #[test]
+        fn test_parse_preserves_original_uri_string() {
+            // A parsed reference keeps the reference exactly as it was written in
+            // the law, including the fragment: it is what error messages and
+            // provenance report back to the reader.
+            for original in [
+                "regelrecht://zvw/is_verzekerd",
+                "regelrecht://wet_op_de_zorgtoeslag/bereken_zorgtoeslag#heeft_recht_op_zorgtoeslag",
+                "regulation/nl/ministeriele_regeling/regeling_standaardpremie#standaardpremie",
+                "#standaardpremie",
+            ] {
+                let uri = RegelrechtUri::parse(original).unwrap();
+                assert_eq!(uri.uri(), original);
+                assert_eq!(uri.to_string(), original);
+            }
+        }
+
+        #[test]
+        fn test_reference_type_is_exclusive() {
+            // Internal and external are the two halves of one choice; a reference
+            // is never both, and never neither.
+            let internal = RegelrechtUri::parse("#standaardpremie").unwrap();
+            assert!(internal.is_internal());
+            assert!(!internal.is_external());
+            assert_eq!(internal.reference_type(), ReferenceType::Internal);
+
+            for external in [
+                "regelrecht://zvw/is_verzekerd",
+                "regulation/nl/wet/wet_op_de_zorgtoeslag",
+            ] {
+                let uri = RegelrechtUri::parse(external).unwrap();
+                assert!(uri.is_external());
+                assert!(!uri.is_internal());
+                assert_eq!(uri.reference_type(), ReferenceType::External);
+            }
+        }
+
+        #[test]
         fn test_parse_invalid_regelrecht_no_output() {
             let result = RegelrechtUri::parse("regelrecht://zvw");
             assert!(result.is_err());

--- a/packages/engine/src/wasm.rs
+++ b/packages/engine/src/wasm.rs
@@ -66,6 +66,32 @@ use crate::service::{LawExecutionService, ServiceProvider};
 use crate::trace::{PathNode, TraceBuilder};
 use crate::types::{RegulatoryLayer, Value};
 
+/// Does this annotation note target a law other than `law_id`?
+///
+/// A federated `annotations.yaml` sidecar may carry notes for several laws, so
+/// `resolveNotes` has to leave the other laws' notes alone. A note without a
+/// `target.source`, or one whose source is not a `regelrecht://` law URI, is
+/// treated as belonging to the law being resolved: the sidecar was handed to
+/// this law and there is nothing that says otherwise.
+///
+/// Split out of `resolve_notes` so it can be tested natively — everything
+/// around it takes or returns a `JsValue`, which aborts outside wasm32. Phrased
+/// negatively so the call site needs no `!`: a negation there would be a second
+/// mutant in exactly the code that cannot be reached from a test.
+fn note_targets_another_law(note: &serde_json::Value, law_id: &str) -> bool {
+    let Some(source) = note
+        .get("target")
+        .and_then(|t| t.get("source"))
+        .and_then(|s| s.as_str())
+    else {
+        return false;
+    };
+    match law_id_from_source(source) {
+        Some(target_law) => target_law != law_id,
+        None => false,
+    }
+}
+
 /// Create a serializer that converts HashMaps to JavaScript objects (not Maps)
 fn js_serializer() -> Serializer {
     Serializer::new().serialize_maps_as_objects(true)
@@ -566,18 +592,8 @@ impl WasmEngine {
 
         let mut resolved: Vec<serde_json::Value> = Vec::with_capacity(notes.len());
         for note in notes {
-            // Skip notes that target a different law (federated sidecars may
-            // carry notes for several laws).
-            if let Some(source) = note
-                .get("target")
-                .and_then(|t| t.get("source"))
-                .and_then(|s| s.as_str())
-            {
-                if let Some(target_law) = law_id_from_source(source) {
-                    if target_law != law_id {
-                        continue;
-                    }
-                }
+            if note_targets_another_law(note, law_id) {
+                continue;
             }
 
             let (match_value, error) = match note.get("target").and_then(|t| t.get("selector")) {
@@ -1048,5 +1064,43 @@ articles:
         // Verify box-drawing rendering works
         let text = trace.render_box_drawing();
         assert!(!text.is_empty(), "Box-drawing trace should not be empty");
+    }
+
+    fn note_with_source(source: &str) -> serde_json::Value {
+        serde_json::json!({ "target": { "source": source } })
+    }
+
+    #[test]
+    fn a_note_for_another_law_is_not_resolved_against_this_one() {
+        // Een federatieve sidecar draagt notities voor meerdere wetten. Keert
+        // dit filter om, dan hangt de engine de annotaties van de ene wet aan
+        // de tekst van de andere.
+        let note = note_with_source("regelrecht://andere_wet");
+        assert!(note_targets_another_law(&note, "test_law"));
+        assert!(!note_targets_another_law(&note, "andere_wet"));
+    }
+
+    #[test]
+    fn a_note_for_this_law_survives_the_filter() {
+        let note = note_with_source("regelrecht://test_law/artikel/1");
+        assert!(!note_targets_another_law(&note, "test_law"));
+    }
+
+    #[test]
+    fn a_note_without_a_law_uri_belongs_to_the_law_being_resolved() {
+        // Geen target.source, of een source die geen regelrecht-wet aanwijst:
+        // de sidecar is bij deze wet aangeleverd en niets zegt het tegendeel.
+        assert!(!note_targets_another_law(
+            &serde_json::json!({}),
+            "test_law"
+        ));
+        assert!(!note_targets_another_law(
+            &serde_json::json!({ "target": {} }),
+            "test_law"
+        ));
+        assert!(!note_targets_another_law(
+            &note_with_source("https://example.com/bron"),
+            "test_law"
+        ));
     }
 }

--- a/packages/engine/src/wasm.rs
+++ b/packages/engine/src/wasm.rs
@@ -721,6 +721,57 @@ articles:
         assert_eq!(engine.list_laws(), vec!["test_law".to_string()]);
     }
 
+    /// `loadLaw()` is de enige weg waarlangs JavaScript een wet de engine in
+    /// krijgt, en het is het contract dat de aanroeper het `$id` terugkrijgt om
+    /// mee verder te werken (`execute(lawId, ...)`). De andere tests laden via
+    /// de service en zouden een kapotte wrapper dus niet zien.
+    #[test]
+    fn test_wasm_engine_load_law_returns_law_id() {
+        let mut engine = WasmEngine::new();
+
+        let law_id = engine.load_law(MINIMAL_LAW_YAML).ok();
+
+        assert_eq!(law_id.as_deref(), Some("test_law"));
+        assert!(engine.has_law("test_law"));
+    }
+
+    /// De grens van `MAX_YAML_SIZE` is inclusief: een document van precies de
+    /// maximumgrootte hoort geladen te worden, pas één byte meer wordt
+    /// geweigerd. Een wet die exact op de grens valt mag niet stilletjes
+    /// onbruikbaar worden.
+    ///
+    /// De afkeurkant van dezelfde grens is native niet te testen: die tak bouwt
+    /// een `JsValue` en wasm-bindgen aborteert het proces buiten wasm32.
+    #[test]
+    fn test_wasm_engine_load_law_accepts_exactly_max_size() {
+        let mut engine = WasmEngine::new();
+
+        let mut yaml = String::from(MINIMAL_LAW_YAML);
+        yaml.push_str("# ");
+        let padding = config::MAX_YAML_SIZE - yaml.len();
+        yaml.push_str(&"x".repeat(padding));
+        assert_eq!(yaml.len(), config::MAX_YAML_SIZE);
+
+        let law_id = engine.load_law(&yaml).ok();
+
+        assert_eq!(
+            law_id.as_deref(),
+            Some("test_law"),
+            "a law of exactly MAX_YAML_SIZE bytes should still load"
+        );
+    }
+
+    /// De engine-versie reist mee in elk uitvoeringsresultaat en is daarmee
+    /// onderdeel van de herleidbaarheid van een beschikking: hij moet de
+    /// werkelijke crate-versie zijn, geen placeholder.
+    #[test]
+    fn test_wasm_engine_version() {
+        let engine = WasmEngine::new();
+
+        assert_eq!(engine.version(), env!("CARGO_PKG_VERSION"));
+        assert!(!engine.version().is_empty());
+    }
+
     #[test]
     fn test_wasm_engine_unload_law() {
         let mut engine = WasmEngine::new();

--- a/packages/engine/tests/bin_evaluate.rs
+++ b/packages/engine/tests/bin_evaluate.rs
@@ -1,0 +1,146 @@
+//! Contract-tests for the `evaluate` CLI binary.
+//!
+//! The binary is the process boundary that external callers use: a JSON request
+//! on stdin, a JSON response on stdout, and flags that change the shape of that
+//! response. These tests pin that contract, not the engine internals behind it.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+/// Self-contained law with one constant output, so the test says something about
+/// the CLI and nothing about the corpus.
+const LAW_YAML: &str = r#"---
+$schema: >-
+  https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.5.3/schema.json
+$id: test_bin_evaluate
+name: Testwet bin evaluate
+regulatory_layer: WET
+bwb_id: BWBR9999903
+publication_date: '2025-01-01'
+valid_from: '2025-01-01'
+url: https://example.com/test_bin_evaluate
+
+articles:
+  - number: '1'
+    url: https://example.com/test_bin_evaluate/1
+    text: >-
+      Het normbedrag bedraagt 500 eurocent.
+    machine_readable:
+      execution:
+        output:
+          - name: normbedrag
+            type: amount
+            type_spec:
+              unit: eurocent
+        actions:
+          - output: normbedrag
+            value: 500
+"#;
+
+struct Run {
+    success: bool,
+    stdout: String,
+}
+
+fn run_evaluate(args: &[&str], request: &serde_json::Value) -> Run {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_evaluate"))
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn evaluate binary");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(request.to_string().as_bytes())
+        .expect("failed to write request to stdin");
+
+    let output = child.wait_with_output().expect("failed to wait for binary");
+    Run {
+        success: output.status.success(),
+        stdout: String::from_utf8(output.stdout).expect("stdout is not valid UTF-8"),
+    }
+}
+
+fn request() -> serde_json::Value {
+    serde_json::json!({
+        "law_yaml": LAW_YAML,
+        "output_names": ["normbedrag"],
+        "params": {},
+        "date": "2025-01-01",
+    })
+}
+
+/// Without flags the binary answers with the plain response envelope: the
+/// requested outputs, the article that produced them, and the law they came from.
+#[test]
+fn evaluate_writes_the_requested_outputs_to_stdout() {
+    let run = run_evaluate(&[], &request());
+    assert!(run.success, "expected exit code 0, stdout: {}", run.stdout);
+
+    let resp: serde_json::Value =
+        serde_json::from_str(&run.stdout).expect("stdout is not valid JSON");
+
+    assert_eq!(resp["outputs"]["normbedrag"], serde_json::json!(500));
+    assert_eq!(resp["law_id"], "test_bin_evaluate");
+    assert_eq!(resp["article_number"], "1");
+    assert!(
+        resp["engine_version"].is_string(),
+        "engine_version is required by RFC-013, got: {}",
+        run.stdout
+    );
+    assert!(
+        resp.get("provenance").is_none(),
+        "without --receipt the response must not be a receipt envelope: {}",
+        run.stdout
+    );
+}
+
+/// `--receipt` (RFC-013) swaps the plain response for the Execution Receipt
+/// envelope, which carries the provenance and the requested outputs.
+#[test]
+fn receipt_flag_emits_the_execution_receipt_envelope() {
+    let run = run_evaluate(&["--receipt"], &request());
+    assert!(run.success, "expected exit code 0, stdout: {}", run.stdout);
+
+    let receipt: serde_json::Value =
+        serde_json::from_str(&run.stdout).expect("stdout is not valid JSON");
+
+    assert_eq!(receipt["provenance"]["regulation_id"], "test_bin_evaluate");
+    assert_eq!(
+        receipt["results"]["requested_outputs"],
+        serde_json::json!(["normbedrag"])
+    );
+    assert_eq!(
+        receipt["results"]["outputs"]["normbedrag"],
+        serde_json::json!(500)
+    );
+    assert_eq!(receipt["execution"]["calculation_date"], "2025-01-01");
+}
+
+/// An unparsable date is rejected before any law is loaded, with a non-zero exit
+/// code and the error in the response envelope rather than a panic.
+#[test]
+fn an_invalid_date_fails_with_an_error_response() {
+    let mut req = request();
+    req["date"] = serde_json::json!("01-01-2025");
+
+    let run = run_evaluate(&[], &req);
+    assert!(
+        !run.success,
+        "expected a non-zero exit code: {}",
+        run.stdout
+    );
+
+    let resp: serde_json::Value =
+        serde_json::from_str(&run.stdout).expect("stdout is not valid JSON");
+    let error = resp["error"].as_str().expect("error message");
+    assert!(
+        error.contains("01-01-2025") && error.contains("YYYY-MM-DD"),
+        "error must name the offending date and the expected format, got: {error}"
+    );
+    assert!(resp.get("outputs").is_none(), "no outputs on failure");
+}

--- a/packages/engine/tests/fixtures/validate_cli/no_schema_field.yaml
+++ b/packages/engine/tests/fixtures/validate_cli/no_schema_field.yaml
@@ -1,0 +1,11 @@
+---
+# Geen `$schema`: er valt niets te valideren, dus keurt de poort het af.
+$id: test_validate_cli_no_schema_field
+regulatory_layer: WET
+publication_date: '2025-01-01'
+bwb_id: BWBR0123456
+url: https://example.invalid/law
+articles:
+  - number: '1'
+    text: Dit bestand noemt geen schemaversie.
+    url: https://example.invalid/law/artikel/1

--- a/packages/engine/tests/fixtures/validate_cli/schema_violation.yaml
+++ b/packages/engine/tests/fixtures/validate_cli/schema_violation.yaml
@@ -1,0 +1,13 @@
+---
+# Het top-level veld `url` ontbreekt: het schema vereist het, het lenient
+# law-model accepteert het. Dit bestand komt dus voorbij de serde-stap en
+# struikelt pas over de schemavalidatie — precies de tak die getest wordt.
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.6/schema/v0.5.6/schema.json
+$id: test_validate_cli_schema_violation
+regulatory_layer: WET
+publication_date: '2025-01-01'
+bwb_id: BWBR0123456
+articles:
+  - number: '1'
+    text: Top-level url ontbreekt.
+    url: https://example.invalid/law/artikel/1

--- a/packages/engine/tests/fixtures/validate_cli/unit_mismatch.yaml
+++ b/packages/engine/tests/fixtures/validate_cli/unit_mismatch.yaml
@@ -1,0 +1,42 @@
+---
+# Schema-geldig, maar de unit-algebra (RFC-023) telt eurocent bij dagen op.
+# Alleen de statische unit-controle vangt dit; het schema ziet er niets in.
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.6/schema/v0.5.6/schema.json
+$id: test_validate_cli_unit_mismatch
+regulatory_layer: WET
+publication_date: '2025-01-01'
+bwb_id: BWBR0123456
+url: https://example.invalid/law
+articles:
+  - number: '1'
+    text: Een bedrag en een aantal dagen worden bij elkaar opgeteld.
+    url: https://example.invalid/law/artikel/1
+    machine_readable:
+      execution:
+        input:
+          - name: bedrag
+            type: amount
+            source:
+              regulation: test_validate_cli_valid
+              output: normbedrag
+            type_spec:
+              unit: eurocent
+          - name: dagen
+            type: number
+            source:
+              regulation: test_validate_cli_valid
+              output: dagen
+            type_spec:
+              unit: days
+        output:
+          - name: onzin
+            type: amount
+            type_spec:
+              unit: eurocent
+        actions:
+          - output: onzin
+            value:
+              operation: ADD
+              values:
+                - $bedrag
+                - $dagen

--- a/packages/engine/tests/fixtures/validate_cli/valid.yaml
+++ b/packages/engine/tests/fixtures/validate_cli/valid.yaml
@@ -1,0 +1,22 @@
+---
+# Schema-geldig en unit-schoon: de OK-tak van de corpuspoort.
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.6/schema/v0.5.6/schema.json
+$id: test_validate_cli_valid
+regulatory_layer: WET
+publication_date: '2025-01-01'
+bwb_id: BWBR0123456
+url: https://example.invalid/law
+articles:
+  - number: '1'
+    text: Het normbedrag bedraagt 500 eurocent.
+    url: https://example.invalid/law/artikel/1
+    machine_readable:
+      execution:
+        output:
+          - name: normbedrag
+            type: amount
+            type_spec:
+              unit: eurocent
+        actions:
+          - output: normbedrag
+            value: 500

--- a/packages/engine/tests/validate_cli.rs
+++ b/packages/engine/tests/validate_cli.rs
@@ -1,0 +1,96 @@
+//! Gedragstest voor de `validate`-binary: de corpuspoort van pre-commit en CI.
+//!
+//! Wat hier vastligt is de afloopcode, niet de opmaak van de meldingen. `just
+//! validate` (en daarmee de pre-commit-hook) beslist op die code of een
+//! wijziging in `corpus/regulation/` mag landen; een `validate` die stilletjes
+//! 0 teruggeeft op een kapot wetsbestand is een open poort.
+//!
+//! Alleen gebouwd met de `validate`-feature, net als de binary zelf (die heeft
+//! `required-features = ["validate"]`). `just test` draait met `--all-features`.
+#![cfg(feature = "validate")]
+
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+fn fixture(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!("tests/fixtures/validate_cli/{name}"))
+}
+
+fn run(args: &[PathBuf]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_validate"))
+        .args(args)
+        .output()
+        .expect("validate-binary kon niet starten")
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+/// Zonder bestanden is er niets gevalideerd, en dat is geen goedkeuring.
+#[test]
+fn zonder_argumenten_is_het_een_gebruiksfout() {
+    let output = run(&[]);
+    assert_eq!(output.status.code(), Some(1), "stderr: {}", stderr(&output));
+    assert!(
+        stderr(&output).contains("Usage"),
+        "stderr: {}",
+        stderr(&output)
+    );
+}
+
+/// Een schema-geldig, unit-schoon bestand komt door de poort.
+#[test]
+fn geldig_bestand_slaagt() {
+    let output = run(&[fixture("valid.yaml")]);
+    assert_eq!(output.status.code(), Some(0), "stderr: {}", stderr(&output));
+    assert!(
+        stderr(&output).contains("OK:"),
+        "stderr: {}",
+        stderr(&output)
+    );
+}
+
+/// Een schemaovertreding die het lenient law-model wél accepteert (ontbrekende
+/// top-level `url`) moet alsnog een afkeuring opleveren.
+#[test]
+fn schemaovertreding_faalt() {
+    let output = run(&[fixture("schema_violation.yaml")]);
+    let err = stderr(&output);
+    assert_eq!(output.status.code(), Some(1), "stderr: {err}");
+    assert!(err.contains("FAIL"), "stderr: {err}");
+    assert!(err.contains("schema"), "stderr: {err}");
+    assert!(!err.contains("OK:"), "stderr: {err}");
+}
+
+/// Een bestand zonder `$schema` is niet te valideren en gaat er dus uit.
+#[test]
+fn ontbrekend_schemaveld_faalt() {
+    let output = run(&[fixture("no_schema_field.yaml")]);
+    let err = stderr(&output);
+    assert_eq!(output.status.code(), Some(1), "stderr: {err}");
+    assert!(err.contains("missing $schema field"), "stderr: {err}");
+}
+
+/// De unit-controle (RFC-023) draait ná een geslaagde schemavalidatie en telt
+/// mee in de afloopcode: eurocent bij dagen optellen is een FAIL, geen WARN.
+#[test]
+fn unit_mismatch_in_geldig_schema_faalt() {
+    let output = run(&[fixture("unit_mismatch.yaml")]);
+    let err = stderr(&output);
+    assert_eq!(output.status.code(), Some(1), "stderr: {err}");
+    assert!(err.contains("units:"), "stderr: {err}");
+    // Het schema keurde het bestand goed; de afkeuring komt van de units.
+    assert!(err.contains("OK:"), "stderr: {err}");
+}
+
+/// Eén kapot bestand tussen goede bestanden bepaalt de afloopcode; de andere
+/// bestanden worden nog wel gecontroleerd.
+#[test]
+fn een_kapot_bestand_kleurt_de_hele_run() {
+    let output = run(&[fixture("valid.yaml"), fixture("schema_violation.yaml")]);
+    let err = stderr(&output);
+    assert_eq!(output.status.code(), Some(1), "stderr: {err}");
+    assert!(err.contains("OK:"), "stderr: {err}");
+    assert!(err.contains("FAIL"), "stderr: {err}");
+}


### PR DESCRIPTION
58 overlevers uit #1052, verspreid over negen bestanden. Dit is de groep waar het onderscheid tussen "testgat" en "zegt niets" het meest schuurt; de grens die is aangehouden is of een functie iets beslist of alleen types vertaalt. `wasm.rs` bestaat grotendeels uit doorgeefluiken die `JsValue` in en uit geven. Die zijn native niet uit te voeren, want wasm-bindgen breekt buiten wasm32 af, en de beslislogica die ze aanroepen wordt in `service.rs` en `annotation/` al gemuteerd; die elf staan als uitsluiting in #1063.

Eén functie daar besliste wel iets. `resolveNotes` filtert de notities weg die een andere wet aanwijzen. Keert die vergelijking om, dan hangt de engine de annotaties van andere wetten aan deze tekst en laat hij de eigen notities liggen. Dat filter staat nu als `note_targets_another_law` naast de binding, negatief geformuleerd zodat de aanroepplaats geen `!` nodig heeft en er geen tweede mutant ontstaat in code die geen test kan bereiken.

Verder beslist `bin/validate.rs` in pre-commit en CI of een corpuswijziging mag landen, en geen enkele test raakte hem aan; er staat nu een integratietest die de binary draait en de afloopcode op vier takken vastlegt. In `trace.rs` had `PathNode::render_internal` een `if j == 0` waarvan beide takken dezelfde `format!` uitvoerden. Die is weg.