### PR TITLE
fix(docs): rfcs/index.md wijst naar /rfcs, niet naar /rfcs/index

### DIFF
--- a/docs/scripts/gen-pa11yci.mjs
+++ b/docs/scripts/gen-pa11yci.mjs
@@ -65,8 +65,17 @@ function scopeRoutes(allRoutes) {
       return null;
     }
     const [, collection, rest] = match;
-    const slug = rest.replace(/\/index$/, '');
-    const route = collection === 'rfcs' ? `/rfcs/${slug}` : `/${slug}`;
+    // Een kale `index` hoort ook weg, niet alleen `…/index`: src/content/
+    // rfcs/index.md is de route /rfcs, niet /rfcs/index.
+    const slug = rest.replace(/(^|\/)index$/, '');
+    const route =
+      collection === 'rfcs'
+        ? slug === ''
+          ? '/rfcs'
+          : `/rfcs/${slug}`
+        : slug === ''
+          ? '/docs'
+          : `/${slug}`;
     if (!allRoutes.includes(route)) {
       console.log(`Volledige gate: ${file} kon niet op een route worden afgebeeld (${route}).`);
       return null;


### PR DESCRIPTION
De afbeelding van bestand naar route in `gen-pa11yci.mjs` knipte alleen een afsluitende `/index` weg, niet een kale `index`. Daardoor viel elke wijziging in de RFC-index terug op de volledige site van 89 pagina's, en dat bestand wordt aangeraakt zodra er een RFC bijkomt.

Nagelopen tegen de echte routeverzameling uit een CI-run: 76 van de 77 inhoudsbestanden beelden nu correct af. Het overgebleven bestand is `rfcs/template.md`, dat geen pagina publiceert en daarom niet af te beelden is; dat valt terecht terug op de volledige site.