### PR TITLE
perf(ci): postgres als service naast de db-job in plaats van per testbinary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,12 +334,34 @@ jobs:
         include:
           - leg: unit
             recipe: test-no-docker
+            postgres-url: ''
           - leg: db
             recipe: test-db
+            # De testhelper start zelf een container als deze leeg is. Hier
+            # staat er al een als service naast de job, en dat scheelt de
+            # opstart in elk van de ruim twintig testbinaries.
+            postgres-url: postgres://postgres:postgres@127.0.0.1:5432
+    services:
+      # Dezelfde image als de testhelper zelf zou starten, zodat de tests op
+      # dezelfde Postgres draaien als lokaal zonder deze variabele. Het
+      # unit-been gebruikt hem niet; die paar seconden opstart zijn de
+      # eenvoud van één matrix waard.
+      postgres:
+        image: postgres:11-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     env:
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
       CARGO_INCREMENTAL: "0"
+      TEST_POSTGRES_URL: ${{ matrix.postgres-url }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 

--- a/packages/pipeline/src/test_utils.rs
+++ b/packages/pipeline/src/test_utils.rs
@@ -16,27 +16,36 @@ use tokio::sync::Mutex;
 use crate::config::PipelineConfig;
 use crate::db;
 
-/// One Postgres container per test binary, shared by every `TestDb` in it,
-/// together with the connection details resolved once.
+/// Where the tests get their Postgres from.
 ///
-/// A container per test is what this used to do, and at 185 call sites that is
-/// 185 container starts per run. Resolving the published port is a second
-/// daemon round-trip; doing that per test had thirty tests inspecting the
-/// daemon at once, which fails with EAGAIN and reads as a test failure.
+/// `TEST_POSTGRES_URL` points at a server that is already running — a
+/// `services:` block in CI, or a container someone started by hand. Without it
+/// the helper starts its own container, so a plain `cargo test` keeps working
+/// without setup.
+///
+/// The container variant is shared per test binary, together with the
+/// connection details resolved once. A container per test is what this used to
+/// do, and at 185 call sites that is 185 container starts per run; resolving
+/// the published port is a second daemon round-trip, and doing that per test
+/// had thirty tests inspecting the daemon at once, which fails with EAGAIN and
+/// reads as a test failure. Cargo runs each test binary as its own process, so
+/// even shared-per-binary still pays that start about two dozen times per run.
+/// An external server pays it zero times.
 ///
 /// Held as a `Weak` so the container still stops when the last `TestDb` in the
 /// binary drops; a `static` is never dropped, so an owning handle here would
 /// leave the container running after the process exits.
 struct SharedPostgres {
     base_url: String,
-    _container: ContainerAsync<Postgres>,
+    _container: Option<ContainerAsync<Postgres>>,
 }
 
 static SHARED_CONTAINER: LazyLock<Mutex<Weak<SharedPostgres>>> =
     LazyLock::new(|| Mutex::new(Weak::new()));
 
-/// Names the per-test database. Only unique within one test binary, which is
-/// enough: each binary has its own container.
+/// Names the per-test database. The process id is part of the name because an
+/// external server is shared by every test binary in a run, and the counter
+/// alone is only unique within one process.
 static DB_SEQ: AtomicU64 = AtomicU64::new(0);
 
 #[allow(clippy::unwrap_used)]
@@ -46,22 +55,34 @@ async fn shared_postgres() -> Arc<SharedPostgres> {
         return running;
     }
 
-    let container = Postgres::default().start().await.unwrap();
-    let host_port = container.get_host_port_ipv4(5432).await.unwrap();
-    // testcontainers reports the published port on the docker host. From a
-    // native Linux dev environment `127.0.0.1` is correct; from a dev
-    // container talking to Docker Desktop on a different host (WSL2, remote
-    // docker) the docker host is reachable as `host.docker.internal` instead.
-    // `TESTCONTAINERS_HOST_OVERRIDE` lets those setups point at the right host
-    // without forking this helper.
-    let host = std::env::var("TESTCONTAINERS_HOST_OVERRIDE")
+    let external = std::env::var("TEST_POSTGRES_URL")
         .ok()
-        .filter(|s| !s.trim().is_empty())
-        .unwrap_or_else(|| "127.0.0.1".to_string());
+        .filter(|s| !s.trim().is_empty());
 
-    let started = Arc::new(SharedPostgres {
-        base_url: format!("postgres://postgres:postgres@{host}:{host_port}"),
-        _container: container,
+    let started = Arc::new(match external {
+        Some(url) => SharedPostgres {
+            base_url: url.trim_end_matches('/').to_string(),
+            _container: None,
+        },
+        None => {
+            let container = Postgres::default().start().await.unwrap();
+            let host_port = container.get_host_port_ipv4(5432).await.unwrap();
+            // testcontainers reports the published port on the docker host.
+            // From a native Linux dev environment `127.0.0.1` is correct; from
+            // a dev container talking to Docker Desktop on a different host
+            // (WSL2, remote docker) the docker host is reachable as
+            // `host.docker.internal` instead. `TESTCONTAINERS_HOST_OVERRIDE`
+            // lets those setups point at the right host without forking this
+            // helper.
+            let host = std::env::var("TESTCONTAINERS_HOST_OVERRIDE")
+                .ok()
+                .filter(|s| !s.trim().is_empty())
+                .unwrap_or_else(|| "127.0.0.1".to_string());
+            SharedPostgres {
+                base_url: format!("postgres://postgres:postgres@{host}:{host_port}"),
+                _container: Some(container),
+            }
+        }
     });
     *shared = Arc::downgrade(&started);
     started
@@ -80,7 +101,11 @@ impl TestDb {
     pub async fn new() -> Self {
         let shared = shared_postgres().await;
 
-        let db_name = format!("regelrecht_test_{}", DB_SEQ.fetch_add(1, Ordering::Relaxed));
+        let db_name = format!(
+            "regelrecht_test_{}_{}",
+            std::process::id(),
+            DB_SEQ.fetch_add(1, Ordering::Relaxed)
+        );
         let admin = PgPool::connect(&format!("{}/postgres", shared.base_url))
             .await
             .unwrap();


### PR DESCRIPTION
De testhelper deelt sinds #1061 één container per proces, maar cargo draait ruim twintig testbinaries als losse processen, dus de opstart wordt per binary betaald: het eerste kost bijna twaalf seconden en elk volgend DB-rakend binary zit op een bodem van bijna twee die er niet hoeft te zijn. `TestDb` honoreert nu `TEST_POSTGRES_URL` als die gezet is en start anders zoals voorheen zijn eigen container, dus een kale `cargo test` blijft werken zonder opzet. De databasenaam draagt het proces-id, want een externe server wordt door alle binaries in een run gedeeld en de teller alleen is enkel binnen één proces uniek.

Geslaagd bij een testfase onder de 30 seconden en een db-job die niet langer duurt dan het unit-been; terug bij een testfase boven de 50 seconden of ook maar één flake op databasenaam-collisies in vijf runs, want een wisselvallige testsuite is duurder dan de winst. Dit vervangt het eerdere plan om sccache te vervangen door een target-dir-cache; dat is afgewezen omdat sccache 108 rustc-aanroepen structureel niet cachet en de cachepot van de repo al over de limiet staat.