### PR TITLE
feat(ci): deploy-filters uit de dependency-graaf in plaats van met de hand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,6 +293,20 @@ jobs:
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('packages/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-registry-
 
+      # De deploy-filters leiden zichzelf af uit de cargo-graaf, dus een crate
+      # die van eigenaar wisselt kan een component stil buiten de deploy laten
+      # vallen. Die test hoort in een required check, en deze baan heeft cargo
+      # al staan; `cargo metadata` bouwt niets en kost seconden.
+      - name: Setup Node.js
+        if: needs.changes.outputs.ci == 'true'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
+        with:
+          node-version: '22'
+
+      - name: Check deploy filters
+        if: needs.changes.outputs.ci == 'true'
+        run: just deploy-filters-test
+
       # Leak-guard laag 2: voorzie het git-ignored aanvulbestand met de casus-/
       # sector-specifieke patronen uit een secret, zodat de skills-no-casus hook in
       # CI op volle sterkte draait zonder die patronen in de publieke repo te zetten.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,60 +33,34 @@ jobs:
       docs: ${{ steps.filter.outputs.docs }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-
-      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
-        id: filter
         with:
-          filters: |
-            editor:
-              - 'frontend/**'
-              - 'packages/frontend-shared/**'
-              - 'packages/editor-api/**'
-              - 'packages/engine/**'
-              - 'packages/corpus/**'
-              - 'packages/github/**'
-              - 'packages/shared/**'
-              - 'packages/Cargo.lock'
-              - 'corpus-registry.yaml'
-              - 'corpus/regulation/**'
-            admin:
-              - 'packages/admin/**'
-              - 'packages/frontend-shared/**'
-              - 'packages/pipeline/**'
-              - 'packages/corpus/**'
-              - 'packages/github/**'
-              - 'packages/harvester/**'
-              - 'packages/shared/**'
-              - 'packages/Cargo.lock'
-            harvester-worker:
-              - 'packages/pipeline/**'
-              - 'packages/harvester/**'
-              - 'packages/corpus/**'
-              - 'packages/github/**'
-              - 'packages/shared/**'
-              - 'packages/Cargo.lock'
-            enrich-worker:
-              - 'packages/pipeline/**'
-              - 'packages/corpus/**'
-              - 'packages/github/**'
-              - 'packages/harvester/**'
-              - 'packages/shared/**'
-              - 'packages/Cargo.lock'
-              - '.claude/skills/law-*/**'
-            pipeline-api:
-              - 'packages/pipeline/**'
-              - 'packages/corpus/**'
-              - 'packages/github/**'
-              - 'packages/harvester/**'
-              - 'packages/shared/**'
-              - 'packages/Cargo.lock'
-            grafana:
-              - 'packages/grafana/**'
-            lawmaking:
-              - 'frontend-lawmaking/**'
-              - 'packages/frontend-shared/**'
-            docs:
-              - 'docs/**'
+          # De diff tegen de base (PR) of tegen de vorige commit (push) bepaalt
+          # welke bestanden gewijzigd zijn.
+          fetch-depth: 0
+
+      - name: Bepaal gewijzigde bestanden
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          # Een lege of nul-SHA (nieuwe branch, eerste push) betekent: geen
+          # betrouwbare diff, dus alles bouwen. Dat regelt het script zelf als
+          # de lijst leeg blijft.
+          if [ -n "$BASE_SHA" ] && [ "$BASE_SHA" != "0000000000000000000000000000000000000000" ] \
+             && git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null; then
+            git diff --name-only "$BASE_SHA" HEAD > changed.txt
+          else
+            : > changed.txt
+          fi
+          echo "Gewijzigde bestanden: $(wc -l < changed.txt)"
+
+      # Welke componenten geraakt worden volgt uit de dependency-graaf van
+      # cargo, niet uit een handmatige padenlijst. Die lijst dreef weg:
+      # packages/auth en packages/law-model stonden er nergens in, terwijl
+      # editor-api en admin op auth leunen en engine, corpus, pipeline en
+      # harvester op law-model. Faalt het script, dan zet het alles op true.
+      - name: Bepaal geraakte componenten
+        id: filter
+        run: node script/deploy-filters.mjs --from-file changed.txt
 
   # -- Build jobs --
   build:

--- a/Justfile
+++ b/Justfile
@@ -66,11 +66,17 @@ validate-annotations *FILES:
 conformance:
     cd packages && {{ci_flags}} cargo test -p regelrecht-engine --features validate --test conformance
 
+# Pins the deploy filters against the real cargo graph. Node's built-in test
+# runner, so no dependency for one file. Needs `cargo metadata`, not a build.
+[doc("Check the deploy filters against the real cargo dependency graph")]
+deploy-filters-test:
+    node --test script/deploy-filters.test.mjs
+
 # Run all quality checks, exactly what CI runs. Needs Docker for the
 # container-backed suites; on a machine without a daemon, swap `test` for
 # `test-no-docker`.
 [doc("Run all quality checks, exactly what CI runs (needs Docker)")]
-check: format lint build-check validate validate-annotations test
+check: format lint build-check validate validate-annotations deploy-filters-test test
 
 # --- Tests ---
 

--- a/script/deploy-filters.mjs
+++ b/script/deploy-filters.mjs
@@ -18,11 +18,12 @@
 // zijn, en dat is precies de fout die dit script moet uitbannen.
 
 import { execFileSync } from 'node:child_process';
-import { appendFileSync, readFileSync } from 'node:fs';
+import { appendFileSync, readFileSync, realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
 // Per component: de crate waar het image aan hangt (of null), plus de paden
 // buiten de graaf die het image beïnvloeden.
-const COMPONENTS = {
+export const COMPONENTS = {
   editor: {
     crate: 'regelrecht-editor-api',
     paths: [
@@ -64,7 +65,7 @@ const RUST_WIDE = [
   'rust-toolchain.toml',
 ];
 
-function workspaceGraph() {
+export function workspaceGraph() {
   const raw = execFileSync(
     'cargo',
     ['metadata', '--no-deps', '--format-version', '1'],
@@ -94,6 +95,49 @@ function workspaceGraph() {
   return { byName, closure, dirOf };
 }
 
+// Eén implementatie van "hoe rapporteren we een component-uitkomst", zodat de
+// fallback hieronder hem kan hergebruiken in plaats van hem na te bouwen.
+function emit(name, value) {
+  console.log(`${name}=${value}`);
+  const out = process.env.GITHUB_OUTPUT;
+  if (out) appendFileSync(out, `${name}=${value}\n`);
+}
+
+// De padprefixen die dit component raken: de handmatige lijst, en voor een
+// component met een image de crate zelf plus zijn hele normal/build-closure.
+export function prefixesFor(spec, graph) {
+  const prefixes = [...spec.paths];
+  if (!spec.crate) return prefixes;
+
+  if (!graph.byName.has(spec.crate)) {
+    throw new Error(`crate ${spec.crate} niet gevonden in de workspace`);
+  }
+  prefixes.push(...RUST_WIDE);
+  for (const dep of [spec.crate, ...graph.closure(spec.crate)]) {
+    const dir = graph.dirOf(dep);
+    if (!dir) throw new Error(`geen pad voor crate ${dep}`);
+    prefixes.push(dir);
+  }
+  return prefixes;
+}
+
+// Welke componenten raakt deze lijst gewijzigde bestanden? Een lege lijst
+// betekent "we weten het niet" en dus alles bouwen, dezelfde kant op als de
+// fallback: een overbodige build is goedkoper dan een stille overslag.
+export function componentsFor(changed, graph) {
+  const result = {};
+  const unknown = changed.length === 0;
+  for (const [name, spec] of Object.entries(COMPONENTS)) {
+    if (unknown) {
+      result[name] = true;
+      continue;
+    }
+    const prefixes = prefixesFor(spec, graph);
+    result[name] = changed.some((file) => prefixes.some((p) => file.startsWith(p)));
+  }
+  return result;
+}
+
 function main() {
   // Uit een bestand als het er is: een grote PR heeft meer bestandsnamen dan
   // er in een commandoregel passen.
@@ -102,45 +146,31 @@ function main() {
     args[0] === '--from-file'
       ? readFileSync(args[1], 'utf8').split('\n').filter(Boolean)
       : args.filter(Boolean);
-  const out = process.env.GITHUB_OUTPUT;
-  const emit = (name, value) => {
-    console.log(`${name}=${value}`);
-    if (out) appendFileSync(out, `${name}=${value}\n`);
-  };
 
   if (changed.length === 0) {
     console.log('Geen lijst met gewijzigde bestanden: alles bouwen.');
-    for (const name of Object.keys(COMPONENTS)) emit(name, true);
+    for (const [name, hit] of Object.entries(componentsFor(changed, null))) {
+      emit(name, hit);
+    }
     return;
   }
 
-  const { byName, closure, dirOf } = workspaceGraph();
-
-  for (const [name, spec] of Object.entries(COMPONENTS)) {
-    const prefixes = [...spec.paths];
-    if (spec.crate) {
-      if (!byName.has(spec.crate)) {
-        throw new Error(`crate ${spec.crate} niet gevonden in de workspace`);
-      }
-      prefixes.push(...RUST_WIDE);
-      for (const dep of [spec.crate, ...closure(spec.crate)]) {
-        const dir = dirOf(dep);
-        if (!dir) throw new Error(`geen pad voor crate ${dep}`);
-        prefixes.push(dir);
-      }
-    }
-    const hit = changed.some((file) => prefixes.some((p) => file.startsWith(p)));
+  const graph = workspaceGraph();
+  for (const [name, hit] of Object.entries(componentsFor(changed, graph))) {
     emit(name, hit);
   }
 }
 
-try {
-  main();
-} catch (error) {
-  console.log(`::warning::deploy-filters faalde (${error.message}); alles bouwen.`);
-  const out = process.env.GITHUB_OUTPUT;
-  for (const name of Object.keys(COMPONENTS)) {
-    console.log(`${name}=true`);
-    if (out) appendFileSync(out, `${name}=true\n`);
+// Alleen draaien als het script zelf is aangeroepen; bij `import` vanuit de
+// test moet er niets gebeuren.
+const invokedDirectly =
+  process.argv[1] && realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));
+
+if (invokedDirectly) {
+  try {
+    main();
+  } catch (error) {
+    console.log(`::warning::deploy-filters faalde (${error.message}); alles bouwen.`);
+    for (const name of Object.keys(COMPONENTS)) emit(name, true);
   }
 }

--- a/script/deploy-filters.mjs
+++ b/script/deploy-filters.mjs
@@ -1,0 +1,146 @@
+// Bepaal welke deploybare componenten door een wijziging geraakt worden.
+//
+// Waarom niet met de hand: `deploy.yml` somde per component de paden op die
+// hem raken, en die lijst dreef weg. `packages/auth` en `packages/law-model`
+// stonden er in geen enkele filter, terwijl editor-api en admin op auth leunen
+// en engine, corpus, pipeline en harvester op law-model. Een merge die alleen
+// zo'n crate raakte bouwde dus geen image en rolde niets uit, zonder dat er
+// iets rood werd. Dit script leidt de Rust-kant af uit de dependency-graaf van
+// cargo, zodat een nieuwe crate vanzelf op de goede plek terechtkomt.
+//
+// De niet-Rust-kant blijft met de hand: frontends, Dockerfiles, het corpus en
+// de skills die de enrich-worker meeneemt. Die verzameling is klein en
+// verandert zelden.
+//
+// Faalt hier iets — cargo ontbreekt, de graaf is onleesbaar, een pad valt
+// buiten alle regels — dan zet het script alles op `true`. De duurste uitkomst
+// is dan een overbodige build; de goedkope uitkomst zou een stille overslag
+// zijn, en dat is precies de fout die dit script moet uitbannen.
+
+import { execFileSync } from 'node:child_process';
+import { appendFileSync, readFileSync } from 'node:fs';
+
+// Per component: de crate waar het image aan hangt (of null), plus de paden
+// buiten de graaf die het image beïnvloeden.
+const COMPONENTS = {
+  editor: {
+    crate: 'regelrecht-editor-api',
+    paths: [
+      'frontend/',
+      'packages/frontend-shared/',
+      'corpus-registry.yaml',
+      'corpus/regulation/',
+    ],
+  },
+  admin: {
+    crate: 'regelrecht-admin',
+    paths: ['packages/frontend-shared/', 'packages/admin/Dockerfile'],
+  },
+  'harvester-worker': {
+    crate: 'regelrecht-pipeline',
+    paths: ['packages/pipeline/Dockerfile'],
+  },
+  'enrich-worker': {
+    crate: 'regelrecht-pipeline',
+    paths: ['packages/pipeline/Dockerfile', '.claude/skills/law-'],
+  },
+  'pipeline-api': {
+    crate: 'regelrecht-pipeline',
+    paths: ['packages/pipeline/Dockerfile'],
+  },
+  grafana: { crate: null, paths: ['packages/grafana/'] },
+  lawmaking: {
+    crate: null,
+    paths: ['frontend-lawmaking/', 'packages/frontend-shared/'],
+  },
+  docs: { crate: null, paths: ['docs/'] },
+};
+
+// Raakt elk component met een Rust-image: de workspace zelf.
+const RUST_WIDE = [
+  'packages/Cargo.lock',
+  'packages/Cargo.toml',
+  'packages/.cargo/',
+  'rust-toolchain.toml',
+];
+
+function workspaceGraph() {
+  const raw = execFileSync(
+    'cargo',
+    ['metadata', '--no-deps', '--format-version', '1'],
+    { cwd: 'packages', maxBuffer: 64 * 1024 * 1024, encoding: 'utf8' },
+  );
+  const meta = JSON.parse(raw);
+  const byName = new Map(meta.packages.map((p) => [p.name, p]));
+
+  // Alleen `normal` en `build`: een dev-dependency zit niet in de binary, dus
+  // een wijziging daarin hoeft geen image te bouwen.
+  const closure = (name, seen = new Set()) => {
+    for (const dep of byName.get(name)?.dependencies ?? []) {
+      const kind = dep.kind ?? 'normal';
+      if (!byName.has(dep.name) || seen.has(dep.name) || kind === 'dev') continue;
+      seen.add(dep.name);
+      closure(dep.name, seen);
+    }
+    return seen;
+  };
+
+  const dirOf = (name) => {
+    const manifest = byName.get(name)?.manifest_path ?? '';
+    const idx = manifest.lastIndexOf('/packages/');
+    return idx === -1 ? null : manifest.slice(idx + 1).replace(/Cargo\.toml$/, '');
+  };
+
+  return { byName, closure, dirOf };
+}
+
+function main() {
+  // Uit een bestand als het er is: een grote PR heeft meer bestandsnamen dan
+  // er in een commandoregel passen.
+  const args = process.argv.slice(2);
+  const changed =
+    args[0] === '--from-file'
+      ? readFileSync(args[1], 'utf8').split('\n').filter(Boolean)
+      : args.filter(Boolean);
+  const out = process.env.GITHUB_OUTPUT;
+  const emit = (name, value) => {
+    console.log(`${name}=${value}`);
+    if (out) appendFileSync(out, `${name}=${value}\n`);
+  };
+
+  if (changed.length === 0) {
+    console.log('Geen lijst met gewijzigde bestanden: alles bouwen.');
+    for (const name of Object.keys(COMPONENTS)) emit(name, true);
+    return;
+  }
+
+  const { byName, closure, dirOf } = workspaceGraph();
+
+  for (const [name, spec] of Object.entries(COMPONENTS)) {
+    const prefixes = [...spec.paths];
+    if (spec.crate) {
+      if (!byName.has(spec.crate)) {
+        throw new Error(`crate ${spec.crate} niet gevonden in de workspace`);
+      }
+      prefixes.push(...RUST_WIDE);
+      for (const dep of [spec.crate, ...closure(spec.crate)]) {
+        const dir = dirOf(dep);
+        if (!dir) throw new Error(`geen pad voor crate ${dep}`);
+        prefixes.push(dir);
+      }
+    }
+    const hit = changed.some((file) => prefixes.some((p) => file.startsWith(p)));
+    emit(name, hit);
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.log(`::warning::deploy-filters faalde (${error.message}); alles bouwen.`);
+  const out = process.env.GITHUB_OUTPUT;
+  for (const name of Object.keys(COMPONENTS)) {
+    console.log(`${name}=true`);
+    if (out) appendFileSync(out, `${name}=true\n`);
+  }
+}

--- a/script/deploy-filters.test.mjs
+++ b/script/deploy-filters.test.mjs
@@ -1,0 +1,175 @@
+// Pint het gedrag van deploy-filters vast tegen de echte cargo-graaf van deze
+// workspace.
+//
+// Waarom tegen de echte graaf en niet tegen een verzonnen fixture: de fout die
+// dit script uitbant was een lijst die wegdreef van de werkelijkheid. Een
+// fixture zou meedrijven. Deze test rekent dezelfde graaf na die de CI gebruikt,
+// dus een crate die van eigenaar wisselt komt hier boven water.
+//
+// De `try`/`catch` in het script vangt alleen gegooide fouten. De gevallen
+// hieronder dekken juist de stille kant: een verkeerde `kind === 'dev'`-check of
+// een verschoven `dirOf` gooit niets, maar levert `false` op voor een component
+// die had moeten uitrollen. Dat is precies de klasse fouten waarvoor het script
+// bestaat.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { COMPONENTS, componentsFor, prefixesFor, workspaceGraph } from './deploy-filters.mjs';
+
+// Eén keer afleiden; `cargo metadata` is de duurste stap in dit bestand.
+const graph = workspaceGraph();
+
+const namesOf = (changed) => componentsFor(changed, graph);
+const allComponents = Object.keys(COMPONENTS);
+
+test('dirOf leidt het cratepad af, relatief en met slash', () => {
+  assert.equal(graph.dirOf('regelrecht-auth'), 'packages/auth/');
+  assert.equal(graph.dirOf('regelrecht-law-model'), 'packages/law-model/');
+  assert.equal(graph.dirOf('regelrecht-editor-api'), 'packages/editor-api/');
+
+  // Geen absoluut pad en geen achtergebleven Cargo.toml: daar zou `startsWith`
+  // stilzwijgend nooit meer matchen.
+  for (const name of graph.byName.keys()) {
+    const dir = graph.dirOf(name);
+    assert.ok(dir.startsWith('packages/'), `${name} gaf ${dir}`);
+    assert.ok(dir.endsWith('/'), `${name} gaf ${dir}`);
+    assert.ok(!dir.includes('Cargo.toml'), `${name} gaf ${dir}`);
+  }
+});
+
+test('de closure van editor-api bevat de twee crates die eerder ontbraken', () => {
+  const closure = graph.closure('regelrecht-editor-api');
+  assert.ok(closure.has('regelrecht-auth'));
+  assert.ok(closure.has('regelrecht-law-model'));
+
+  // law-model zit er indirect in, via pipeline en corpus; shared hangt er weer
+  // onder. Valt de recursie weg, dan blijft alleen de directe laag over.
+  assert.ok(closure.has('regelrecht-shared'));
+  assert.ok(closure.has('regelrecht-engine'));
+});
+
+test('een dev-dependency telt niet mee voor de closure', () => {
+  // harvester heeft law-model uitsluitend als dev-dependency: die code zit niet
+  // in de binary, dus een wijziging erin hoeft dit image niet te bouwen.
+  const harvester = graph.closure('regelrecht-harvester');
+  assert.ok(harvester.has('regelrecht-shared'));
+  assert.ok(
+    !harvester.has('regelrecht-law-model'),
+    'law-model is een dev-dependency van harvester en hoort niet in de closure',
+  );
+
+  // corpus heeft engine alleen als dev-dependency.
+  const corpus = graph.closure('regelrecht-corpus');
+  assert.ok(corpus.has('regelrecht-law-model'));
+  assert.ok(corpus.has('regelrecht-github'));
+  assert.ok(
+    !corpus.has('regelrecht-engine'),
+    'engine is een dev-dependency van corpus en hoort niet in de closure',
+  );
+});
+
+test('een wijziging in packages/auth laat de editor uitrollen', () => {
+  // Het gat waarvoor dit script is geschreven. Zonder de graaf stond auth in
+  // geen enkele filter en rolde er niets uit.
+  const hit = namesOf(['packages/auth/src/oidc.rs']);
+  assert.equal(hit.editor, true);
+  assert.equal(hit.admin, true);
+
+  // pipeline leunt niet op auth, dus de drie pipeline-images blijven staan.
+  assert.equal(hit['pipeline-api'], false);
+  assert.equal(hit['harvester-worker'], false);
+  assert.equal(hit['enrich-worker'], false);
+  assert.equal(hit.docs, false);
+});
+
+test('een wijziging in packages/law-model raakt alle crate-componenten', () => {
+  const hit = namesOf(['packages/law-model/src/lib.rs']);
+  assert.equal(hit.editor, true);
+  assert.equal(hit.admin, true);
+  assert.equal(hit['pipeline-api'], true);
+  assert.equal(hit['harvester-worker'], true);
+  assert.equal(hit['enrich-worker'], true);
+
+  // De componenten zonder Rust-image blijven er buiten.
+  assert.equal(hit.docs, false);
+  assert.equal(hit.grafana, false);
+  assert.equal(hit.lawmaking, false);
+});
+
+test('een pad dat bij geen enkel component hoort levert niets op', () => {
+  // tui en arch-extract zitten in geen enkele closure: het zijn crates zonder
+  // image. Zou hier iets `true` worden, dan is de closure te ruim en zegt een
+  // groene filter niets meer.
+  for (const path of [
+    'packages/tui/src/main.rs',
+    'packages/arch-extract/src/lib.rs',
+    'README.md',
+    'REVIEW.md',
+  ]) {
+    const hit = namesOf([path]);
+    const geraakt = allComponents.filter((name) => hit[name]);
+    assert.deepEqual(geraakt, [], `${path} raakte ${geraakt.join(', ')}`);
+  }
+});
+
+test('de handmatige paden buiten de graaf blijven werken', () => {
+  assert.equal(namesOf(['docs/src/content/docs/index.md']).docs, true);
+  assert.equal(namesOf(['docs/src/content/docs/index.md']).editor, false);
+
+  assert.equal(namesOf(['packages/grafana/dashboards/pipeline.json']).grafana, true);
+  assert.equal(namesOf(['packages/grafana/dashboards/pipeline.json']).editor, false);
+
+  assert.equal(namesOf(['frontend-lawmaking/src/App.vue']).lawmaking, true);
+  assert.equal(namesOf(['frontend-lawmaking/src/App.vue']).editor, false);
+
+  assert.equal(namesOf(['frontend/src/main.ts']).editor, true);
+  assert.equal(namesOf(['frontend/src/main.ts']).lawmaking, false);
+
+  // frontend-shared zit in drie frontends tegelijk.
+  const shared = namesOf(['packages/frontend-shared/src/auth.ts']);
+  assert.equal(shared.editor, true);
+  assert.equal(shared.admin, true);
+  assert.equal(shared.lawmaking, true);
+});
+
+test('de skills raken alleen de enrich-worker', () => {
+  // Drie componenten hangen aan dezelfde crate; alleen de enrich-worker neemt
+  // de skills mee in zijn image.
+  const hit = namesOf(['.claude/skills/law-generate/SKILL.md']);
+  assert.equal(hit['enrich-worker'], true);
+  assert.equal(hit['harvester-worker'], false);
+  assert.equal(hit['pipeline-api'], false);
+});
+
+test('een workspace-brede wijziging raakt elk Rust-image', () => {
+  for (const path of ['packages/Cargo.lock', 'packages/Cargo.toml', 'rust-toolchain.toml']) {
+    const hit = namesOf([path]);
+    assert.equal(hit.editor, true, path);
+    assert.equal(hit.admin, true, path);
+    assert.equal(hit['pipeline-api'], true, path);
+    assert.equal(hit.docs, false, path);
+  }
+});
+
+test('zonder lijst met gewijzigde bestanden bouwt alles', () => {
+  // Fail-open: weten we niets, dan is een overbodige build goedkoper dan een
+  // stille overslag.
+  const hit = componentsFor([], null);
+  for (const name of allComponents) {
+    assert.equal(hit[name], true, name);
+  }
+});
+
+test('elk component in de tabel levert bruikbare prefixen op', () => {
+  // Vangt een tikfout in een cratenaam: die gooit, en de fallback zou dan bij
+  // elke run alles bouwen zonder dat iemand het merkt.
+  for (const [name, spec] of Object.entries(COMPONENTS)) {
+    const prefixes = prefixesFor(spec, graph);
+    assert.ok(prefixes.length > 0, `${name} leverde geen prefixen op`);
+    for (const prefix of prefixes) {
+      assert.equal(typeof prefix, 'string');
+      assert.ok(prefix.length > 0, `${name} leverde een lege prefix op`);
+    }
+  }
+});


### PR DESCRIPTION
`deploy.yml` somde per component op welke paden hem raken, en die lijst dreef weg. `packages/auth` en `packages/law-model` stonden in geen enkele filter, terwijl editor-api en admin op auth leunen en engine, corpus, pipeline en harvester op law-model. Een merge die alleen zo'n crate raakte bouwde geen image en rolde niets uit zonder dat er iets rood werd, en productie bleef op de oude code draaien tot een volgende PR het toevallig meenam. Dat is de bug uit #1060.

`script/deploy-filters.mjs` leidt de Rust-kant nu af uit `cargo metadata`, alleen `normal`- en `build`-dependencies, want een dev-dependency zit niet in de binary. De niet-Rust-kant blijft met de hand: frontends, Dockerfiles, corpus en de skills die de enrich-worker meeneemt, een verzameling die klein is en zelden verandert. Faalt het script, dan zet het alles op `true` met een zichtbare `::warning::`. De duurste uitkomst is dan een overbodige build, en een stille overslag is de fout die dit moet uitbannen.

Elk pad dat de oude filters vingen geeft dezelfde uitkomst. Aan de deploystappen en aan ZAD is niets veranderd.