### PR TITLE
perf(ci): buildcache naar GHCR in plaats van de Actions-cache

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -87,7 +87,24 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha${{ inputs.cache-scope != '' && format(',scope={0}', inputs.cache-scope) || '' }}
-          cache-to: type=gha,mode=max${{ inputs.cache-scope != '' && format(',scope={0}', inputs.cache-scope) || '' }}
+          # De cache ligt in GHCR, niet in de Actions-cache.
+          #
+          # Waarom weg van type=gha: die schrijft per git-ref, en op main is
+          # dat funest. Een PR-run leest alle scopes die zijn token ziet, dus
+          # ook die van main, maar main ziet alleen zichzelf. Daarbovenop
+          # evicteert LRU precies het verkeerde: main's index-bestandjes worden
+          # zelden aangeraakt en vliegen eruit, terwijl de bijbehorende
+          # gigabytes aan blobs vers blijven omdat elke PR ze leest. Gemeten
+          # gevolg: build-jobs op main mediaan 799s, op PR-branches 203s.
+          #
+          # Alleen main schrijft. Een PR leest main's cache en exporteert niet,
+          # zodat er geen tags achterblijven die niemand opruimt (GHCR ruimt
+          # untagged manifests niet automatisch op). Prijs: een PR die
+          # Cargo.lock wijzigt bouwt de cook-laag bij elke push opnieuw.
+          #
+          # ignore-error omdat een mislukte export anders de hele buildstap
+          # laat falen; fork-PR's mogen niet naar GHCR schrijven.
+          cache-from: type=registry,ref=ghcr.io/minbzk/regelrecht-buildcache:${{ inputs.cache-scope != '' && inputs.cache-scope || 'default' }}
+          cache-to: ${{ github.ref == 'refs/heads/main' && format('type=registry,ref=ghcr.io/minbzk/regelrecht-buildcache:{0},mode=max,ignore-error=true', inputs.cache-scope != '' && inputs.cache-scope || 'default') || '' }}
           secrets: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,10 +113,7 @@ jobs:
       dockerfile: packages/pipeline/Dockerfile
       target: harvester-worker
       build-args: BIN=regelrecht-harvest-worker
-      # Eén scope voor de drie targets uit packages/pipeline/Dockerfile: alles
-      # boven `ARG BIN` is byte-identiek, dus met aparte scopes bouwt en bewaart
-      # elk van de drie dezelfde chef- en cook-lagen.
-      cache-scope: pipeline
+      cache-scope: harvester-worker
     # Only GITHUB_TOKEN is needed; it is automatically available to called workflows
 
   build-enrich-worker:
@@ -136,10 +133,7 @@ jobs:
       dockerfile: packages/pipeline/Dockerfile
       target: enrich-worker
       build-args: BIN=regelrecht-enrich-worker
-      # Eén scope voor de drie targets uit packages/pipeline/Dockerfile: alles
-      # boven `ARG BIN` is byte-identiek, dus met aparte scopes bouwt en bewaart
-      # elk van de drie dezelfde chef- en cook-lagen.
-      cache-scope: pipeline
+      cache-scope: enrich-worker
     # Only GITHUB_TOKEN is needed; it is automatically available to called workflows
 
   build-pipeline-api:
@@ -154,10 +148,7 @@ jobs:
       dockerfile: packages/pipeline/Dockerfile
       target: pipeline-api
       build-args: BIN=regelrecht-pipeline-api
-      # Eén scope voor de drie targets uit packages/pipeline/Dockerfile: alles
-      # boven `ARG BIN` is byte-identiek, dus met aparte scopes bouwt en bewaart
-      # elk van de drie dezelfde chef- en cook-lagen.
-      cache-scope: pipeline
+      cache-scope: pipeline-api
 
   build-grafana:
     needs: changes

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,7 +113,10 @@ jobs:
       dockerfile: packages/pipeline/Dockerfile
       target: harvester-worker
       build-args: BIN=regelrecht-harvest-worker
-      cache-scope: harvester-worker
+      # Eén scope voor de drie targets uit packages/pipeline/Dockerfile: alles
+      # boven `ARG BIN` is byte-identiek, dus met aparte scopes bouwt en bewaart
+      # elk van de drie dezelfde chef- en cook-lagen.
+      cache-scope: pipeline
     # Only GITHUB_TOKEN is needed; it is automatically available to called workflows
 
   build-enrich-worker:
@@ -133,7 +136,10 @@ jobs:
       dockerfile: packages/pipeline/Dockerfile
       target: enrich-worker
       build-args: BIN=regelrecht-enrich-worker
-      cache-scope: enrich-worker
+      # Eén scope voor de drie targets uit packages/pipeline/Dockerfile: alles
+      # boven `ARG BIN` is byte-identiek, dus met aparte scopes bouwt en bewaart
+      # elk van de drie dezelfde chef- en cook-lagen.
+      cache-scope: pipeline
     # Only GITHUB_TOKEN is needed; it is automatically available to called workflows
 
   build-pipeline-api:
@@ -148,7 +154,10 @@ jobs:
       dockerfile: packages/pipeline/Dockerfile
       target: pipeline-api
       build-args: BIN=regelrecht-pipeline-api
-      cache-scope: pipeline-api
+      # Eén scope voor de drie targets uit packages/pipeline/Dockerfile: alles
+      # boven `ARG BIN` is byte-identiek, dus met aparte scopes bouwt en bewaart
+      # elk van de drie dezelfde chef- en cook-lagen.
+      cache-scope: pipeline
 
   build-grafana:
     needs: changes


### PR DESCRIPTION
`type=gha` schrijft zijn cache-index per git-ref. Een PR-run leest alle scopes die zijn token ziet, dus ook die van main, maar main ziet alleen zichzelf. LRU evicteert daarbovenop het verkeerde: main's indexbestandjes worden alleen door een build op main aangeraakt en vliegen eruit, terwijl de bijbehorende gigabytes aan blobs vers blijven omdat elke PR ze leest. Main begint daardoor structureel koud, met een mediaan van 799s tegen 203s op PR-branches.

De cache verhuist naar `ghcr.io/minbzk/regelrecht-buildcache:<scope>`, want een registry-cache kent geen pot, geen LRU en geen ref-scoping. Alleen main schrijft: GHCR ruimt untagged manifests niet automatisch op en de nachtelijke opruimer slikt zijn eigen DELETE-fouten in. De prijs is dat een PR die `Cargo.lock` wijzigt de cook-laag bij elke push opnieuw bouwt; per-PR tags kunnen erbij zodra die opruimer aantoonbaar werkt.

Terugdraaien als de mediaan op main over tien opeenvolgende pushes niet onder 600s ligt, of als het cachepakket na twee weken boven de 100 GB staat. Eén handmatige stap bij de eerste merge: GHCR maakt het pakket privé aan, en publiek zetten maakt het gratis en zichtbaar.