### PR TITLE
fix(editor): maak de traject-branch aan bij het aanmaken van een traject

### DIFF
--- a/packages/corpus/src/github_api_backend.rs
+++ b/packages/corpus/src/github_api_backend.rs
@@ -195,7 +195,17 @@ impl GitHubApiBackend {
     /// when missing. Shared by `ensure_ready` (rest-token bootstrap at
     /// backend init) and `persist` (lazy bootstrap with the per-call
     /// user token, for backends that had no token at init).
-    async fn ensure_branch(
+    ///
+    /// Also reused by the editor-api create-traject flow to mint the
+    /// traject branch eagerly, while it still holds the token that just
+    /// proved push access — closing the "fresh traject is
+    /// dead-on-arrival because its branch does not exist yet" gap. The
+    /// benign-race handling below makes eager and lazy bootstrap safe to
+    /// coexist: whichever runs second sees the branch and no-ops.
+    ///
+    /// `repo` is the `owner/name` form; `token` is `None` only for
+    /// anonymous public reads (branch creation always needs one).
+    pub async fn ensure_branch(
         client: &GithubClient,
         repo: &str,
         branch: &str,

--- a/packages/editor-api/src/trajects.rs
+++ b/packages/editor-api/src/trajects.rs
@@ -750,6 +750,7 @@ async fn resolve_writable_target(
     req: &CreateTrajectRequest,
     account_id: Uuid,
     headers: &axum::http::HeaderMap,
+    traject_id: Uuid,
 ) -> Result<WritableTarget, (StatusCode, String)> {
     let owner = req
         .repo_owner
@@ -907,6 +908,54 @@ async fn resolve_writable_target(
                 "validated user-supplied repo for new traject"
             );
 
+            // Mint the traject branch eagerly, right here where we still
+            // hold the token that just proved push access. Without this a
+            // freshly created traject is dead-on-arrival: the index scan
+            // reads `traject/{slug}-{short}`, which does not exist yet, so
+            // the Trees API 404s and every traject-scoped corpus endpoint
+            // 502s — including the very write UI you'd use to trigger the
+            // lazy branch-bootstrap on the write path. A closed loop.
+            //
+            // In user-token write mode the backend has no service token to
+            // bootstrap the branch at `ensure_ready`, so this is the only
+            // moment a token is guaranteed in hand. Reuse `ensure_branch`
+            // rather than calling `create_branch` directly: it already
+            // absorbs the "branch already exists" race (a repeated create,
+            // or two members racing), keeping this idempotent (criterion 4).
+            // The lazy bootstrap on the write path stays as the safety net
+            // for trajects that predate this and sit branch-less in the DB.
+            let writable_branch = derive_branch_name(req.name.trim(), traject_id);
+            regelrecht_corpus::GitHubApiBackend::ensure_branch(
+                &client,
+                &format!("{owner}/{repo}"),
+                &writable_branch,
+                Some(base_branch),
+                Some(&token),
+            )
+            .await
+            .map_err(|e| {
+                // Push access was just confirmed by the preflight, so a
+                // failure here is genuinely exceptional (an upstream GitHub
+                // hiccup or a permission revoked mid-flight). Fail loud so no
+                // good-looking-but-broken traject is created — nothing has
+                // been written to the DB yet at this point.
+                tracing::error!(
+                    error = %e,
+                    owner = %owner,
+                    repo = %repo,
+                    branch = %writable_branch,
+                    "failed to create traject branch during create preflight"
+                );
+                (
+                    StatusCode::BAD_GATEWAY,
+                    format!(
+                        "kon de traject-branch '{writable_branch}' niet aanmaken op \
+                         {owner}/{repo}; het traject is niet aangemaakt. Probeer het \
+                         opnieuw of controleer je GitHub-toegang."
+                    ),
+                )
+            })?;
+
             Ok(WritableTarget {
                 owner: owner.to_string(),
                 repo: repo.to_string(),
@@ -1007,24 +1056,33 @@ pub async fn create(
         return Err((StatusCode::BAD_REQUEST, "name is required".to_string()));
     }
 
+    // Mint the traject id client-side so the writable-branch name (derived
+    // from it) is known *before* we touch GitHub or the database. The
+    // preflight below uses it to create the branch while it still holds the
+    // proving token, and the INSERT reuses the same id — one identity across
+    // GitHub, URL ref and DB row.
+    let traject_id = Uuid::new_v4();
+
     // Resolve the writable-own GitHub target up-front. Validation may need
-    // to talk to GitHub (which can fail with a helpful 4xx); we do that
-    // *before* opening the DB transaction so a network blip doesn't leak a
-    // half-rolled row.
-    let target = resolve_writable_target(&state, &req, account.id, &headers).await?;
+    // to talk to GitHub (which can fail with a helpful 4xx) and — for a
+    // user-supplied repo — mints the traject branch there; we do that
+    // *before* opening the DB transaction so a network blip or a failed
+    // branch-create leaves no half-rolled row behind.
+    let target = resolve_writable_target(&state, &req, account.id, &headers, traject_id).await?;
 
     let pool = get_pool_msg(&state)?;
     let mut tx = pool.begin().await.map_err(db_err_msg("begin tx"))?;
 
-    let traject_id: Uuid = sqlx::query_scalar(
-        "INSERT INTO trajects (name, description, scope, created_by)
-         VALUES ($1, $2, $3, $4) RETURNING id",
+    sqlx::query(
+        "INSERT INTO trajects (id, name, description, scope, created_by)
+         VALUES ($1, $2, $3, $4, $5)",
     )
+    .bind(traject_id)
     .bind(name)
     .bind(&req.description)
     .bind(&req.scope)
     .bind(account.id)
-    .fetch_one(&mut *tx)
+    .execute(&mut *tx)
     .await
     .map_err(db_err_msg("insert traject"))?;
 

--- a/packages/editor-api/src/trajects.rs
+++ b/packages/editor-api/src/trajects.rs
@@ -736,6 +736,15 @@ struct WritableTarget {
     /// `MinBZK/regelrecht-corpus` for the default, `<owner>/<repo>` for
     /// user-supplied repos.
     display_name: String,
+    /// True when resolving this target minted the traject branch on
+    /// GitHub. Only the user-supplied-repo arm does that; the MinBZK
+    /// default leaves it `false` because its service-token backend
+    /// bootstraps its own branch in `ensure_ready`.
+    ///
+    /// The handler uses this to tell an operator about a branch that was
+    /// created but whose traject never made it into the database — see
+    /// the failure log in `create`.
+    minted_branch: bool,
 }
 
 /// Decide whether the create-request asks for the MinBZK default or a
@@ -780,6 +789,7 @@ async fn resolve_writable_target(
             path: Some(CENTRAL_WRITABLE_PATH.to_string()),
             auth_ref: CENTRAL_WRITABLE_AUTH_REF.to_string(),
             display_name: CENTRAL_WRITABLE_NAME.to_string(),
+            minted_branch: false,
         }),
         // All three filled → user-supplied repo path. Validate.
         (Some(owner), Some(repo), Some(base_branch)) => {
@@ -978,6 +988,7 @@ async fn resolve_writable_target(
                 path: repo_path,
                 auth_ref,
                 display_name: format!("{owner}/{repo}"),
+                minted_branch: true,
             })
         }
         // Partial → caller error, refuse rather than guess.
@@ -1086,105 +1097,130 @@ pub async fn create(
     let target =
         resolve_writable_target(&state, &req, account.id, &headers, &writable_branch).await?;
 
-    let pool = get_pool_msg(&state)?;
-    let mut tx = pool.begin().await.map_err(db_err_msg("begin tx"))?;
+    // Everything below is database work, and GitHub is not part of that
+    // transaction. If any of it fails after the branch was minted, the ref
+    // stays behind on the user's repo with no traject pointing at it — and a
+    // retry derives a fresh uuid-suffixed name rather than reusing the stray.
+    // Deleting someone else's ref from an error path is worse than leaving
+    // it, so make it findable instead: one error log with the exact
+    // coordinates. Grouping the DB work in a block puts that log on *every*
+    // failure path (begin, each insert, commit), not just the first one.
+    let persisted: Result<(), (StatusCode, String)> = async {
+        let pool = get_pool_msg(&state)?;
+        let mut tx = pool.begin().await.map_err(db_err_msg("begin tx"))?;
 
-    sqlx::query(
-        "INSERT INTO trajects (id, name, description, scope, created_by)
-         VALUES ($1, $2, $3, $4, $5)",
-    )
-    .bind(traject_id)
-    .bind(name)
-    .bind(&req.description)
-    .bind(&req.scope)
-    .bind(account.id)
-    .execute(&mut *tx)
-    .await
-    .map_err(db_err_msg("insert traject"))?;
+        sqlx::query(
+            "INSERT INTO trajects (id, name, description, scope, created_by)
+             VALUES ($1, $2, $3, $4, $5)",
+        )
+        .bind(traject_id)
+        .bind(name)
+        .bind(&req.description)
+        .bind(&req.scope)
+        .bind(account.id)
+        .execute(&mut *tx)
+        .await
+        .map_err(db_err_msg("insert traject"))?;
 
-    sqlx::query(
-        "INSERT INTO traject_members (traject_id, account_id, role)
-         VALUES ($1, $2, 'owner')",
-    )
-    .bind(traject_id)
-    .bind(account.id)
-    .execute(&mut *tx)
-    .await
-    .map_err(db_err_msg("insert member"))?;
+        sqlx::query(
+            "INSERT INTO traject_members (traject_id, account_id, role)
+             VALUES ($1, $2, 'owner')",
+        )
+        .bind(traject_id)
+        .bind(account.id)
+        .execute(&mut *tx)
+        .await
+        .map_err(db_err_msg("insert member"))?;
 
-    // Seed federated read-config from the global registry. The global
-    // corpus read guard is dropped before the next await so we don't hold
-    // it across the database transaction.
-    let seeded: Vec<SeedSource> = {
-        let corpus = state.corpus.read().await;
-        corpus
-            .registry
-            .sources()
-            .iter()
-            .map(SeedSource::from_source)
-            .collect()
-    };
+        // Seed federated read-config from the global registry. The global
+        // corpus read guard is dropped before the next await so we don't hold
+        // it across the database transaction.
+        let seeded: Vec<SeedSource> = {
+            let corpus = state.corpus.read().await;
+            corpus
+                .registry
+                .sources()
+                .iter()
+                .map(SeedSource::from_source)
+                .collect()
+        };
 
-    for seed in seeded {
+        for seed in seeded {
+            sqlx::query(
+                "INSERT INTO traject_corpus_sources
+                 (traject_id, source_id, name, source_type,
+                  gh_owner, gh_repo, gh_branch, gh_path, gh_ref,
+                  local_path, priority, auth_ref, scopes, is_writable_own)
+                 VALUES ($1, $2, $3, $4::corpus_source_type,
+                         $5, $6, $7, $8, $9,
+                         $10, $11, $12, $13, FALSE)",
+            )
+            .bind(traject_id)
+            .bind(&seed.source_id)
+            .bind(&seed.name)
+            .bind(&seed.source_type)
+            .bind(seed.gh_owner)
+            .bind(seed.gh_repo)
+            .bind(seed.gh_branch)
+            .bind(seed.gh_path)
+            .bind(seed.gh_ref)
+            .bind(seed.local_path)
+            .bind(seed.priority as i32)
+            .bind(seed.auth_ref)
+            .bind(seed.scopes)
+            .execute(&mut *tx)
+            .await
+            .map_err(db_err_msg("seed traject source"))?;
+        }
+
+        // Writable-own source: the phase-1 MinBZK default or the user-supplied
+        // repo (already validated up-front for push access). `writable_branch` is
+        // the name derived at the top of this handler — for a user-supplied repo
+        // that branch now exists on GitHub, minted during the preflight. Auth
+        // flows through `CORPUS_AUTH_{AUTH_REF_UPPER}_TOKEN` via the `auth_ref`
+        // stored on this row.
+        let writable_source_id = format!("traject-own-{}", traject_id.simple());
         sqlx::query(
             "INSERT INTO traject_corpus_sources
              (traject_id, source_id, name, source_type,
-              gh_owner, gh_repo, gh_branch, gh_path, gh_ref,
-              local_path, priority, auth_ref, scopes, is_writable_own)
-             VALUES ($1, $2, $3, $4::corpus_source_type,
-                     $5, $6, $7, $8, $9,
-                     $10, $11, $12, $13, FALSE)",
+              gh_owner, gh_repo, gh_branch, gh_base_branch, gh_path,
+              priority, auth_ref, is_writable_own)
+             VALUES ($1, $2, $3, 'github',
+                     $4, $5, $6, $7, $8,
+                     0, $9, TRUE)",
         )
         .bind(traject_id)
-        .bind(&seed.source_id)
-        .bind(&seed.name)
-        .bind(&seed.source_type)
-        .bind(seed.gh_owner)
-        .bind(seed.gh_repo)
-        .bind(seed.gh_branch)
-        .bind(seed.gh_path)
-        .bind(seed.gh_ref)
-        .bind(seed.local_path)
-        .bind(seed.priority as i32)
-        .bind(seed.auth_ref)
-        .bind(seed.scopes)
+        .bind(&writable_source_id)
+        .bind(&target.display_name)
+        .bind(&target.owner)
+        .bind(&target.repo)
+        .bind(&writable_branch)
+        .bind(&target.base_branch)
+        .bind(&target.path)
+        .bind(&target.auth_ref)
         .execute(&mut *tx)
         .await
-        .map_err(db_err_msg("seed traject source"))?;
+        .map_err(db_err_msg("insert writable source"))?;
+
+        tx.commit()
+            .await
+            .map_err(db_err_msg("commit traject create"))?;
+        Ok(())
     }
-
-    // Writable-own source: the phase-1 MinBZK default or the user-supplied
-    // repo (already validated up-front for push access). `writable_branch` is
-    // the name derived at the top of this handler — for a user-supplied repo
-    // that branch now exists on GitHub, minted during the preflight. Auth
-    // flows through `CORPUS_AUTH_{AUTH_REF_UPPER}_TOKEN` via the `auth_ref`
-    // stored on this row.
-    let writable_source_id = format!("traject-own-{}", traject_id.simple());
-    sqlx::query(
-        "INSERT INTO traject_corpus_sources
-         (traject_id, source_id, name, source_type,
-          gh_owner, gh_repo, gh_branch, gh_base_branch, gh_path,
-          priority, auth_ref, is_writable_own)
-         VALUES ($1, $2, $3, 'github',
-                 $4, $5, $6, $7, $8,
-                 0, $9, TRUE)",
-    )
-    .bind(traject_id)
-    .bind(&writable_source_id)
-    .bind(&target.display_name)
-    .bind(&target.owner)
-    .bind(&target.repo)
-    .bind(&writable_branch)
-    .bind(&target.base_branch)
-    .bind(&target.path)
-    .bind(&target.auth_ref)
-    .execute(&mut *tx)
-    .await
-    .map_err(db_err_msg("insert writable source"))?;
-
-    tx.commit()
-        .await
-        .map_err(db_err_msg("commit traject create"))?;
+    .await;
+    if let Err(e) = persisted {
+        if target.minted_branch {
+            tracing::error!(
+                traject_id = %traject_id,
+                owner = %target.owner,
+                repo = %target.repo,
+                branch = %writable_branch,
+                "orphaned traject branch: it was created on GitHub but persisting \
+                 the traject failed, so nothing references it; remove it by hand"
+            );
+        }
+        return Err(e);
+    }
 
     state.trajects.invalidate(traject_id).await;
 

--- a/packages/editor-api/src/trajects.rs
+++ b/packages/editor-api/src/trajects.rs
@@ -750,7 +750,10 @@ async fn resolve_writable_target(
     req: &CreateTrajectRequest,
     account_id: Uuid,
     headers: &axum::http::HeaderMap,
-    traject_id: Uuid,
+    // The branch this traject will write to, derived once by the caller
+    // and reused verbatim for both the GitHub ref-create below and the
+    // `gh_branch` column.
+    writable_branch: &str,
 ) -> Result<WritableTarget, (StatusCode, String)> {
     let owner = req
         .repo_owner
@@ -924,11 +927,16 @@ async fn resolve_writable_target(
             // or two members racing), keeping this idempotent (criterion 4).
             // The lazy bootstrap on the write path stays as the safety net
             // for trajects that predate this and sit branch-less in the DB.
-            let writable_branch = derive_branch_name(req.name.trim(), traject_id);
+            //
+            // `writable_branch` is the caller's single derivation, the very
+            // same string the INSERT persists as `gh_branch`. Deriving it a
+            // second time here would reintroduce the failure mode this fix
+            // exists to close: mint branch A, store branch B, traject still
+            // dead-on-arrival.
             regelrecht_corpus::GitHubApiBackend::ensure_branch(
                 &client,
                 &format!("{owner}/{repo}"),
-                &writable_branch,
+                writable_branch,
                 Some(base_branch),
                 Some(&token),
             )
@@ -1036,9 +1044,13 @@ fn repo_access_error_to_status(
 ///
 /// Seeds the federated config by copying the global registry's sources
 /// (with their original priorities) and then attaching the writable own
-/// source at priority 0. Branch creation on the writable source is
-/// handled by `GitBackend` on first use, which falls back to the
-/// configured base branch when the traject branch doesn't yet exist.
+/// source at priority 0. For a user-supplied repo the traject branch is
+/// minted here, during the preflight — a traject whose branch does not
+/// exist yet cannot be indexed, so creating it lazily on first write left
+/// every fresh traject dead-on-arrival. The lazy bootstrap on the write
+/// path (`GitHubApiBackend::persist`) remains as the safety net for
+/// trajects created before that, and for the MinBZK default, whose
+/// service-token backend bootstraps its branch in `ensure_ready`.
 ///
 /// When the request supplies `repo_owner`/`repo_name`/`base_branch`,
 /// the writable-own source points to that user repo and the
@@ -1057,18 +1069,22 @@ pub async fn create(
     }
 
     // Mint the traject id client-side so the writable-branch name (derived
-    // from it) is known *before* we touch GitHub or the database. The
-    // preflight below uses it to create the branch while it still holds the
-    // proving token, and the INSERT reuses the same id — one identity across
-    // GitHub, URL ref and DB row.
+    // from it) is known *before* we touch GitHub or the database, and derive
+    // that name exactly once. Both consumers — the ref-create in the
+    // preflight and the `gh_branch` column on the writable-own source — read
+    // this one string, so the branch that gets minted on GitHub and the
+    // branch the index scan later reads cannot drift apart. One identity
+    // across GitHub, URL ref and DB row.
     let traject_id = Uuid::new_v4();
+    let writable_branch = derive_branch_name(name, traject_id);
 
     // Resolve the writable-own GitHub target up-front. Validation may need
     // to talk to GitHub (which can fail with a helpful 4xx) and — for a
     // user-supplied repo — mints the traject branch there; we do that
     // *before* opening the DB transaction so a network blip or a failed
     // branch-create leaves no half-rolled row behind.
-    let target = resolve_writable_target(&state, &req, account.id, &headers, traject_id).await?;
+    let target =
+        resolve_writable_target(&state, &req, account.id, &headers, &writable_branch).await?;
 
     let pool = get_pool_msg(&state)?;
     let mut tx = pool.begin().await.map_err(db_err_msg("begin tx"))?;
@@ -1138,12 +1154,12 @@ pub async fn create(
     }
 
     // Writable-own source: the phase-1 MinBZK default or the user-supplied
-    // repo (already validated up-front for push access). The branch name is
-    // derived from the traject name + id; auth flows through
-    // `CORPUS_AUTH_{AUTH_REF_UPPER}_TOKEN` via the `auth_ref` stored on this
-    // row.
+    // repo (already validated up-front for push access). `writable_branch` is
+    // the name derived at the top of this handler — for a user-supplied repo
+    // that branch now exists on GitHub, minted during the preflight. Auth
+    // flows through `CORPUS_AUTH_{AUTH_REF_UPPER}_TOKEN` via the `auth_ref`
+    // stored on this row.
     let writable_source_id = format!("traject-own-{}", traject_id.simple());
-    let writable_branch = derive_branch_name(name, traject_id);
     sqlx::query(
         "INSERT INTO traject_corpus_sources
          (traject_id, source_id, name, source_type,

--- a/packages/editor-api/tests/trajects_test.rs
+++ b/packages/editor-api/tests/trajects_test.rs
@@ -265,6 +265,11 @@ async fn create_custom_repo_preflights_with_the_linked_user_token() {
     // user (their sealed-cookie token), not the operator token. Matching on
     // the Authorization header pins that — an operator-token request would
     // not match the mocks and the preflight would fail on the 404.
+    //
+    // It also mints the traject branch as part of create (see
+    // `create_custom_repo_mints_the_traject_branch` for the dedicated
+    // regression assertion); the branch-bootstrap mocks below are needed
+    // for the create to succeed at all now that branch creation is eager.
     use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -304,6 +309,7 @@ async fn create_custom_repo_preflights_with_the_linked_user_token() {
         .expect(1)
         .mount(&server)
         .await;
+    mount_branch_bootstrap_mocks(&server).await;
 
     let mut headers = axum::http::HeaderMap::new();
     headers.insert(
@@ -326,6 +332,146 @@ async fn create_custom_repo_preflights_with_the_linked_user_token() {
     .expect("create with a linked token must pass the preflight");
     assert_eq!(status, StatusCode::CREATED);
     assert_eq!(summary.name, "Repo traject");
+}
+
+/// Mount the three GitHub Refs API mocks that `ensure_branch` hits when the
+/// traject branch does not yet exist: `branch_exists` (404 → "create it"),
+/// resolve the base ref's sha, then POST the new ref. The traject branch name
+/// carries a per-create random 8-hex suffix, so the branch paths are matched
+/// by regex rather than a literal.
+async fn mount_branch_bootstrap_mocks(server: &wiremock::MockServer) {
+    use wiremock::matchers::{header, method, path, path_regex};
+    use wiremock::{Mock, ResponseTemplate};
+
+    // 1) branch_exists on the traject branch → 404 (does not exist yet).
+    Mock::given(method("GET"))
+        .and(path_regex(
+            r"^/repos/example-org/regelrecht-corpus-example/git/ref/heads/traject/.+$",
+        ))
+        .and(header("authorization", "Bearer user-token"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+            "message": "Not Found",
+        })))
+        .mount(server)
+        .await;
+    // 2) resolve the base branch ref → its tip sha.
+    Mock::given(method("GET"))
+        .and(path(
+            "/repos/example-org/regelrecht-corpus-example/git/ref/heads/main",
+        ))
+        .and(header("authorization", "Bearer user-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ref": "refs/heads/main",
+            "object": { "sha": "abc123def456", "type": "commit" },
+        })))
+        .mount(server)
+        .await;
+    // 3) create the traject ref from that sha.
+    Mock::given(method("POST"))
+        .and(path(
+            "/repos/example-org/regelrecht-corpus-example/git/refs",
+        ))
+        .and(header("authorization", "Bearer user-token"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "ref": "refs/heads/traject/repo-traject",
+            "object": { "sha": "abc123def456", "type": "commit" },
+        })))
+        .expect(1)
+        .mount(server)
+        .await;
+}
+
+#[tokio::test]
+async fn create_custom_repo_mints_the_traject_branch() {
+    // Regression for the "fresh traject is dead-on-arrival" bug: in
+    // user-token write mode nothing minted the traject branch at create
+    // time, so the very first index scan 404'd on a non-existent branch and
+    // every corpus endpoint 502'd — a deadlock, because the write UI that
+    // would lazily mint the branch was itself behind that 502.
+    //
+    // `create` must now POST a new ref for `traject/{slug}-{short}` off the
+    // base branch during the preflight. The `.expect(1)` on the POST-refs
+    // mock (in `mount_branch_bootstrap_mocks`) is what fails on current main,
+    // where no such request is ever made.
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let db = TestDb::new().await;
+    let server = MockServer::start().await;
+
+    let mut oauth = GithubOAuth::for_tests(true);
+    oauth.api_base = server.uri();
+    let mut state = empty_state(db.pool.clone());
+    state.config = Arc::new(AppConfig {
+        oidc: None,
+        base_url: None,
+        github_oauth: Some(oauth.clone()),
+        task_enrich_provider: "claude".to_string(),
+    });
+    let owner = seed_account(&db.pool, "owner-branch@example.com", "Owner").await;
+
+    Mock::given(method("GET"))
+        .and(path("/repos/example-org/regelrecht-corpus-example"))
+        .and(header("authorization", "Bearer user-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "default_branch": "main",
+            "private": true,
+            "permissions": { "push": true, "pull": true },
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(
+            "/repos/example-org/regelrecht-corpus-example/branches/main",
+        ))
+        .and(header("authorization", "Bearer user-token"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({ "name": "main" })),
+        )
+        .mount(&server)
+        .await;
+    mount_branch_bootstrap_mocks(&server).await;
+
+    let mut headers = axum::http::HeaderMap::new();
+    headers.insert(
+        axum::http::header::COOKIE,
+        axum::http::HeaderValue::from_str(&github_oauth::seal_token_cookie_for_tests(
+            &oauth,
+            owner.id,
+            "user-token",
+        ))
+        .unwrap(),
+    );
+
+    let (status, Json(summary)) = trajects::create(
+        State(state.clone()),
+        Extension(owner.clone()),
+        headers,
+        Json(custom_repo_req("Repo traject")),
+    )
+    .await
+    .expect("create with a linked token must mint the branch and succeed");
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(summary.name, "Repo traject");
+
+    // The traject row exists, and its writable-own source carries the
+    // branch we just minted on the repo.
+    let branch: String = sqlx::query_scalar(
+        "SELECT gh_branch FROM traject_corpus_sources
+         WHERE traject_id = $1 AND is_writable_own = TRUE",
+    )
+    .bind(summary.id)
+    .fetch_one(&db.pool)
+    .await
+    .unwrap();
+    assert!(
+        branch.starts_with("traject/repo-traject-"),
+        "writable-own source should carry the minted traject branch, got {branch}"
+    );
+
+    // The POST that created the ref is asserted by the `.expect(1)` on the
+    // mock, verified when the server drops at end of test.
+    drop(server);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/editor-api/tests/trajects_test.rs
+++ b/packages/editor-api/tests/trajects_test.rs
@@ -469,9 +469,146 @@ async fn create_custom_repo_mints_the_traject_branch() {
         "writable-own source should carry the minted traject branch, got {branch}"
     );
 
-    // The POST that created the ref is asserted by the `.expect(1)` on the
-    // mock, verified when the server drops at end of test.
-    drop(server);
+    // The load-bearing assertion: the ref actually POSTed to GitHub is the
+    // SAME branch the writable-own source stores. `gh_branch` is what the
+    // index scan reads (`effective_ref()`), so minting *a* branch is not
+    // enough — mint `traject/x` while persisting `traject/y` and the traject
+    // is still dead-on-arrival, now with a stray branch alongside it. Reading
+    // the request body pins the two together; a `.expect(1)` on the mock
+    // alone would not catch that drift.
+    let requests = server
+        .received_requests()
+        .await
+        .expect("mock server records requests");
+    let created_refs: Vec<String> = requests
+        .iter()
+        .filter(|r| r.method == wiremock::http::Method::POST && r.url.path().ends_with("/git/refs"))
+        .map(|r| {
+            let body: serde_json::Value =
+                serde_json::from_slice(&r.body).expect("ref-create body is JSON");
+            body["ref"].as_str().unwrap_or_default().to_string()
+        })
+        .collect();
+    assert_eq!(
+        created_refs,
+        vec![format!("refs/heads/{branch}")],
+        "create must POST exactly the ref it persists as gh_branch"
+    );
+}
+
+#[tokio::test]
+async fn create_fails_loudly_and_persists_nothing_when_the_branch_cannot_be_minted() {
+    // Criterion: a traject that cannot get its branch must not come into
+    // existence at all. The mint happens before the DB transaction opens, so
+    // a failing ref-create has to surface as an error *and* leave zero rows
+    // behind — no traject that looks fine in the list but 502s on every
+    // corpus call. Move the mint after the INSERT and this test goes red.
+    use wiremock::matchers::{header, method, path, path_regex};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let db = TestDb::new().await;
+    let server = MockServer::start().await;
+
+    let mut oauth = GithubOAuth::for_tests(true);
+    oauth.api_base = server.uri();
+    let mut state = empty_state(db.pool.clone());
+    state.config = Arc::new(AppConfig {
+        oidc: None,
+        base_url: None,
+        github_oauth: Some(oauth.clone()),
+        task_enrich_provider: "claude".to_string(),
+    });
+    let owner = seed_account(&db.pool, "owner-branchfail@example.com", "Owner").await;
+
+    // Preflight passes: repo readable, push allowed, base branch present.
+    Mock::given(method("GET"))
+        .and(path("/repos/example-org/regelrecht-corpus-example"))
+        .and(header("authorization", "Bearer user-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "default_branch": "main",
+            "private": true,
+            "permissions": { "push": true, "pull": true },
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(
+            "/repos/example-org/regelrecht-corpus-example/branches/main",
+        ))
+        .and(header("authorization", "Bearer user-token"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({ "name": "main" })),
+        )
+        .mount(&server)
+        .await;
+    // The traject branch does not exist...
+    Mock::given(method("GET"))
+        .and(path_regex(
+            r"^/repos/example-org/regelrecht-corpus-example/git/ref/heads/traject/.+$",
+        ))
+        .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+            "message": "Not Found",
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(
+            "/repos/example-org/regelrecht-corpus-example/git/ref/heads/main",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ref": "refs/heads/main",
+            "object": { "sha": "abc123def456", "type": "commit" },
+        })))
+        .mount(&server)
+        .await;
+    // ...and creating it fails (GitHub hiccup / access revoked mid-flight).
+    Mock::given(method("POST"))
+        .and(path(
+            "/repos/example-org/regelrecht-corpus-example/git/refs",
+        ))
+        .respond_with(ResponseTemplate::new(500).set_body_json(serde_json::json!({
+            "message": "Internal Server Error",
+        })))
+        .mount(&server)
+        .await;
+
+    let mut headers = axum::http::HeaderMap::new();
+    headers.insert(
+        axum::http::header::COOKIE,
+        axum::http::HeaderValue::from_str(&github_oauth::seal_token_cookie_for_tests(
+            &oauth,
+            owner.id,
+            "user-token",
+        ))
+        .unwrap(),
+    );
+
+    let err = trajects::create(
+        State(state.clone()),
+        Extension(owner.clone()),
+        headers,
+        Json(custom_repo_req("Repo traject")),
+    )
+    .await
+    .expect_err("a failed branch-create must fail the whole create");
+    assert_eq!(err.0, StatusCode::BAD_GATEWAY);
+    // Dutch, names the branch, and says the traject was not created — an
+    // operator must not have to read the logs to understand this.
+    assert!(
+        err.1.contains("traject-branch") && err.1.contains("niet aangemaakt"),
+        "expected a Dutch branch-create failure message, got: {}",
+        err.1
+    );
+
+    // Nothing was persisted: no traject row, so no half-broken traject.
+    let trajects_left: i64 = sqlx::query_scalar("SELECT count(*) FROM trajects")
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        trajects_left, 0,
+        "a failed branch-create must leave no traject behind"
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Probleem

Een vers aangemaakt traject op een eigen GitHub-repo was onbruikbaar zolang er nog nooit iets naar geschreven was.

De traject-branch heet `traject/{slug}-{short}`. In user-token-schrijfmodus heeft de backend geen eigen service-token voor een door de gebruiker aangeleverde repo, dus sloeg `ensure_ready` het aanmaken van die branch over. De index-scan gaat er intussen wél van uit dat de branch bestaat: hij scant `effective_ref()`, en dat is precies die traject-branch. Bestond hij niet, dan gaf de Trees API een 404 en werd dat via `require_traject_index` een 502 op elk traject-scoped corpus-endpoint.

Dat sloot zichzelf op: bibliotheek, zoeken en "wet toevoegen" hangen allemaal aan `/corpus/laws` → 502, terwijl juist die schrijf-UI de enige manier was om de lazy branch-bootstrap op het schrijfpad te triggeren. De lazy bootstrap en de "luid falen"-gate zijn los van elkaar ontworpen en beten elkaar.

Bestaande trajecten hadden er geen last van, omdat die al eens beschreven waren en hun branch dus bestond.

## Oplossing

De traject-branch wordt nu meteen bij het aanmaken gemunt, in de preflight — precies daar waar het token dat zojuist push-toegang bewees nog in de hand is. In user-token-modus is dat het enige moment waarop een bruikbaar token gegarandeerd beschikbaar is.

- Hergebruikt `GitHubApiBackend::ensure_branch` in plaats van `create_branch` rechtstreeks aan te roepen. Die vangt de "branch bestaat al"-race al af, dus het aanmaken is idempotent bij een herhaalde aanroep of twee leden die tegelijk aanmaken.
- Het traject-id wordt nu vóór de preflight gemunt, zodat de branchnaam (afgeleid via `derive_branch_name`) bekend is voordat we GitHub of de database aanraken. De INSERT hergebruikt hetzelfde id — één identiteit over GitHub, URL-ref en DB-rij.
- Mislukt het aanmaken van de branch, dan faalt het aanmaken van het traject luid met een begrijpelijke Nederlandse melding. Dat gebeurt vóór de DB-transactie, dus er blijft geen half-aangemaakt traject achter dat er goed uitziet maar stuk is. Push-toegang is op dat moment net bevestigd, dus dit hoort een uitzondering te zijn.
- De bestaande lazy bootstrap op het schrijfpad blijft staan als vangnet voor trajecten die al zonder branch in de database zitten.

## Test

`create_custom_repo_mints_the_traject_branch` legt vast dat create een nieuwe ref POST voor de traject-branch, afgetakt van de base-branch. De test faalt op de huidige main: daar worden alleen de twee preflight-requests gedaan en nooit een ref-create.

Backfill voor bestaande branch-loze trajecten valt buiten deze wijziging.
