### PR TITLE
fix(ci): schema-wijzigingen bouwen weer, en een Dockerfile raakt alleen zijn eigen image

### DIFF
--- a/script/deploy-filters.mjs
+++ b/script/deploy-filters.mjs
@@ -63,6 +63,10 @@ const RUST_WIDE = [
   'packages/Cargo.toml',
   'packages/.cargo/',
   'rust-toolchain.toml',
+  // Elk Rust-image doet `COPY schema/ /schema/`, en corpus bakt er een schema
+  // uit in met `include_str!`. Zonder deze regel levert een schemawijziging
+  // stille, verouderde images op.
+  'schema/',
 ];
 
 export function workspaceGraph() {
@@ -124,6 +128,14 @@ export function prefixesFor(spec, graph) {
 // Welke componenten raakt deze lijst gewijzigde bestanden? Een lege lijst
 // betekent "we weten het niet" en dus alles bouwen, dezelfde kant op als de
 // fallback: een overbodige build is goedkoper dan een stille overslag.
+// Een Dockerfile in een cratemap hoort niet bij de crate maar bij het image dat
+// hem gebruikt. Zonder dit onderscheid zet een wijziging in
+// packages/pipeline/Dockerfile ook editor en admin op true, want die hangen via
+// de graaf aan pipeline terwijl ze die Dockerfile niet gebruiken: twee builds
+// van een kwartier voor niets. Welke component welke Dockerfile gebruikt staat
+// in `paths`, en dat blijft handwerk omdat het niet uit de graaf volgt.
+const isDockerfile = (file) => /(^|\/)Dockerfile[^/]*$/.test(file);
+
 export function componentsFor(changed, graph) {
   const result = {};
   const unknown = changed.length === 0;
@@ -132,8 +144,13 @@ export function componentsFor(changed, graph) {
       result[name] = true;
       continue;
     }
-    const prefixes = prefixesFor(spec, graph);
-    result[name] = changed.some((file) => prefixes.some((p) => file.startsWith(p)));
+    const explicit = spec.paths;
+    const derived = prefixesFor(spec, graph).filter((p) => !explicit.includes(p));
+    result[name] = changed.some(
+      (file) =>
+        explicit.some((p) => file.startsWith(p)) ||
+        (!isDockerfile(file) && derived.some((p) => file.startsWith(p))),
+    );
   }
   return result;
 }

--- a/script/deploy-filters.test.mjs
+++ b/script/deploy-filters.test.mjs
@@ -211,3 +211,30 @@ test('faalt de afleiding, dan bouwt het script alles met een zichtbare waarschuw
     );
   }
 });
+
+test('een schemawijziging raakt elk Rust-image', () => {
+  // Elk Rust-image doet `COPY schema/`, en corpus bakt er een schema uit in met
+  // include_str!. Zonder deze regel levert een schemawijziging stille,
+  // verouderde images op: de gevaarlijkste uitkomst, want niets wordt rood.
+  const hit = namesOf(['schema/v0.5.6/schema.json']);
+  for (const name of ['editor', 'admin', 'harvester-worker', 'enrich-worker', 'pipeline-api']) {
+    assert.equal(hit[name], true, name);
+  }
+});
+
+test('een Dockerfile raakt alleen de images die hem gebruiken', () => {
+  // packages/pipeline/Dockerfile ligt in de cratemap van pipeline, en editor en
+  // admin hangen via de graaf aan die crate. Ze gebruiken die Dockerfile niet,
+  // dus ze horen niet mee te bouwen.
+  const pipeline = namesOf(['packages/pipeline/Dockerfile']);
+  assert.equal(pipeline['harvester-worker'], true);
+  assert.equal(pipeline['enrich-worker'], true);
+  assert.equal(pipeline['pipeline-api'], true);
+  assert.equal(pipeline.editor, false);
+  assert.equal(pipeline.admin, false);
+
+  // En andersom blijft de crate zelf wel gewoon werken.
+  const source = namesOf(['packages/pipeline/src/worker.rs']);
+  assert.equal(source.editor, true);
+  assert.equal(source.admin, true);
+});


### PR DESCRIPTION
Twee gaten in `deploy-filters`, gevonden bij het doormeten van de deploy-builds.

`schema/` stond in geen enkele prefix, terwijl `frontend/Dockerfile`, `packages/pipeline/Dockerfile` en `packages/admin/Dockerfile` alle drie `COPY schema/ /schema/` doen en `corpus` er een schema uit inbakt met `include_str!`. Een schemawijziging bouwde dus niets en leverde stille, verouderde images op. Dat is de gevaarlijkste vorm: er wordt niets rood.

En een Dockerfile in een cratemap werd als crate-wijziging gelezen. `packages/pipeline/Dockerfile` zette daardoor ook editor en admin op `true`, want die hangen via de graaf aan pipeline terwijl ze die Dockerfile niet gebruiken: twee builds van ruwweg een kwartier voor niets. Welke component welke Dockerfile gebruikt staat in `paths` en blijft handwerk, want dat volgt niet uit de graaf.

Beide vastgelegd in de testsuite, die daarmee op vijftien tests staat.