### PR TITLE
test(ci): dek het vangnet van deploy-filters af en pin node in deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,6 +58,13 @@ jobs:
       # packages/auth en packages/law-model stonden er nergens in, terwijl
       # editor-api en admin op auth leunen en engine, corpus, pipeline en
       # harvester op law-model. Faalt het script, dan zet het alles op true.
+      # Dezelfde Node als waarmee de testsuite in ci.yml draait. Dit script
+      # bepaalt wat er naar productie gaat; het hoort niet stil mee te
+      # verschuiven met wat er toevallig op de runner staat.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
+        with:
+          node-version: '22'
+
       - name: Bepaal geraakte componenten
         id: filter
         run: node script/deploy-filters.mjs --from-file changed.txt

--- a/script/deploy-filters.test.mjs
+++ b/script/deploy-filters.test.mjs
@@ -12,8 +12,12 @@
 // die had moeten uitrollen. Dat is precies de klasse fouten waarvoor het script
 // bestaat.
 
+import { spawnSync } from 'node:child_process';
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT = fileURLToPath(new URL('./deploy-filters.mjs', import.meta.url));
 
 import { COMPONENTS, componentsFor, prefixesFor, workspaceGraph } from './deploy-filters.mjs';
 
@@ -171,5 +175,39 @@ test('elk component in de tabel levert bruikbare prefixen op', () => {
       assert.equal(typeof prefix, 'string');
       assert.ok(prefix.length > 0, `${name} leverde een lege prefix op`);
     }
+  }
+});
+
+// --- Het vangnet zelf ---
+//
+// De tests hierboven dekken de stille kant: een verkeerde check levert `false`
+// op zonder te gooien. De twee hieronder dekken de luide kant, en die is het
+// vangnet waar de rest op leunt. Gaat er iets stuk in de afleiding, dan moet
+// alles gebouwd worden; blijft dat vangnet ongetest, dan kan het wegvallen
+// zonder dat iemand het merkt, en is een storing weer een stille overslag.
+
+test('een onbekende crate in de tabel gooit, zodat het vangnet aanslaat', () => {
+  assert.throws(
+    () => prefixesFor({ crate: 'regelrecht-bestaat-niet', paths: [] }, graph),
+    /niet gevonden in de workspace/,
+  );
+});
+
+test('faalt de afleiding, dan bouwt het script alles met een zichtbare waarschuwing', () => {
+  // Het script als geheel, niet de losse functies: het vangnet zit in de
+  // top-level try/catch. Zonder cargo op PATH faalt `cargo metadata`.
+  const result = spawnSync(process.execPath, [SCRIPT, 'packages/auth/src/lib.rs'], {
+    encoding: 'utf8',
+    env: { ...process.env, PATH: '/nonexistent' },
+  });
+
+  assert.equal(result.status, 0, 'het script hoort niet te falen, maar alles te bouwen');
+  assert.match(result.stdout, /::warning::/, 'de fallback hoort zichtbaar te zijn in het log');
+  for (const name of allComponents) {
+    assert.match(
+      result.stdout,
+      new RegExp(`^${name}=true$`, 'm'),
+      `${name} hoort op true te staan als de afleiding faalt`,
+    );
   }
 });


### PR DESCRIPTION
Naar aanleiding van de review op #1076. Die wees er terecht op dat de PR-tekst beweerde dat beide faalpaden getest waren, terwijl dat handwerk in een shell was; de elf tests dekten alleen de stille kant, waar een verkeerde check `false` oplevert zonder te gooien.

Nu ook de luide kant, en dat is het vangnet waar de rest op leunt. Een onbekende crate in de tabel hoort te gooien, en het script als geheel hoort bij een falende afleiding alles op `true` te zetten met een zichtbare `::warning::`. Dat tweede geval draait als subproces zonder cargo op `PATH`, want het vangnet zit in de top-level `try`/`catch` en is niet vanuit een import te raken.

Gecontroleerd dat de test ook echt kan falen: met de emit-lus in de `catch` leeggemaakt faalt hij en is de exitcode 1, hersteld slagen alle dertien.

Daarnaast de kleine bevinding uit dezelfde review: node staat in `deploy.yml` nu vast op 22, dezelfde versie als waarmee `ci.yml` de testsuite draait.