### PR TITLE
feat(editor): classificeer de mislukte trajectscan en meld hem kloppend

### DIFF
--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -23,11 +23,15 @@ use regelrecht_corpus::source_map::{
 };
 use regelrecht_corpus::timing;
 use regelrecht_corpus::CorpusError;
+use regelrecht_github::GithubClient;
 
 use crate::accounts::AccountRecord;
 use crate::credentials::{self, TrajectCredentials};
 use crate::state::{AppState, CorpusState};
 use crate::traject_corpus::{ScenarioListEntry, TrajectCorpus, TrajectCorpusError};
+use crate::traject_index_diagnosis::{
+    classify_index_failure, index_failure_to_status, IndexFailureKind, TokenOrigin,
+};
 use crate::trajects::resolve_traject_ref;
 use crate::user_notes;
 
@@ -137,6 +141,11 @@ pub(crate) enum ReadScope {
 pub(crate) struct TrajectScope {
     traject: Arc<TrajectCorpus>,
     own_read_token: Result<Option<String>, (StatusCode, String)>,
+    /// The caller's editor account. Only used for logging on the
+    /// index-failure path: reading the logs back, an operator needs to know
+    /// *whose* access path broke, and an account id says that without
+    /// putting a name or e-mail address in the log.
+    account_id: Uuid,
 }
 
 impl TrajectScope {
@@ -208,6 +217,7 @@ impl ReadScope {
         ReadScope::Traject(TrajectScope {
             traject,
             own_read_token,
+            account_id,
         })
     }
 
@@ -237,7 +247,7 @@ impl ReadScope {
                 t.traject
                     .law_yaml_with_read_token(law_id, token)
                     .await
-                    .map_err(law_read_error(law_id))
+                    .map_err(law_read_error(t.traject.traject_id, law_id))
             }
             // The global corpus is fully loaded up front, so there's no lazy
             // fetch that could fail — a miss is always a genuine miss.
@@ -259,7 +269,12 @@ impl ReadScope {
                     .law_yaml_versions_with_read_token(law_id, token)
                     .await
                     .map_err(|e| {
-                        tracing::warn!(law_id = %law_id, error = %e, "failed to load law versions");
+                        tracing::warn!(
+                            traject = %t.traject.traject_id,
+                            law_id = %law_id,
+                            error = %e,
+                            "failed to load law versions"
+                        );
                         (
                             StatusCode::BAD_GATEWAY,
                             format!("Kon versies van wet '{law_id}' niet laden"),
@@ -290,12 +305,14 @@ impl ReadScope {
 }
 
 /// Map a law-body backend failure to the client-facing 502; the raw error
-/// is logged for operators.
+/// is logged for operators, tagged with the traject so it can be correlated
+/// with the rest of that traject's read path.
 fn law_read_error(
+    traject_id: Uuid,
     law_id: &str,
 ) -> impl FnOnce(regelrecht_corpus::error::CorpusError) -> (StatusCode, String) + '_ {
     move |e| {
-        tracing::warn!(law_id = %law_id, error = %e, "failed to load law body");
+        tracing::warn!(traject = %traject_id, law_id = %law_id, error = %e, "failed to load law body");
         (
             StatusCode::BAD_GATEWAY,
             format!("Kon wet '{law_id}' niet laden"),
@@ -397,32 +414,95 @@ async fn require_traject_scope(
 /// Criterion "luid falen": when the traject's writable-own source failed
 /// to index, the traject-scoped law index must refuse to serve instead of
 /// presenting a normal-looking list in which every law silently resolved
-/// from the central seed corpus. A missing/expired GitHub link is the one
-/// *actionable* cause, so that surfaces as the deferred 428 (the connect
-/// flow); any other scan failure maps to an explicit 502 carrying the
-/// scan error. `/sources` deliberately stays outside this gate — the
-/// per-source `index_error` there is how the failure is diagnosed.
-fn require_traject_index(scope: &ReadScope) -> Result<(), (StatusCode, String)> {
+/// from the central seed corpus. `/sources` deliberately stays outside
+/// this gate — the per-source `index_error` there is how the failure is
+/// diagnosed.
+///
+/// Refusing is not the same as being useless about it. A failed scan has
+/// half a dozen wildly different causes — a traject that was never
+/// initialised, a branch someone deleted, a repo that moved, a link that
+/// GitHub no longer accepts — each with its own remedy, and one blanket
+/// 502 tells the member none of them. So the failure path classifies the
+/// cause in-band, with the very token the scan used (see
+/// [`crate::traject_index_diagnosis`]), and answers with the matching
+/// status and a Dutch sentence that names both the problem and the fix.
+///
+/// The extra GitHub calls that costs land **only here**, on a request
+/// that has already failed; the happy path returns on the first line
+/// without touching the network.
+async fn require_traject_index(scope: &ReadScope) -> Result<(), (StatusCode, String)> {
     let ReadScope::Traject(t) = scope else {
         return Ok(());
     };
-    let Some(err) = t.traject.own_index_error() else {
+    let Some(scan_error) = t.traject.own_index_error() else {
         return Ok(());
     };
     // Deferred read-token outcome first: unlinked (or expired) in
-    // user-token mode → 428 into the koppel-flow.
-    t.own_read_token()?;
+    // user-token mode → 428 into the koppel-flow. That is the one
+    // situation the server can already name without asking GitHub.
+    let user_token = t.own_read_token()?;
+
+    // Same token the scan authenticated with, so the probe walks the same
+    // access path: the caller's personal one when there is one, otherwise
+    // the source's server-side token.
+    let server_token = if user_token.is_none() {
+        t.traject.own_server_token()
+    } else {
+        None
+    };
+    let (token, origin) = match (user_token, server_token.as_deref()) {
+        (Some(tok), _) => (Some(tok), TokenOrigin::User),
+        (None, Some(tok)) => (Some(tok), TokenOrigin::Server),
+        (None, None) => (None, TokenOrigin::Absent),
+    };
+
+    let (kind, status, message) = match t.traject.own_source_target() {
+        Some(target) => {
+            // Plain `new()`: it honours the same `GITHUB_API_BASE` seam the
+            // scan's own client did, so the probe reaches the same host that
+            // just refused it.
+            let kind = match GithubClient::new() {
+                Ok(client) => classify_index_failure(&client, &target, token).await,
+                // No client, nothing to probe with — an infrastructure
+                // fault of our own, not a diagnosis.
+                Err(e) => {
+                    tracing::error!(
+                        traject = %target.traject_id,
+                        error = %e,
+                        "failed to build GitHub client for traject index diagnosis"
+                    );
+                    IndexFailureKind::Unknown
+                }
+            };
+            let (status, message) = index_failure_to_status(kind, &target, origin);
+            (kind, status, message)
+        }
+        // A writable-own source that isn't GitHub-backed (local dev /
+        // preview stack): there is no repo to interrogate.
+        None => (
+            IndexFailureKind::Unknown,
+            StatusCode::BAD_GATEWAY,
+            "De bibliotheek van dit traject kon niet worden gelezen. Probeer het opnieuw en \
+             meld het als het blijft misgaan."
+                .to_string(),
+        ),
+    };
+
+    // The one place this path logs its outcome, with a fixed field set so an
+    // incident is findable both by traject and by kind. `error` carries the
+    // raw scan failure; `account` says whose access path broke without naming
+    // the person behind it.
     tracing::warn!(
-        error = %err,
+        traject = %t.traject.traject_id,
+        source_id = %t.traject.writable_own_source_id,
+        account = %t.account_id,
+        kind = %kind,
+        token_origin = %origin.as_str(),
+        status = status.as_u16(),
+        error = %scan_error,
         "traject library refused: writable-own source failed to index"
     );
-    Err((
-        StatusCode::BAD_GATEWAY,
-        format!(
-            "De bibliotheek van dit traject is niet beschikbaar: de traject-repo kon niet \
-             worden gescand ({err})"
-        ),
-    ))
+    Err((status, message))
 }
 
 /// GET /api/sources — list all registered corpus sources (global).
@@ -475,8 +555,9 @@ pub async fn list_traject_corpus_laws(
 ) -> Result<Json<Vec<CorpusLawEntry>>, (StatusCode, String)> {
     let scope = require_traject_scope(&state, &session, &account, &headers, &traject_ref).await?;
     // No silent central-only fallback: a traject whose own repo couldn't
-    // be scanned fails this listing loudly (428 koppel-flow / 502).
-    require_traject_index(&scope)?;
+    // be scanned fails this listing loudly, with the cause classified and
+    // the status that fits it.
+    require_traject_index(&scope).await?;
     Ok(Json(list_corpus_laws_in_scope(&scope, params)))
 }
 

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -1797,7 +1797,11 @@ async fn require_traject_corpus_from_ref_with_scan_token(
         .get(SESSION_KEY_SUB)
         .await
         .map_err(|e| {
-            tracing::error!(error = %e, "session read sub in require_traject_corpus_from_ref");
+            tracing::error!(
+                traject = %traject_id,
+                error = %e,
+                "session read sub in require_traject_corpus_from_ref"
+            );
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "session read failed".to_string(),
@@ -1819,7 +1823,7 @@ async fn require_traject_corpus_from_ref_with_scan_token(
     .fetch_one(pool)
     .await
     .map_err(|e| {
-        tracing::error!(error = %e, "membership re-check query failed");
+        tracing::error!(traject = %traject_id, error = %e, "membership re-check query failed");
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             "membership check failed".to_string(),
@@ -1840,10 +1844,13 @@ async fn require_traject_corpus_from_ref_with_scan_token(
         .trajects
         .get_or_build(pool, traject_id, auth_file, own_scan_token)
         .await
-        .map_err(traject_corpus_error)
+        .map_err(|e| traject_corpus_error(traject_id, e))
 }
 
-fn traject_corpus_error(e: TrajectCorpusError) -> (StatusCode, String) {
+/// `traject_id` is carried in purely so the one log line here names the
+/// traject: every warning on this read path has to be correlatable with the
+/// rest of that traject's trail.
+fn traject_corpus_error(traject_id: Uuid, e: TrajectCorpusError) -> (StatusCode, String) {
     match e {
         TrajectCorpusError::NotFound => (
             StatusCode::NOT_FOUND,
@@ -1854,7 +1861,7 @@ fn traject_corpus_error(e: TrajectCorpusError) -> (StatusCode, String) {
             "Traject heeft geen eigen schrijfbare source".to_string(),
         ),
         other => {
-            tracing::error!(error = %other, "traject corpus build failed");
+            tracing::error!(traject = %traject_id, error = %other, "traject corpus build failed");
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Traject corpus init failed".to_string(),

--- a/packages/editor-api/src/lib.rs
+++ b/packages/editor-api/src/lib.rs
@@ -15,5 +15,6 @@ pub mod github_oauth;
 pub mod state;
 pub mod task_requests;
 pub mod traject_corpus;
+pub mod traject_index_diagnosis;
 pub mod trajects;
 pub mod user_notes;

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -30,6 +30,7 @@ mod state;
 mod task_requests;
 mod tasks_api;
 mod traject_corpus;
+mod traject_index_diagnosis;
 mod trajects;
 mod user_notes;
 mod user_settings;

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -40,11 +40,22 @@ use tokio::sync::{Mutex, RwLock};
 use uuid::Uuid;
 
 use crate::state::{BackendEntry, CorpusState};
+use crate::traject_index_diagnosis::OwnSourceTarget;
 
 /// Resolved corpus state for a single traject, plus per-source write
 /// routing.
 pub struct TrajectCorpus {
     pub corpus: CorpusState,
+    /// The traject this snapshot belongs to. Carried on the snapshot so
+    /// every log line written from a read path can be tied back to one
+    /// traject — a warning without it cannot be correlated with anything.
+    pub traject_id: Uuid,
+    /// The branch the writable-own source branches from (the
+    /// `gh_base_branch` column), when that source is GitHub-backed.
+    /// Kept outside the registry's [`Source`] because it is
+    /// traject-flow-specific; the diagnosis of a failed index scan needs
+    /// it to tell "the base branch is gone" apart from the other causes.
+    pub own_base_branch: Option<String>,
     /// Maps the `source_id` a law was loaded from to the `source_id`
     /// whose backend should receive the write. When the read source is
     /// itself writable (local source, or a GitHub source that doesn't
@@ -373,6 +384,57 @@ impl TrajectCorpus {
             .index_failures
             .get(&self.writable_own_source_id)
             .map(String::as_str)
+    }
+
+    /// The GitHub coordinates of the writable-own source, for the in-band
+    /// diagnosis of a failed index scan (see
+    /// [`crate::traject_index_diagnosis`]). `None` when that source isn't
+    /// GitHub-backed (a local dev/preview stack), which leaves nothing to
+    /// ask GitHub about.
+    ///
+    /// The branch comes straight from the stored source config rather than
+    /// being re-derived from the traject name, so the probe asks about the
+    /// branch the scan actually read.
+    pub fn own_source_target(&self) -> Option<OwnSourceTarget> {
+        let source = self
+            .corpus
+            .registry
+            .get_source(&self.writable_own_source_id)?;
+        let SourceType::GitHub { github } = &source.source_type else {
+            return None;
+        };
+        Some(OwnSourceTarget {
+            traject_id: self.traject_id,
+            source_id: self.writable_own_source_id.clone(),
+            owner: github.owner.clone(),
+            repo: github.repo.clone(),
+            branch: github.branch.clone(),
+            // Mirrors `build_traject_github_backend`'s default: a NULL
+            // `gh_base_branch` means "main".
+            base_branch: self
+                .own_base_branch
+                .clone()
+                .unwrap_or_else(|| "main".to_string()),
+        })
+    }
+
+    /// Re-resolve the server-side token configured for the writable-own
+    /// source, if any.
+    ///
+    /// Only for the error path: when a request carries no personal token
+    /// the failed scan authenticated with this one, so the diagnosis has to
+    /// use it too or it would probe a different access path than the one
+    /// that broke. Resolved on demand and dropped by the caller — no token
+    /// is ever stored on this shared, cross-user snapshot.
+    pub fn own_server_token(&self) -> Option<String> {
+        let source = self
+            .corpus
+            .registry
+            .get_source(&self.writable_own_source_id)?;
+        regelrecht_corpus::auth::CredentialResolver::new(self.corpus.auth_file.as_deref())
+            .resolve_source(source)
+            .ok()
+            .and_then(regelrecht_corpus::auth::TokenDecision::into_token)
     }
 
     /// Resolve the YAML content for a law in this traject, preferring the
@@ -1514,6 +1576,14 @@ async fn build_traject_corpus(
         .map(|r| r.source_id.clone())
         .ok_or(TrajectCorpusError::NoWritableOwn)?;
 
+    // Traject-flow-specific, so it never made it into `Source`: the branch
+    // the traject branch is cut from. Kept on the snapshot so a failed
+    // index scan can be diagnosed without a second DB round trip.
+    let own_base_branch = rows
+        .iter()
+        .find(|r| r.is_writable_own)
+        .and_then(|r| r.gh_base_branch.clone());
+
     // Build the read-source → write-target-source map. Every non-
     // writable_own source (local seed, GitHub seed, …) is routed to the
     // writable_own's backend so a save on any read-only seed-loaded law
@@ -1737,6 +1807,8 @@ async fn build_traject_corpus(
             auth_file: auth_file.map(|p| p.to_path_buf()),
             index_failures,
         },
+        traject_id,
+        own_base_branch,
         write_target_for_source,
         writable_own_source_id,
         overlay: Arc::new(RwLock::new(HashMap::new())),
@@ -1846,6 +1918,8 @@ async fn next_snapshot(old: &Arc<TrajectCorpus>, source_map: SourceMap) -> Arc<T
             // scan failures to report.
             index_failures: HashMap::new(),
         },
+        traject_id: old.traject_id,
+        own_base_branch: old.own_base_branch.clone(),
         write_target_for_source: old.write_target_for_source.clone(),
         writable_own_source_id: old.writable_own_source_id.clone(),
         overlay: old.overlay.clone(),
@@ -2149,6 +2223,8 @@ mod tests {
                 auth_file: None,
                 index_failures: HashMap::new(),
             },
+            traject_id: Uuid::nil(),
+            own_base_branch: None,
             write_target_for_source: HashMap::new(),
             writable_own_source_id: "own".to_string(),
             overlay: Arc::new(RwLock::new(HashMap::new())),
@@ -2612,6 +2688,8 @@ mod tests {
                 auth_file: None,
                 index_failures: HashMap::new(),
             },
+            traject_id: Uuid::nil(),
+            own_base_branch: None,
             write_target_for_source: HashMap::new(),
             writable_own_source_id: "own".to_string(),
             overlay: Arc::new(RwLock::new(HashMap::new())),

--- a/packages/editor-api/src/traject_index_diagnosis.rs
+++ b/packages/editor-api/src/traject_index_diagnosis.rs
@@ -33,9 +33,9 @@
 //!
 //! Nothing here runs on the happy path. The probe costs two GitHub calls
 //! (repo + base branch), a third when the traject branch has to be checked
-//! or when a refused credential has to be confirmed, and a fourth only when
-//! the traject branch turns out to be absent — and all of that exclusively
-//! after a scan has already failed.
+//! or when a refusal has to be pinned down, and a fourth only when the
+//! traject branch turns out to be absent — and all of that exclusively after
+//! a scan has already failed.
 
 use axum::http::StatusCode;
 use regelrecht_github::{GithubClient, GithubError, RepoAccessError};
@@ -178,10 +178,20 @@ pub async fn classify_index_failure(
         .await
     {
         Ok(_) => classify_traject_branch(client, target, token).await,
-        // Not taken at face value — see [`confirm_link_revoked`]: this is the
-        // one verdict that ends in the connect flow, and the preflight folds
-        // more than a refused credential into it.
-        Err(RepoAccessError::Unauthorized) => confirm_link_revoked(client, target, token).await,
+        // Neither refusal is taken at face value — see [`Refusal`]: the
+        // preflight answers in write-path terms and folds statuses that mean
+        // very different things to a reader.
+        Err(RepoAccessError::Unauthorized) => match probe_refusal(client, target, token).await {
+            // GitHub refuses the credential itself. Re-linking is the fix, so
+            // this — and only this — earns the connect flow.
+            Refusal::Credential => IndexFailureKind::LinkRevoked,
+            Refusal::Throttled | Refusal::Unreachable => IndexFailureKind::GithubUnreachable,
+            Refusal::Access => IndexFailureKind::InsufficientScope,
+            // The read went through, or failed on something unrelated: the
+            // refusal is unexplained. Say so, rather than send the member off
+            // to re-link a credential that may be perfectly fine.
+            Refusal::Unclear => IndexFailureKind::Unknown,
+        },
         Err(RepoAccessError::RepoNotFound) => IndexFailureKind::RepoUnavailable,
         Err(RepoAccessError::BranchNotFound) => IndexFailureKind::BaseBranchMissing,
         // The preflight raises this both for `permissions.push == false` and
@@ -189,56 +199,67 @@ pub async fn classify_index_failure(
         // same thing to the user: this account does not have enough access
         // to this repo. Kept apart from `LinkRevoked` because the remedy
         // differs — re-linking the same account changes nothing here.
-        Err(RepoAccessError::NoPushAccess) => IndexFailureKind::InsufficientScope,
+        Err(RepoAccessError::NoPushAccess) => match probe_refusal(client, target, token).await {
+            Refusal::Throttled | Refusal::Unreachable => IndexFailureKind::GithubUnreachable,
+            // `push == false` (the read itself goes through), a genuine 403
+            // on the branch read, or a credential that fell over between the
+            // two calls: for a reader they all say the same thing, and none
+            // of them is the connect-flow case — the repo lookup that just
+            // succeeded rules that out.
+            Refusal::Credential | Refusal::Access | Refusal::Unclear => {
+                IndexFailureKind::InsufficientScope
+            }
+        },
         Err(RepoAccessError::Transport(_)) => IndexFailureKind::GithubUnreachable,
         Err(RepoAccessError::Other(_)) => IndexFailureKind::Unknown,
     }
 }
 
-/// Confirm — with an actual 401 — that GitHub is refusing the credential,
-/// before the answer becomes the one status on this path that re-enters the
-/// connect flow.
+/// What GitHub says when the repository is read once more, with the raw
+/// status kept instead of folded.
 ///
-/// `validate_repo_access` answers [`RepoAccessError::Unauthorized`] for a 401
-/// *and* for a 403 on the repo lookup. On the write path that conflation is
-/// harmless (both end in the same 502), but here 401 means
+/// `validate_repo_access` is the create-traject preflight, and it answers in
+/// write-path terms: [`RepoAccessError::Unauthorized`] covers a 401 *and* a
+/// 403 on the repo lookup, [`RepoAccessError::NoPushAccess`] covers both
+/// `permissions.push == false` and a 403 on the branch read. Harmless there —
+/// each pair ends in one status. Not here: 401 means
 /// [`IndexFailureKind::LinkRevoked`] → 428 → `apiAuthGuard.js` → connect
-/// flow, and GitHub also answers 403 when the token's rate limit is spent,
-/// when an organisation's SAML/SSO authorisation has not been granted, or
-/// when an IP allow list blocks the call. Re-linking fixes none of those, so
-/// a 428 would bounce the member round the connect flow and land on the same
-/// 403 every time.
+/// flow, while a 403 is also how GitHub reports a spent rate limit, an
+/// ungranted SAML/SSO authorisation and an IP-allow-list block. Re-linking
+/// fixes none of those, and a rate limit is not a permission problem at all —
+/// it passes on its own.
 ///
-/// One extra read settles it, because [`GithubClient::branch_exists`] keeps
-/// the raw status instead of folding it. Strictly on the error path, and only
-/// for the single outcome that can reach the connect flow.
-async fn confirm_link_revoked(
-    client: &GithubClient,
-    target: &OwnSourceTarget,
-    token: &str,
-) -> IndexFailureKind {
+/// So both refusals are re-asked through [`GithubClient::branch_exists`],
+/// which preserves the status. Strictly on the error path, and only for the
+/// two outcomes whose folding actually costs the member a wrong remedy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Refusal {
+    /// 401 — GitHub refuses the credential itself.
+    Credential,
+    /// A rate limit, primary or secondary. Temporary, and nobody's fault.
+    Throttled,
+    /// 403 — authenticated, but this repository stays shut for this token.
+    Access,
+    /// GitHub could not be reached at all.
+    Unreachable,
+    /// The read went through, or failed on something else entirely.
+    Unclear,
+}
+
+async fn probe_refusal(client: &GithubClient, target: &OwnSourceTarget, token: &str) -> Refusal {
     match client
         .branch_exists(&target.full_repo(), &target.base_branch, Some(token))
         .await
     {
-        // GitHub refuses the credential itself. Re-linking is the fix, so
-        // this — and only this — earns the connect flow.
-        Err(GithubError::Api { status: 401, .. }) => IndexFailureKind::LinkRevoked,
-        // Authenticated fine, just throttled. Neither a permission problem
-        // nor a link problem: it passes by itself, so it reads as the
-        // temporary GitHub outage it effectively is.
+        Err(GithubError::Api { status: 401, .. }) => Refusal::Credential,
         Err(GithubError::Api { status, message })
             if status == 429 || (status == 403 && is_rate_limited(&message)) =>
         {
-            IndexFailureKind::GithubUnreachable
+            Refusal::Throttled
         }
-        // Authenticated, but this repository stays shut for this token.
-        Err(GithubError::Api { status: 403, .. }) => IndexFailureKind::InsufficientScope,
-        Err(GithubError::Transport(_)) => IndexFailureKind::GithubUnreachable,
-        // Anything else — including a read that suddenly succeeds — leaves
-        // the refusal unexplained. Say so rather than send the member off to
-        // re-link something that may be perfectly fine.
-        _ => IndexFailureKind::Unknown,
+        Err(GithubError::Api { status: 403, .. }) => Refusal::Access,
+        Err(GithubError::Transport(_)) => Refusal::Unreachable,
+        _ => Refusal::Unclear,
     }
 }
 

--- a/packages/editor-api/src/traject_index_diagnosis.rs
+++ b/packages/editor-api/src/traject_index_diagnosis.rs
@@ -375,14 +375,29 @@ pub fn index_failure_to_status(
                 ),
             ),
         },
-        IndexFailureKind::InsufficientScope => (
-            StatusCode::FORBIDDEN,
-            format!(
-                "Je GitHub-toegang tot {repo} is niet toereikend voor dit traject. Vraag de \
-                 eigenaar van de repo om toegang, of koppel het GitHub-account dat die toegang \
-                 wel heeft."
+        // Split for the same reason as `LinkRevoked`, one step further: a
+        // server token that is too narrow is not something the member can
+        // re-link away either — a writable-at-rest source never consults a
+        // personal link for reads, so pointing at the connect flow would be a
+        // dead end. Same 403 either way; only the remedy differs.
+        IndexFailureKind::InsufficientScope => match origin {
+            TokenOrigin::User => (
+                StatusCode::FORBIDDEN,
+                format!(
+                    "Je GitHub-toegang tot {repo} is niet toereikend voor dit traject. Vraag de \
+                     eigenaar van de repo om toegang, of koppel het GitHub-account dat die \
+                     toegang wel heeft."
+                ),
             ),
-        ),
+            TokenOrigin::Server | TokenOrigin::Absent => (
+                StatusCode::FORBIDDEN,
+                format!(
+                    "Het GitHub-token van de beheerder heeft niet genoeg toegang tot {repo} voor \
+                     dit traject. Meld dit bij je beheerder; zelf opnieuw koppelen helpt hier \
+                     niet."
+                ),
+            ),
+        },
         IndexFailureKind::GithubUnreachable => (
             StatusCode::SERVICE_UNAVAILABLE,
             "GitHub is nu niet bereikbaar, waardoor de bibliotheek van dit traject niet geladen \

--- a/packages/editor-api/src/traject_index_diagnosis.rs
+++ b/packages/editor-api/src/traject_index_diagnosis.rs
@@ -32,9 +32,10 @@
 //! # Cost
 //!
 //! Nothing here runs on the happy path. The probe costs two GitHub calls
-//! (repo + base branch), a third when the traject branch has to be checked,
-//! and a fourth only when that branch turns out to be absent — and all of
-//! that exclusively after a scan has already failed.
+//! (repo + base branch), a third when the traject branch has to be checked
+//! or when a refused credential has to be confirmed, and a fourth only when
+//! the traject branch turns out to be absent — and all of that exclusively
+//! after a scan has already failed.
 
 use axum::http::StatusCode;
 use regelrecht_github::{GithubClient, GithubError, RepoAccessError};
@@ -177,7 +178,10 @@ pub async fn classify_index_failure(
         .await
     {
         Ok(_) => classify_traject_branch(client, target, token).await,
-        Err(RepoAccessError::Unauthorized) => IndexFailureKind::LinkRevoked,
+        // Not taken at face value — see [`confirm_link_revoked`]: this is the
+        // one verdict that ends in the connect flow, and the preflight folds
+        // more than a refused credential into it.
+        Err(RepoAccessError::Unauthorized) => confirm_link_revoked(client, target, token).await,
         Err(RepoAccessError::RepoNotFound) => IndexFailureKind::RepoUnavailable,
         Err(RepoAccessError::BranchNotFound) => IndexFailureKind::BaseBranchMissing,
         // The preflight raises this both for `permissions.push == false` and
@@ -189,6 +193,63 @@ pub async fn classify_index_failure(
         Err(RepoAccessError::Transport(_)) => IndexFailureKind::GithubUnreachable,
         Err(RepoAccessError::Other(_)) => IndexFailureKind::Unknown,
     }
+}
+
+/// Confirm — with an actual 401 — that GitHub is refusing the credential,
+/// before the answer becomes the one status on this path that re-enters the
+/// connect flow.
+///
+/// `validate_repo_access` answers [`RepoAccessError::Unauthorized`] for a 401
+/// *and* for a 403 on the repo lookup. On the write path that conflation is
+/// harmless (both end in the same 502), but here 401 means
+/// [`IndexFailureKind::LinkRevoked`] → 428 → `apiAuthGuard.js` → connect
+/// flow, and GitHub also answers 403 when the token's rate limit is spent,
+/// when an organisation's SAML/SSO authorisation has not been granted, or
+/// when an IP allow list blocks the call. Re-linking fixes none of those, so
+/// a 428 would bounce the member round the connect flow and land on the same
+/// 403 every time.
+///
+/// One extra read settles it, because [`GithubClient::branch_exists`] keeps
+/// the raw status instead of folding it. Strictly on the error path, and only
+/// for the single outcome that can reach the connect flow.
+async fn confirm_link_revoked(
+    client: &GithubClient,
+    target: &OwnSourceTarget,
+    token: &str,
+) -> IndexFailureKind {
+    match client
+        .branch_exists(&target.full_repo(), &target.base_branch, Some(token))
+        .await
+    {
+        // GitHub refuses the credential itself. Re-linking is the fix, so
+        // this — and only this — earns the connect flow.
+        Err(GithubError::Api { status: 401, .. }) => IndexFailureKind::LinkRevoked,
+        // Authenticated fine, just throttled. Neither a permission problem
+        // nor a link problem: it passes by itself, so it reads as the
+        // temporary GitHub outage it effectively is.
+        Err(GithubError::Api { status, message })
+            if status == 429 || (status == 403 && is_rate_limited(&message)) =>
+        {
+            IndexFailureKind::GithubUnreachable
+        }
+        // Authenticated, but this repository stays shut for this token.
+        Err(GithubError::Api { status: 403, .. }) => IndexFailureKind::InsufficientScope,
+        Err(GithubError::Transport(_)) => IndexFailureKind::GithubUnreachable,
+        // Anything else — including a read that suddenly succeeds — leaves
+        // the refusal unexplained. Say so rather than send the member off to
+        // re-link something that may be perfectly fine.
+        _ => IndexFailureKind::Unknown,
+    }
+}
+
+/// Whether a GitHub error body is the rate limiter talking.
+///
+/// Both documented wordings — "API rate limit exceeded for …" (primary) and
+/// "You have exceeded a secondary rate limit …" — carry this phrase. A miss
+/// only costs precision: the answer lands on the neighbouring classification,
+/// never on the connect flow.
+fn is_rate_limited(message: &str) -> bool {
+    message.to_ascii_lowercase().contains("rate limit")
 }
 
 /// Repo, base branch and access all check out — so the remaining question is
@@ -240,7 +301,8 @@ async fn classify_traject_branch(
 /// Every message says what is wrong *and* what to do about it, and none of
 /// them falls back on "de gegevens konden niet worden opgehaald". They stay
 /// short and carry no raw GitHub payload, so the frontend's length cap on
-/// the index-error pane can never truncate one.
+/// the index-error pane can never replace one — see `ID_BUDGET` for the one
+/// part of a message whose length is not ours to choose.
 ///
 /// On the statuses: **428 is reserved editor-wide for the GitHub connect
 /// flow** (`apiAuthGuard.js` redirects every 428 on `/api/*` into it), so it
@@ -253,41 +315,45 @@ pub fn index_failure_to_status(
     target: &OwnSourceTarget,
     origin: TokenOrigin,
 ) -> (StatusCode, String) {
-    let repo = target.full_repo();
+    let repo = clamp_identifier(&target.full_repo());
+    let branch = clamp_identifier(&target.branch);
+    let base_branch = clamp_identifier(&target.base_branch);
     match kind {
         IndexFailureKind::TrajectBranchMissing => (
             StatusCode::CONFLICT,
             format!(
-                "Dit traject is nog niet geïnitialiseerd: de branch '{}' bestaat nog niet in \
-                 {repo}. Sla één wijziging op, dan wordt de branch aangemaakt en vult de \
-                 bibliotheek zich.",
-                target.branch
+                "Dit traject is nog niet geïnitialiseerd: de branch '{branch}' bestaat nog niet \
+                 in {repo}. Sla één wijziging op, dan wordt de branch aangemaakt en vult de \
+                 bibliotheek zich."
             ),
         ),
         IndexFailureKind::TrajectBranchGone => (
             StatusCode::GONE,
             format!(
-                "De branch '{}' van dit traject is verwijderd uit {repo}. Werk dat alleen daar \
-                 stond, is mogelijk verloren. Laat een beheerder de branch herstellen voordat \
-                 je verder werkt.",
-                target.branch
+                "De branch '{branch}' van dit traject is verwijderd uit {repo}. Werk dat alleen \
+                 daar stond, is mogelijk verloren. Laat een beheerder de branch herstellen \
+                 voordat je verder werkt."
             ),
         ),
+        // GitHub answers 404 for a repo that is not there *and* for one this
+        // token may not see, and nothing in-band separates the two — so the
+        // message names both, with the remedy for each. Claiming only the
+        // rename would send a member who was quietly removed from the repo
+        // to an administrator to fix an address that is perfectly correct.
         IndexFailureKind::RepoUnavailable => (
             StatusCode::NOT_FOUND,
             format!(
-                "De repo {repo} staat niet meer op het adres dat in dit traject is vastgelegd: \
-                 hernoemd, overgedragen of verwijderd. Laat een beheerder het traject naar het \
-                 juiste adres verwijzen."
+                "GitHub kent {repo} niet op het adres uit dit traject: hernoemd, overgedragen of \
+                 verwijderd — of je hebt er geen toegang meer toe. Vraag toegang tot de repo, of \
+                 laat een beheerder het adres nakijken."
             ),
         ),
         IndexFailureKind::BaseBranchMissing => (
             StatusCode::CONFLICT,
             format!(
-                "De basisbranch '{}' van dit traject bestaat niet meer in {repo}. Laat een \
-                 beheerder die branch herstellen of het traject op een bestaande basisbranch \
-                 zetten.",
-                target.base_branch
+                "De basisbranch '{base_branch}' van dit traject bestaat niet meer in {repo}. \
+                 Laat een beheerder die branch herstellen of het traject op een bestaande \
+                 basisbranch zetten."
             ),
         ),
         // The only 428 on this path, and only when the rejected token is the
@@ -338,5 +404,70 @@ pub fn index_failure_to_status(
                  meld het als het blijft misgaan."
             ),
         ),
+    }
+}
+
+/// How many characters a repo address or branch name may take up in a
+/// message.
+///
+/// The library pane (`indexErrorSupportingText`) does not shorten a message
+/// it finds too long — it *replaces* it with "De gegevens konden niet worden
+/// opgehaald.", the very sentence this module exists to retire. The prose is
+/// ours to keep short; the identifiers are not. GitHub allows an owner of 39
+/// characters and a repo of 100, and a base branch is typed in by hand, so
+/// two long ones spliced into the longest sentence here would push it past
+/// the 300-character cap and silently undo the whole diagnosis.
+///
+/// 64 keeps the worst case (two identifiers in the longest message) under
+/// 300 with room to spare, while leaving every realistic `owner/repo` and
+/// every generated `traject/<slug>-<id>` branch untouched.
+const ID_BUDGET: usize = 64;
+
+/// Shorten `id` to [`ID_BUDGET`] characters, eliding the middle so the parts
+/// that identify it best — the owner at the front, the distinguishing tail at
+/// the back — both survive.
+fn clamp_identifier(id: &str) -> String {
+    if id.chars().count() <= ID_BUDGET {
+        return id.to_string();
+    }
+    // One character goes to the ellipsis; the remainder splits head-heavy.
+    let keep = ID_BUDGET - 1;
+    let tail = keep / 3;
+    let head = keep - tail;
+    let chars: Vec<char> = id.chars().collect();
+    let front: String = chars[..head].iter().collect();
+    let back: String = chars[chars.len() - tail..].iter().collect();
+    format!("{front}…{back}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_identifiers_are_left_alone() {
+        assert_eq!(clamp_identifier("example-org/corpus"), "example-org/corpus");
+        assert_eq!(
+            clamp_identifier(&"a".repeat(ID_BUDGET)),
+            "a".repeat(ID_BUDGET)
+        );
+    }
+
+    #[test]
+    fn long_identifiers_keep_both_ends() {
+        let long = format!("{}/{}", "o".repeat(39), "r".repeat(100));
+        let short = clamp_identifier(&long);
+        assert_eq!(short.chars().count(), ID_BUDGET);
+        assert!(short.starts_with("oooo"), "{short}");
+        assert!(short.ends_with("rrrr"), "{short}");
+        assert!(short.contains('…'), "{short}");
+    }
+
+    #[test]
+    fn multibyte_identifiers_do_not_split_a_character() {
+        // Char-wise, not byte-wise: slicing a multi-byte name by bytes would
+        // panic instead of shortening.
+        let long = "é".repeat(ID_BUDGET * 2);
+        assert_eq!(clamp_identifier(&long).chars().count(), ID_BUDGET);
     }
 }

--- a/packages/editor-api/src/traject_index_diagnosis.rs
+++ b/packages/editor-api/src/traject_index_diagnosis.rs
@@ -1,0 +1,342 @@
+//! In-band diagnosis of a failed index scan of a traject's own repo.
+//!
+//! # Why here, and not in an admin screen
+//!
+//! From the outside these failure modes cannot be told apart: GitHub answers
+//! 404 both for "this repository does not exist" and for "it is private and
+//! your token cannot see it" (see [`RepoAccessError::RepoNotFound`]). An
+//! operator looking in from outside has no token that can resolve that
+//! ambiguity — and the more the platform leans on per-user tokens, the less
+//! it ever will.
+//!
+//! The member's own request, however, carries exactly the token that can:
+//! it is their repo. So the moment the scan fails, everything needed to
+//! classify the cause sharply is already in hand. The diagnosis therefore
+//! runs in-band, on the error path of the request that hit the problem.
+//!
+//! # Shape
+//!
+//! [`classify_index_failure`] probes GitHub and returns an
+//! [`IndexFailureKind`] — a small, stable, closed set of causes.
+//! [`index_failure_to_status`] turns that into the HTTP status and the Dutch
+//! message the user reads. Splitting the two keeps the probing testable
+//! against a mocked GitHub and keeps every user-facing sentence in one place.
+//!
+//! This is the *read* counterpart of `trajects::repo_access_error_to_status`,
+//! which does the same job for the create-traject preflight. They are
+//! deliberately separate: the write path talks to the person configuring a
+//! repo ("your token has no push access"), the read path talks to a member
+//! whose library will not open ("your traject has not been initialised yet").
+//! Same underlying `RepoAccessError`, different audience, different remedy.
+//!
+//! # Cost
+//!
+//! Nothing here runs on the happy path. The probe costs two GitHub calls
+//! (repo + base branch), a third when the traject branch has to be checked,
+//! and a fourth only when that branch turns out to be absent — and all of
+//! that exclusively after a scan has already failed.
+
+use axum::http::StatusCode;
+use regelrecht_github::{GithubClient, GithubError, RepoAccessError};
+use uuid::Uuid;
+
+/// Where the token used for the diagnosis came from — the same token the
+/// failed scan used, so the classification describes the access path that
+/// actually broke.
+///
+/// It decides whether "GitHub rejects this token" is something the *user*
+/// can fix (re-link their account) or something only an operator can.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenOrigin {
+    /// The caller's own linked GitHub account.
+    User,
+    /// A server-side token configured for this source.
+    Server,
+    /// No token at all was available.
+    Absent,
+}
+
+impl TokenOrigin {
+    /// Stable log value.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::Server => "server",
+            Self::Absent => "absent",
+        }
+    }
+}
+
+/// The writable-own source of a traject, as GitHub coordinates: enough to
+/// ask GitHub every question the classification needs, plus the two ids
+/// every log line on this path carries.
+#[derive(Debug, Clone)]
+pub struct OwnSourceTarget {
+    pub traject_id: Uuid,
+    pub source_id: String,
+    pub owner: String,
+    pub repo: String,
+    /// The traject's own branch — the one the editor commits to. Read from
+    /// the traject's stored source config, never re-derived, so the probe
+    /// asks about the branch the scan actually used.
+    pub branch: String,
+    /// The branch the traject branch is cut from.
+    pub base_branch: String,
+}
+
+impl OwnSourceTarget {
+    /// `owner/name`, the form the Refs and Activity APIs take.
+    pub fn full_repo(&self) -> String {
+        format!("{}/{}", self.owner, self.repo)
+    }
+}
+
+/// Why a traject's own index scan failed.
+///
+/// A closed set on purpose: the value is logged verbatim as the `kind`
+/// field, so a fault can be looked up by *sort* across trajects as well as
+/// by traject. Adding a variant is a deliberate act; falling into
+/// [`Unknown`](Self::Unknown) is the explicit "we could not tell" bucket
+/// rather than a silent catch-all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexFailureKind {
+    /// Repo and base branch are fine, the traject branch simply does not
+    /// exist yet and never did: a fresh traject that has not been written
+    /// to. The most common cause by far.
+    TrajectBranchMissing,
+    /// The traject branch is gone *and* the repository's activity log
+    /// records its deletion. Work that only lived there may be lost.
+    TrajectBranchGone,
+    /// The repository is not at the address the traject has stored:
+    /// renamed, transferred or deleted.
+    RepoUnavailable,
+    /// The repository is readable but the branch the traject branches from
+    /// no longer exists.
+    BaseBranchMissing,
+    /// GitHub rejects the token outright (revoked, expired, wrong).
+    LinkRevoked,
+    /// The token authenticates but does not carry enough access to this
+    /// repository.
+    InsufficientScope,
+    /// GitHub could not be reached at all (DNS, TLS, timeout, reset).
+    GithubUnreachable,
+    /// There is no GitHub credential available for this source at all, so
+    /// nothing can be probed and nothing can be read.
+    NoCredential,
+    /// Repo, base branch and traject branch all check out, or GitHub
+    /// answered something we cannot place. The scan failed for a reason
+    /// this classification does not cover.
+    Unknown,
+}
+
+impl IndexFailureKind {
+    /// Stable log value — the fixed vocabulary of the `kind` field.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::TrajectBranchMissing => "traject_branch_missing",
+            Self::TrajectBranchGone => "traject_branch_gone",
+            Self::RepoUnavailable => "repo_unavailable",
+            Self::BaseBranchMissing => "base_branch_missing",
+            Self::LinkRevoked => "link_revoked",
+            Self::InsufficientScope => "insufficient_scope",
+            Self::GithubUnreachable => "github_unreachable",
+            Self::NoCredential => "no_credential",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+impl std::fmt::Display for IndexFailureKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Classify why the scan of `target` failed, using `token` — the very token
+/// the scan used, so the probe walks the same access path.
+///
+/// Never returns an error: a diagnosis that cannot complete is itself a
+/// classification ([`IndexFailureKind::Unknown`]). The caller is already on
+/// an error path and must always be able to answer the user.
+pub async fn classify_index_failure(
+    client: &GithubClient,
+    target: &OwnSourceTarget,
+    token: Option<&str>,
+) -> IndexFailureKind {
+    let Some(token) = token else {
+        // Nothing to probe with. A private repo is unreadable either way,
+        // and probing anonymously would report a 404 as "repo gone" — a
+        // wrong answer is worse than an honest one.
+        return IndexFailureKind::NoCredential;
+    };
+
+    // Repo reachable? Base branch present? Token good enough? One helper,
+    // already used by the create-traject preflight, answers all three.
+    match client
+        .validate_repo_access(&target.owner, &target.repo, &target.base_branch, token)
+        .await
+    {
+        Ok(_) => classify_traject_branch(client, target, token).await,
+        Err(RepoAccessError::Unauthorized) => IndexFailureKind::LinkRevoked,
+        Err(RepoAccessError::RepoNotFound) => IndexFailureKind::RepoUnavailable,
+        Err(RepoAccessError::BranchNotFound) => IndexFailureKind::BaseBranchMissing,
+        // The preflight raises this both for `permissions.push == false` and
+        // for a 403 on the branch read. On the read path either means the
+        // same thing to the user: this account does not have enough access
+        // to this repo. Kept apart from `LinkRevoked` because the remedy
+        // differs — re-linking the same account changes nothing here.
+        Err(RepoAccessError::NoPushAccess) => IndexFailureKind::InsufficientScope,
+        Err(RepoAccessError::Transport(_)) => IndexFailureKind::GithubUnreachable,
+        Err(RepoAccessError::Other(_)) => IndexFailureKind::Unknown,
+    }
+}
+
+/// Repo, base branch and access all check out — so the remaining question is
+/// the traject's own branch.
+async fn classify_traject_branch(
+    client: &GithubClient,
+    target: &OwnSourceTarget,
+    token: &str,
+) -> IndexFailureKind {
+    let full_repo = target.full_repo();
+    match client
+        .branch_exists(&full_repo, &target.branch, Some(token))
+        .await
+    {
+        // Everything the classification can check is healthy; whatever broke
+        // the scan is outside this set.
+        Ok(true) => IndexFailureKind::Unknown,
+        Ok(false) => {
+            // Absent branch: never created, or created and later deleted.
+            // The Refs API cannot tell them apart (both are a 404), the
+            // activity log can.
+            match client
+                .branch_deletion_recorded(&full_repo, &target.branch, Some(token))
+                .await
+            {
+                Ok(true) => IndexFailureKind::TrajectBranchGone,
+                Ok(false) => IndexFailureKind::TrajectBranchMissing,
+                Err(e) => {
+                    // Degrade to the far more common cause rather than
+                    // claiming a data loss we could not confirm.
+                    tracing::debug!(
+                        traject = %target.traject_id,
+                        source_id = %target.source_id,
+                        error = %e,
+                        "branch-deletion probe failed; reporting the traject branch as \
+                         never created"
+                    );
+                    IndexFailureKind::TrajectBranchMissing
+                }
+            }
+        }
+        Err(GithubError::Transport(_)) => IndexFailureKind::GithubUnreachable,
+        Err(_) => IndexFailureKind::Unknown,
+    }
+}
+
+/// The HTTP status and the Dutch sentence a member reads for `kind`.
+///
+/// Every message says what is wrong *and* what to do about it, and none of
+/// them falls back on "de gegevens konden niet worden opgehaald". They stay
+/// short and carry no raw GitHub payload, so the frontend's length cap on
+/// the index-error pane can never truncate one.
+///
+/// On the statuses: **428 is reserved editor-wide for the GitHub connect
+/// flow** (`apiAuthGuard.js` redirects every 428 on `/api/*` into it), so it
+/// is used for exactly one case — a link that GitHub itself rejects, which
+/// re-linking fixes. Notably *not* for [`IndexFailureKind::InsufficientScope`]:
+/// re-linking the same account would land right back here, and a 428 would
+/// make that an endless round trip.
+pub fn index_failure_to_status(
+    kind: IndexFailureKind,
+    target: &OwnSourceTarget,
+    origin: TokenOrigin,
+) -> (StatusCode, String) {
+    let repo = target.full_repo();
+    match kind {
+        IndexFailureKind::TrajectBranchMissing => (
+            StatusCode::CONFLICT,
+            format!(
+                "Dit traject is nog niet geïnitialiseerd: de branch '{}' bestaat nog niet in \
+                 {repo}. Sla één wijziging op, dan wordt de branch aangemaakt en vult de \
+                 bibliotheek zich.",
+                target.branch
+            ),
+        ),
+        IndexFailureKind::TrajectBranchGone => (
+            StatusCode::GONE,
+            format!(
+                "De branch '{}' van dit traject is verwijderd uit {repo}. Werk dat alleen daar \
+                 stond, is mogelijk verloren. Laat een beheerder de branch herstellen voordat \
+                 je verder werkt.",
+                target.branch
+            ),
+        ),
+        IndexFailureKind::RepoUnavailable => (
+            StatusCode::NOT_FOUND,
+            format!(
+                "De repo {repo} staat niet meer op het adres dat in dit traject is vastgelegd: \
+                 hernoemd, overgedragen of verwijderd. Laat een beheerder het traject naar het \
+                 juiste adres verwijzen."
+            ),
+        ),
+        IndexFailureKind::BaseBranchMissing => (
+            StatusCode::CONFLICT,
+            format!(
+                "De basisbranch '{}' van dit traject bestaat niet meer in {repo}. Laat een \
+                 beheerder die branch herstellen of het traject op een bestaande basisbranch \
+                 zetten.",
+                target.base_branch
+            ),
+        ),
+        // The only 428 on this path, and only when the rejected token is the
+        // caller's own: then the connect flow is the fix. A rejected server
+        // token is nothing the member can re-link away.
+        IndexFailureKind::LinkRevoked => match origin {
+            TokenOrigin::User => (
+                StatusCode::PRECONDITION_REQUIRED,
+                format!(
+                    "Je GitHub-koppeling wordt door GitHub geweigerd, waardoor {repo} niet \
+                     gelezen kan worden. Koppel je GitHub-account opnieuw."
+                ),
+            ),
+            TokenOrigin::Server | TokenOrigin::Absent => (
+                StatusCode::BAD_GATEWAY,
+                format!(
+                    "Het GitHub-token van de beheerder wordt geweigerd, waardoor {repo} niet \
+                     gelezen kan worden. Meld dit bij je beheerder."
+                ),
+            ),
+        },
+        IndexFailureKind::InsufficientScope => (
+            StatusCode::FORBIDDEN,
+            format!(
+                "Je GitHub-toegang tot {repo} is niet toereikend voor dit traject. Vraag de \
+                 eigenaar van de repo om toegang, of koppel het GitHub-account dat die toegang \
+                 wel heeft."
+            ),
+        ),
+        IndexFailureKind::GithubUnreachable => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "GitHub is nu niet bereikbaar, waardoor de bibliotheek van dit traject niet geladen \
+             kan worden. Probeer het over een paar minuten opnieuw."
+                .to_string(),
+        ),
+        IndexFailureKind::NoCredential => (
+            StatusCode::BAD_GATEWAY,
+            format!(
+                "Er is geen GitHub-toegang beschikbaar om {repo} te lezen. Koppel je \
+                 GitHub-account, of laat een beheerder een token voor deze repo instellen."
+            ),
+        ),
+        IndexFailureKind::Unknown => (
+            StatusCode::BAD_GATEWAY,
+            format!(
+                "De bibliotheek van dit traject kon niet worden gelezen en de oorzaak is niet \
+                 vast te stellen; {repo} gaf geen duidelijk antwoord. Probeer het opnieuw en \
+                 meld het als het blijft misgaan."
+            ),
+        ),
+    }
+}

--- a/packages/editor-api/tests/traject_index_diagnosis_test.rs
+++ b/packages/editor-api/tests/traject_index_diagnosis_test.rs
@@ -100,7 +100,12 @@ async fn mock_trajectbranch(server: &MockServer, status: u16) {
 /// `GET /repos/{owner}/{repo}/activity` — het verwijderlogboek.
 async fn mock_activity(server: &MockServer, deletions: usize) {
     let body: Vec<serde_json::Value> = (0..deletions)
-        .map(|_| serde_json::json!({ "activity_type": "branch_deletion" }))
+        .map(|_| {
+            serde_json::json!({
+                "activity_type": "branch_deletion",
+                "ref": format!("refs/heads/{BRANCH}"),
+            })
+        })
         .collect();
     Mock::given(method("GET"))
         .and(path(format!("/repos/{OWNER}/{REPO}/activity")))
@@ -194,16 +199,16 @@ async fn verdwenen_basisbranch_noemt_de_basisbranch() {
     assert!(melding.contains(BASE), "{melding}");
 }
 
-/// Situatie 5: GitHub weigert het token. Met het eigen token van de
-/// gebruiker is de koppel-flow (428) het antwoord — dat is de enige
-/// situatie op dit pad die 428 mag geven. Hetzelfde oordeel over het token
-/// van de beheerder stuurt de gebruiker níet die flow in: daar valt voor
-/// hem niets te koppelen.
+/// Situatie 5: GitHub weigert het token. Een ingetrokken token wordt op
+/// élke call geweigerd — vandaar de 401 op de hele mock. Met het eigen
+/// token van de gebruiker is de koppel-flow (428) het antwoord; dat is de
+/// enige situatie op dit pad die 428 mag geven. Hetzelfde oordeel over het
+/// token van de beheerder stuurt de gebruiker níet die flow in: daar valt
+/// voor hem niets te koppelen.
 #[tokio::test]
 async fn geweigerd_token_stuurt_alleen_de_eigen_koppeling_naar_de_koppel_flow() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
-        .and(path(format!("/repos/{OWNER}/{REPO}")))
         .respond_with(ResponseTemplate::new(401))
         .mount(&server)
         .await;
@@ -238,6 +243,64 @@ async fn te_smalle_toegang_meldt_rechten_en_vermijdt_de_koppel_flow() {
     assert_eq!(status, StatusCode::FORBIDDEN);
     assert_ne!(status, StatusCode::PRECONDITION_REQUIRED);
     assert!(melding.contains("niet toereikend"), "{melding}");
+}
+
+/// GitHub gebruikt 403 óók voor een uitgeputte rate limit, een organisatie
+/// die SSO afdwingt en een IP-allowlist die de call blokkeert. Geen van die
+/// drie is een ontbrekende of verlopen koppeling, en opnieuw koppelen lost
+/// er geen één op — een 428 zou de gebruiker via `apiAuthGuard.js` telkens
+/// opnieuw de koppel-flow in sturen, met exact dezelfde 403 als resultaat.
+#[tokio::test]
+async fn geweigerde_repo_met_403_stuurt_de_gebruiker_niet_de_koppel_flow_in() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/{OWNER}/{REPO}")))
+        .respond_with(ResponseTemplate::new(403))
+        .mount(&server)
+        .await;
+    // De bevestigingslezing krijgt hetzelfde antwoord: het token wordt niet
+    // geweigerd, deze repo blijft dicht.
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/{OWNER}/{REPO}/git/ref/heads/{BASE}")))
+        .respond_with(ResponseTemplate::new(403))
+        .mount(&server)
+        .await;
+
+    let (kind, status, melding) = classificeer(&server, TokenOrigin::User).await;
+
+    assert_eq!(kind, IndexFailureKind::InsufficientScope);
+    assert_ne!(
+        status,
+        StatusCode::PRECONDITION_REQUIRED,
+        "een 403 van GitHub mag de koppel-flow niet triggeren, got: {melding}"
+    );
+    assert_eq!(status, StatusCode::FORBIDDEN);
+}
+
+/// Een opgebruikte rate limit komt als 403 binnen en is noch een rechten-
+/// noch een koppelprobleem: hij lost zichzelf op. De melding moet dus
+/// "probeer het straks nog eens" zijn, niet "vraag om toegang".
+#[tokio::test]
+async fn opgebruikte_rate_limit_meldt_probeer_het_later() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/{OWNER}/{REPO}")))
+        .respond_with(ResponseTemplate::new(403))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/{OWNER}/{REPO}/git/ref/heads/{BASE}")))
+        .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+            "message": "API rate limit exceeded for user ID 1.",
+        })))
+        .mount(&server)
+        .await;
+
+    let (kind, status, melding) = classificeer(&server, TokenOrigin::User).await;
+
+    assert_eq!(kind, IndexFailureKind::GithubUnreachable);
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert!(melding.contains("paar minuten"), "{melding}");
 }
 
 /// Restcategorie: repo, basisbranch én traject-branch zijn alle drie in
@@ -301,20 +364,22 @@ async fn onbereikbaar_github_meldt_probeer_het_later() {
 /// kapt alles boven de 300 tekens weg en negeert alles wat op HTML of JSON
 /// lijkt. Geldt voor élke classificatie, en geen enkele valt terug op de
 /// generieke tekst of lijkt op een andere.
+const ALLE_SITUATIES: [IndexFailureKind; 9] = [
+    IndexFailureKind::TrajectBranchMissing,
+    IndexFailureKind::TrajectBranchGone,
+    IndexFailureKind::RepoUnavailable,
+    IndexFailureKind::BaseBranchMissing,
+    IndexFailureKind::LinkRevoked,
+    IndexFailureKind::InsufficientScope,
+    IndexFailureKind::GithubUnreachable,
+    IndexFailureKind::NoCredential,
+    IndexFailureKind::Unknown,
+];
+
 #[test]
 fn elke_melding_overleeft_de_grens_van_de_bibliotheek() {
     let target = target();
-    let alle = [
-        IndexFailureKind::TrajectBranchMissing,
-        IndexFailureKind::TrajectBranchGone,
-        IndexFailureKind::RepoUnavailable,
-        IndexFailureKind::BaseBranchMissing,
-        IndexFailureKind::LinkRevoked,
-        IndexFailureKind::InsufficientScope,
-        IndexFailureKind::GithubUnreachable,
-        IndexFailureKind::NoCredential,
-        IndexFailureKind::Unknown,
-    ];
+    let alle = ALLE_SITUATIES;
 
     let mut meldingen = Vec::new();
     let mut namen = Vec::new();
@@ -355,4 +420,35 @@ fn elke_melding_overleeft_de_grens_van_de_bibliotheek() {
         namen.len(),
         "twee situaties delen een logwaarde"
     );
+}
+
+/// Dezelfde grens, maar met de langste namen die GitHub toestaat: een
+/// eigenaar van 39 tekens, een repo van 100 en een basisbranch die (anders
+/// dan de traject-branch) door een mens is ingetypt. Een lange repo-naam mag
+/// de melding niet over de 300 duwen — dan kapt de bibliotheek hem niet af
+/// maar vervangt hem integraal door precies de generieke tekst die deze
+/// classificatie moest wegnemen.
+#[test]
+fn zelfs_de_langst_mogelijke_repo_naam_kapt_de_melding_niet_weg() {
+    let target = OwnSourceTarget {
+        traject_id: Uuid::nil(),
+        source_id: "traject-eigen".to_string(),
+        owner: "o".repeat(39),
+        repo: "r".repeat(100),
+        // De traject-branch is afgeleid (slug van 32 + korte id), de
+        // basisbranch komt uit een invoerveld; beide ruim genomen.
+        branch: format!("traject/{}-1a2b3c4d", "s".repeat(32)),
+        base_branch: "b".repeat(120),
+    };
+
+    for kind in ALLE_SITUATIES {
+        for origin in [TokenOrigin::User, TokenOrigin::Server, TokenOrigin::Absent] {
+            let (_, melding) = index_failure_to_status(kind, &target, origin);
+            assert!(
+                melding.chars().count() <= MELDING_MAX,
+                "{kind} is {} tekens en valt daarmee terug op '{GENERIEKE_TERUGVAL}': {melding}",
+                melding.chars().count()
+            );
+        }
+    }
 }

--- a/packages/editor-api/tests/traject_index_diagnosis_test.rs
+++ b/packages/editor-api/tests/traject_index_diagnosis_test.rs
@@ -243,6 +243,17 @@ async fn te_smalle_toegang_meldt_rechten_en_vermijdt_de_koppel_flow() {
     assert_eq!(status, StatusCode::FORBIDDEN);
     assert_ne!(status, StatusCode::PRECONDITION_REQUIRED);
     assert!(melding.contains("niet toereikend"), "{melding}");
+
+    // Is het het token van de beheerder dat te smal is, dan valt er voor het
+    // lid niets te koppelen — een leesbron met een eigen servertoken kijkt
+    // sowieso nooit naar een persoonlijke koppeling.
+    let (status, melding) = index_failure_to_status(kind, &target(), TokenOrigin::Server);
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert!(melding.contains("beheerder"), "{melding}");
+    assert!(
+        !melding.contains("Koppel je GitHub-account"),
+        "een servertoken-probleem mag niet naar de koppel-flow wijzen: {melding}"
+    );
 }
 
 /// GitHub gebruikt 403 óók voor een uitgeputte rate limit, een organisatie

--- a/packages/editor-api/tests/traject_index_diagnosis_test.rs
+++ b/packages/editor-api/tests/traject_index_diagnosis_test.rs
@@ -314,6 +314,35 @@ async fn opgebruikte_rate_limit_meldt_probeer_het_later() {
     assert!(melding.contains("paar minuten"), "{melding}");
 }
 
+/// Dezelfde rate limit kan ook één call later toeslaan: de repo-lookup gaat
+/// nog goed, de lezing van de basisbranch krijgt de 403. De preflight noemt
+/// dat "geen schrijftoegang" — als dat blindelings zou worden overgenomen,
+/// kreeg het lid "vraag toegang tot de repo" voor iets wat vanzelf overgaat.
+#[tokio::test]
+async fn rate_limit_op_de_basisbranch_meldt_ook_probeer_het_later() {
+    let server = MockServer::start().await;
+    mock_repo_gezond(&server).await;
+    let throttled = ResponseTemplate::new(403).set_body_json(serde_json::json!({
+        "message": "You have exceeded a secondary rate limit.",
+    }));
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/{OWNER}/{REPO}/branches/{BASE}")))
+        .respond_with(throttled.clone())
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/{OWNER}/{REPO}/git/ref/heads/{BASE}")))
+        .respond_with(throttled)
+        .mount(&server)
+        .await;
+
+    let (kind, status, melding) = classificeer(&server, TokenOrigin::User).await;
+
+    assert_eq!(kind, IndexFailureKind::GithubUnreachable);
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert!(melding.contains("paar minuten"), "{melding}");
+}
+
 /// Restcategorie: repo, basisbranch én traject-branch zijn alle drie in
 /// orde, dus de scan viel om op iets wat deze classificatie niet dekt. Dat
 /// wordt expliciet "onbekend" genoemd — met een eigen melding, niet met de

--- a/packages/editor-api/tests/traject_index_diagnosis_test.rs
+++ b/packages/editor-api/tests/traject_index_diagnosis_test.rs
@@ -1,0 +1,358 @@
+//! Eén test per oorzaak van een mislukte index-scan van de traject-eigen
+//! source: geeft de classificatie het juiste antwoord, en leest de melding
+//! die eruit komt als iets waar een gebruiker wat mee kan?
+//!
+//! GitHub wordt gespeeld door wiremock; de client wijst via `with_base_url`
+//! naar die mock. Geen database, geen netwerk naar buiten — de classificatie
+//! is bewust een losse functie zodat precies dit mogelijk is.
+//!
+//! Repo-coördinaten zijn verzonnen placeholders (`example-org/...`): dit is
+//! een publieke repo, dus er staat nergens een echt adres in.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use pretty_assertions::assert_eq;
+use uuid::Uuid;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use axum::http::StatusCode;
+use regelrecht_editor_api::traject_index_diagnosis::{
+    classify_index_failure, index_failure_to_status, IndexFailureKind, OwnSourceTarget, TokenOrigin,
+};
+use regelrecht_github::GithubClient;
+
+const OWNER: &str = "example-org";
+const REPO: &str = "regelrecht-corpus-example";
+const BRANCH: &str = "traject/tarieven-1a2b3c4d";
+const BASE: &str = "main";
+const TOKEN: &str = "gh-token-uit-de-test";
+
+/// De melding die de bibliotheek toont als er niets beters is. Geen enkele
+/// classificatie mag hierop terugvallen.
+const GENERIEKE_TERUGVAL: &str = "De gegevens konden niet worden opgehaald.";
+
+/// Bovengrens die de bibliotheek hanteert voordat ze een backend-melding
+/// als onbruikbaar wegkapt.
+const MELDING_MAX: usize = 300;
+
+fn target() -> OwnSourceTarget {
+    OwnSourceTarget {
+        traject_id: Uuid::nil(),
+        source_id: "traject-eigen".to_string(),
+        owner: OWNER.to_string(),
+        repo: REPO.to_string(),
+        branch: BRANCH.to_string(),
+        base_branch: BASE.to_string(),
+    }
+}
+
+fn client_for(server: &MockServer) -> GithubClient {
+    GithubClient::new().unwrap().with_base_url(server.uri())
+}
+
+/// `GET /repos/{owner}/{repo}` — repo bestaat en het token mag pushen.
+async fn mock_repo_gezond(server: &MockServer) {
+    mock_repo(server, true).await;
+}
+
+async fn mock_repo(server: &MockServer, push: bool) {
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/{OWNER}/{REPO}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "default_branch": BASE,
+            "private": true,
+            "permissions": { "push": push },
+        })))
+        .mount(server)
+        .await;
+}
+
+/// `GET /repos/{owner}/{repo}/branches/{base}` — de basisbranch bestaat.
+async fn mock_basisbranch_gezond(server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/{OWNER}/{REPO}/branches/{BASE}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "name": BASE,
+        })))
+        .mount(server)
+        .await;
+}
+
+/// `GET /repos/{owner}/{repo}/git/ref/heads/{branch}` — de traject-branch.
+async fn mock_trajectbranch(server: &MockServer, status: u16) {
+    let template = if status == 200 {
+        ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "object": { "sha": "0".repeat(40) },
+        }))
+    } else {
+        ResponseTemplate::new(status)
+    };
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/repos/{OWNER}/{REPO}/git/ref/heads/{BRANCH}"
+        )))
+        .respond_with(template)
+        .mount(server)
+        .await;
+}
+
+/// `GET /repos/{owner}/{repo}/activity` — het verwijderlogboek.
+async fn mock_activity(server: &MockServer, deletions: usize) {
+    let body: Vec<serde_json::Value> = (0..deletions)
+        .map(|_| serde_json::json!({ "activity_type": "branch_deletion" }))
+        .collect();
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/{OWNER}/{REPO}/activity")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(server)
+        .await;
+}
+
+/// Classificeer met een gezonde repo + basisbranch als vertrekpunt.
+async fn classificeer(
+    server: &MockServer,
+    origin: TokenOrigin,
+) -> (IndexFailureKind, StatusCode, String) {
+    let target = target();
+    let kind = classify_index_failure(&client_for(server), &target, Some(TOKEN)).await;
+    let (status, melding) = index_failure_to_status(kind, &target, origin);
+    (kind, status, melding)
+}
+
+/// Situatie 1: vers traject, de branch is nooit gemint. De melder uit het
+/// oorspronkelijke bugrapport zat hier — en kreeg toen een kale 502.
+#[tokio::test]
+async fn verse_traject_meldt_dat_het_nog_niet_geinitialiseerd_is() {
+    let server = MockServer::start().await;
+    mock_repo_gezond(&server).await;
+    mock_basisbranch_gezond(&server).await;
+    mock_trajectbranch(&server, 404).await;
+    mock_activity(&server, 0).await;
+
+    let (kind, status, melding) = classificeer(&server, TokenOrigin::User).await;
+
+    assert_eq!(kind, IndexFailureKind::TrajectBranchMissing);
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert!(melding.contains("nog niet geïnitialiseerd"), "{melding}");
+    assert!(melding.contains(BRANCH), "{melding}");
+}
+
+/// Situatie 2: de branch heeft bestaan en is verwijderd. Zelfde 404 op de
+/// Refs API als situatie 1 — het activiteitenlogboek maakt het verschil, en
+/// alleen hier mag er over mogelijk werkverlies gepraat worden.
+#[tokio::test]
+async fn verwijderde_trajectbranch_waarschuwt_voor_werkverlies() {
+    let server = MockServer::start().await;
+    mock_repo_gezond(&server).await;
+    mock_basisbranch_gezond(&server).await;
+    mock_trajectbranch(&server, 404).await;
+    mock_activity(&server, 1).await;
+
+    let (kind, status, melding) = classificeer(&server, TokenOrigin::User).await;
+
+    assert_eq!(kind, IndexFailureKind::TrajectBranchGone);
+    assert_eq!(status, StatusCode::GONE);
+    assert!(melding.contains("verwijderd"), "{melding}");
+    assert!(melding.contains("mogelijk verloren"), "{melding}");
+}
+
+/// Situatie 3: de repo staat niet meer op het vastgelegde adres.
+#[tokio::test]
+async fn verplaatste_repo_meldt_het_adres_uit_het_traject() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/{OWNER}/{REPO}")))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+
+    let (kind, status, melding) = classificeer(&server, TokenOrigin::User).await;
+
+    assert_eq!(kind, IndexFailureKind::RepoUnavailable);
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert!(melding.contains(&format!("{OWNER}/{REPO}")), "{melding}");
+    assert!(melding.contains("hernoemd"), "{melding}");
+}
+
+/// Situatie 4: de basisbranch waar het traject vanaf takt bestaat niet meer.
+#[tokio::test]
+async fn verdwenen_basisbranch_noemt_de_basisbranch() {
+    let server = MockServer::start().await;
+    mock_repo_gezond(&server).await;
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/{OWNER}/{REPO}/branches/{BASE}")))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+
+    let (kind, status, melding) = classificeer(&server, TokenOrigin::User).await;
+
+    assert_eq!(kind, IndexFailureKind::BaseBranchMissing);
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert!(melding.contains("basisbranch"), "{melding}");
+    assert!(melding.contains(BASE), "{melding}");
+}
+
+/// Situatie 5: GitHub weigert het token. Met het eigen token van de
+/// gebruiker is de koppel-flow (428) het antwoord — dat is de enige
+/// situatie op dit pad die 428 mag geven. Hetzelfde oordeel over het token
+/// van de beheerder stuurt de gebruiker níet die flow in: daar valt voor
+/// hem niets te koppelen.
+#[tokio::test]
+async fn geweigerd_token_stuurt_alleen_de_eigen_koppeling_naar_de_koppel_flow() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/{OWNER}/{REPO}")))
+        .respond_with(ResponseTemplate::new(401))
+        .mount(&server)
+        .await;
+
+    let (kind, status, melding) = classificeer(&server, TokenOrigin::User).await;
+    assert_eq!(kind, IndexFailureKind::LinkRevoked);
+    assert_eq!(status, StatusCode::PRECONDITION_REQUIRED);
+    assert!(
+        melding.contains("Koppel je GitHub-account opnieuw"),
+        "{melding}"
+    );
+    // Het token zelf hoort nergens in de melding te staan, ook niet een stuk.
+    assert!(!melding.contains(TOKEN), "{melding}");
+    assert!(!melding.contains(&TOKEN[..6]), "{melding}");
+
+    let (status, melding) = index_failure_to_status(kind, &target(), TokenOrigin::Server);
+    assert_eq!(status, StatusCode::BAD_GATEWAY);
+    assert!(melding.contains("beheerder"), "{melding}");
+}
+
+/// Situatie 5, andere smaak: het token is geldig maar de toegang is te
+/// smal. Opnieuw koppelen lost dat niet op, dus juist géén 428 — dat zou
+/// de gebruiker in een rondje sturen.
+#[tokio::test]
+async fn te_smalle_toegang_meldt_rechten_en_vermijdt_de_koppel_flow() {
+    let server = MockServer::start().await;
+    mock_repo(&server, false).await;
+
+    let (kind, status, melding) = classificeer(&server, TokenOrigin::User).await;
+
+    assert_eq!(kind, IndexFailureKind::InsufficientScope);
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_ne!(status, StatusCode::PRECONDITION_REQUIRED);
+    assert!(melding.contains("niet toereikend"), "{melding}");
+}
+
+/// Restcategorie: repo, basisbranch én traject-branch zijn alle drie in
+/// orde, dus de scan viel om op iets wat deze classificatie niet dekt. Dat
+/// wordt expliciet "onbekend" genoemd — met een eigen melding, niet met de
+/// generieke terugval.
+#[tokio::test]
+async fn gezonde_repo_met_gevallen_scan_wordt_expliciet_onbekend() {
+    let server = MockServer::start().await;
+    mock_repo_gezond(&server).await;
+    mock_basisbranch_gezond(&server).await;
+    mock_trajectbranch(&server, 200).await;
+
+    let (kind, status, melding) = classificeer(&server, TokenOrigin::User).await;
+
+    assert_eq!(kind, IndexFailureKind::Unknown);
+    assert_eq!(status, StatusCode::BAD_GATEWAY);
+    assert_ne!(melding, GENERIEKE_TERUGVAL);
+    assert!(melding.contains("niet vast te stellen"), "{melding}");
+}
+
+/// Zonder token valt er niets te vragen — en er wordt dan ook niets
+/// gevraagd: anoniem proberen zou een 404 opleveren en "repo weg" melden,
+/// wat pertinent onwaar is voor een privé-repo.
+#[tokio::test]
+async fn zonder_token_wordt_github_niet_bevraagd() {
+    let server = MockServer::start().await;
+    let target = target();
+
+    let kind = classify_index_failure(&client_for(&server), &target, None).await;
+
+    assert_eq!(kind, IndexFailureKind::NoCredential);
+    assert!(
+        server.received_requests().await.unwrap().is_empty(),
+        "de classificatie mag zonder token geen enkele GitHub-call doen"
+    );
+    let (status, melding) = index_failure_to_status(kind, &target, TokenOrigin::Absent);
+    assert_eq!(status, StatusCode::BAD_GATEWAY);
+    assert!(melding.contains("geen GitHub-toegang"), "{melding}");
+}
+
+/// GitHub helemaal niet te bereiken: geen diagnose, wel een eerlijk
+/// "probeer het straks nog eens" in plaats van een verwijt aan de repo.
+#[tokio::test]
+async fn onbereikbaar_github_meldt_probeer_het_later() {
+    // Poort 1 op loopback: niets luistert, de verbinding wordt geweigerd.
+    let client = GithubClient::new()
+        .unwrap()
+        .with_base_url("http://127.0.0.1:1");
+    let target = target();
+
+    let kind = classify_index_failure(&client, &target, Some(TOKEN)).await;
+    let (status, melding) = index_failure_to_status(kind, &target, TokenOrigin::User);
+
+    assert_eq!(kind, IndexFailureKind::GithubUnreachable);
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert!(melding.contains("niet bereikbaar"), "{melding}");
+}
+
+/// De melding moet ongeschonden bij de gebruiker aankomen: de bibliotheek
+/// kapt alles boven de 300 tekens weg en negeert alles wat op HTML of JSON
+/// lijkt. Geldt voor élke classificatie, en geen enkele valt terug op de
+/// generieke tekst of lijkt op een andere.
+#[test]
+fn elke_melding_overleeft_de_grens_van_de_bibliotheek() {
+    let target = target();
+    let alle = [
+        IndexFailureKind::TrajectBranchMissing,
+        IndexFailureKind::TrajectBranchGone,
+        IndexFailureKind::RepoUnavailable,
+        IndexFailureKind::BaseBranchMissing,
+        IndexFailureKind::LinkRevoked,
+        IndexFailureKind::InsufficientScope,
+        IndexFailureKind::GithubUnreachable,
+        IndexFailureKind::NoCredential,
+        IndexFailureKind::Unknown,
+    ];
+
+    let mut meldingen = Vec::new();
+    let mut namen = Vec::new();
+    for kind in alle {
+        for origin in [TokenOrigin::User, TokenOrigin::Server, TokenOrigin::Absent] {
+            let (status, melding) = index_failure_to_status(kind, &target, origin);
+            assert!(
+                melding.chars().count() <= MELDING_MAX,
+                "{kind} is {} tekens: {melding}",
+                melding.chars().count()
+            );
+            assert!(!melding.starts_with('<'), "{kind}: {melding}");
+            assert!(!melding.starts_with('{'), "{kind}: {melding}");
+            assert_ne!(
+                melding, GENERIEKE_TERUGVAL,
+                "{kind} valt terug op de generieke tekst"
+            );
+            // 428 blijft van de koppel-flow: alleen een geweigerde eigen
+            // koppeling mag hem geven.
+            if status == StatusCode::PRECONDITION_REQUIRED {
+                assert_eq!(kind, IndexFailureKind::LinkRevoked);
+                assert_eq!(origin, TokenOrigin::User);
+            }
+        }
+        meldingen.push(index_failure_to_status(kind, &target, TokenOrigin::User).1);
+        namen.push(kind.as_str());
+    }
+
+    let unieke_meldingen: std::collections::HashSet<_> = meldingen.iter().collect();
+    assert_eq!(
+        unieke_meldingen.len(),
+        meldingen.len(),
+        "twee situaties delen een melding"
+    );
+    let unieke_namen: std::collections::HashSet<_> = namen.iter().collect();
+    assert_eq!(
+        unieke_namen.len(),
+        namen.len(),
+        "twee situaties delen een logwaarde"
+    );
+}

--- a/packages/editor-api/tests/traject_index_user_token_test.rs
+++ b/packages/editor-api/tests/traject_index_user_token_test.rs
@@ -21,8 +21,10 @@
 //!    wordt de kapotte (token-loos gescande) snapshot synchroon herbouwd
 //!    en is de bibliotheek weer gezond.
 //! 4. **Gekoppeld maar geen toegang.** Faalt de scan ook mét user-token,
-//!    dan is de fout een expliciete 502 (met de scan-fout), geen 428 en
-//!    geen stille fallback. `index_error` blijft zichtbaar op `/sources`.
+//!    dan faalt de bibliotheek luid en geclassificeerd — hier: GitHub kent
+//!    de repo niet op dat adres, dus 404 met een melding die het adres
+//!    noemt. Geen 428 (opnieuw koppelen lost dit niet op) en geen stille
+//!    fallback; `index_error` blijft zichtbaar op `/sources`.
 //!
 //! GitHub wordt gespeeld door wiremock via de proces-brede
 //! `GITHUB_API_BASE`-seam — daarom staan alle scenario's in ÉÉN test.
@@ -425,9 +427,11 @@ async fn traject_index_scans_with_user_token_and_fails_loud_without_any_token() 
 
     // ------------------------------------------------------------------
     // Scenario 4: gekoppeld maar géén toegang — de scan faalt ook mét
-    // user-token (repo zonder Trees-mock → altijd 404). Expliciete 502
-    // met de scan-fout, geen 428 (koppelen lost dit niet op) en geen
-    // stille seed-fallback.
+    // user-token (repo zonder Trees-mock → altijd 404). De diagnose vraagt
+    // het na met datzelfde token en krijgt op de repo-lookup óók een 404:
+    // de repo staat niet op dit adres. Dus 404 met een melding die het
+    // adres noemt — geen 428 (koppelen lost dit niet op) en geen stille
+    // seed-fallback.
     // ------------------------------------------------------------------
     let traject_b = seeded_traject(
         &db.pool,
@@ -451,14 +455,20 @@ async fn traject_index_scans_with_user_token_and_fails_loud_without_any_token() 
     .expect_err("scan-fout mét token → expliciete fout, geen stille fallback");
     assert_eq!(
         err.0,
-        StatusCode::BAD_GATEWAY,
-        "gekoppeld-maar-geen-toegang is geen koppel-probleem: 502, got: {}: {}",
+        StatusCode::NOT_FOUND,
+        "gekoppeld-maar-geen-toegang is geen koppel-probleem, maar wél een \
+         geclassificeerde fout, got: {}: {}",
         err.0,
         err.1
     );
     assert!(
-        err.1.contains("404"),
-        "de fout moet de onderliggende scan-fout dragen, got: {}",
+        err.1.contains("example-org/example-no-access-repo"),
+        "de melding moet het adres noemen waar de repo niet (meer) staat, got: {}",
+        err.1
+    );
+    assert!(
+        !err.1.contains("De gegevens konden niet worden opgehaald"),
+        "geen enkele situatie mag terugvallen op de generieke melding, got: {}",
         err.1
     );
 

--- a/packages/editor-api/tests/traject_own_index_test.rs
+++ b/packages/editor-api/tests/traject_own_index_test.rs
@@ -12,9 +12,10 @@
 //!    unauthenticated Trees-API geeft 404, en hier faalt ook het
 //!    user-token (ongemockt trees-pad). Sinds de user-token-fallback op de
 //!    scan valt de bibliotheek dan niet langer stil terug op de seed: de
-//!    listing faalt luid (428 zonder gekoppeld token, 502 mét token dat
-//!    de repo alsnog niet kan lezen). `GET .../sources` blijft de diagnose
-//!    dragen: de writable-own toont `law_count: 0` mét een `index_error`.
+//!    listing faalt luid (428 zonder gekoppeld token; mét token dat de repo
+//!    alsnog niet kan lezen een geclassificeerde 404 die het repo-adres
+//!    noemt). `GET .../sources` blijft de diagnose dragen: de writable-own
+//!    toont `law_count: 0` mét een `index_error`.
 //!    (De volledige user-token-scanflow — succes via het token, heling na
 //!    een kapotte snapshot — staat in `traject_index_user_token_test.rs`.)
 //! 2. **Happy path van #952.** Zodra de scan de traject-repo wél kan lezen
@@ -349,7 +350,9 @@ async fn traject_index_shows_promoted_law_and_surfaces_failed_own_scans() {
 
     // …en een request mét gekoppeld token (dat deze repo alsnog niet kan
     // lezen — het trees-pad is ongemockt, dus ook met token 404) faalt
-    // expliciet met een 502 die de scan-fout draagt.
+    // luid én geclassificeerd: de diagnose vraagt de repo-lookup na met
+    // hetzelfde token, krijgt óók 404, en meldt dat de repo niet op dit
+    // adres staat.
     let err = list_traject_corpus_laws(
         State(state.clone()),
         Extension(account.clone()),
@@ -362,9 +365,14 @@ async fn traject_index_shows_promoted_law_and_surfaces_failed_own_scans() {
     .expect_err("scan-fout mét token → expliciete fout, geen stille fallback");
     assert_eq!(
         err.0,
-        axum::http::StatusCode::BAD_GATEWAY,
+        axum::http::StatusCode::NOT_FOUND,
         "got: {}: {}",
         err.0,
+        err.1
+    );
+    assert!(
+        err.1.contains(repo_a),
+        "de melding moet het adres noemen waar de repo niet (meer) staat, got: {}",
         err.1
     );
 

--- a/packages/github/src/activity.rs
+++ b/packages/github/src/activity.rs
@@ -15,7 +15,7 @@ use serde::Deserialize;
 use crate::client::GithubClient;
 use crate::error::{GithubError, Result};
 
-/// The one field of an activity entry we care about. GitHub also returns
+/// The two fields of an activity entry we care about. GitHub also returns
 /// the actor, the before/after shas and a timestamp — deliberately not
 /// deserialised: the actor is a person, and this crate's callers log the
 /// classification, not who caused it.
@@ -23,6 +23,12 @@ use crate::error::{GithubError, Result};
 struct ActivityEntry {
     #[serde(default)]
     activity_type: String,
+    /// The full ref the entry is about (`refs/heads/…`). Absent on a host
+    /// that does not send it, which then matches nothing — the safe
+    /// direction: a missed deletion degrades to "never created", whereas a
+    /// wrongly claimed one warns about work loss that never happened.
+    #[serde(rename = "ref", default)]
+    git_ref: String,
 }
 
 /// The `activity_type` value that marks a branch deletion.
@@ -48,6 +54,7 @@ impl GithubClient {
         branch: &str,
         token: Option<&str>,
     ) -> Result<bool> {
+        let wanted_ref = format!("refs/heads/{branch}");
         // The branch is percent-encoded, so the `/` in a `traject/<slug>`
         // name reaches GitHub as part of the ref rather than splitting the
         // query. One entry is enough: the question is "any deletion at all".
@@ -55,7 +62,7 @@ impl GithubClient {
             "{}/repos/{}/activity?ref={}&activity_type={}&per_page=1",
             self.api_base,
             repo,
-            crate::repo_access::percent_encode_path_segment(&format!("refs/heads/{branch}")),
+            crate::repo_access::percent_encode_path_segment(&wanted_ref),
             BRANCH_DELETION,
         );
         let headers = self.default_headers(token)?;
@@ -83,10 +90,13 @@ impl GithubClient {
             .json()
             .await
             .map_err(|e| GithubError::Decode(format!("parse activity response: {e}")))?;
-        // Filter rather than trust the server-side `activity_type` filter:
-        // an enterprise host that ignores the parameter would otherwise turn
-        // "this branch was pushed to" into "this branch was deleted".
-        Ok(entries.iter().any(|e| e.activity_type == BRANCH_DELETION))
+        // Filter rather than trust the server-side `activity_type` and `ref`
+        // filters: a host that ignores either parameter would otherwise turn
+        // "this branch was pushed to" — or "some other branch was deleted" —
+        // into "this branch was deleted".
+        Ok(entries
+            .iter()
+            .any(|e| e.activity_type == BRANCH_DELETION && e.git_ref == wanted_ref))
     }
 }
 
@@ -153,6 +163,27 @@ mod tests {
 
         assert!(!client_for(&server)
             .branch_deletion_recorded("acme/foo", "main", Some("t"))
+            .await
+            .unwrap());
+    }
+
+    #[tokio::test]
+    async fn a_deletion_of_another_branch_is_not_ours() {
+        // Same defence as the `activity_type` filter, and this one matters
+        // more: a host that ignores `ref` would answer with whatever branch
+        // was deleted last, and the caller would tell a member their work
+        // may be lost over someone else's branch.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/acme/foo/activity"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                { "activity_type": "branch_deletion", "ref": "refs/heads/een-andere-branch" }
+            ])))
+            .mount(&server)
+            .await;
+
+        assert!(!client_for(&server)
+            .branch_deletion_recorded("acme/foo", "traject/tarief-1a2b", Some("t"))
             .await
             .unwrap());
     }

--- a/packages/github/src/activity.rs
+++ b/packages/github/src/activity.rs
@@ -1,0 +1,175 @@
+//! Repository Activity API: the audit trail GitHub keeps of ref changes
+//! (pushes, force pushes, branch creations and deletions) on a repository.
+//!
+//! One question is asked of it, and only on an error path: *was this branch
+//! ever deleted?* That is the single in-band signal separating "the branch
+//! was never created" from "the branch existed and is gone" — two states
+//! that look identical to the Refs API (both are a 404) but call for very
+//! different answers: initialise it, versus warn that work may be lost.
+//!
+//! Read access to the repository is enough for this endpoint, so the same
+//! token that reads the corpus can ask the question.
+
+use serde::Deserialize;
+
+use crate::client::GithubClient;
+use crate::error::{GithubError, Result};
+
+/// The one field of an activity entry we care about. GitHub also returns
+/// the actor, the before/after shas and a timestamp — deliberately not
+/// deserialised: the actor is a person, and this crate's callers log the
+/// classification, not who caused it.
+#[derive(Debug, Deserialize)]
+struct ActivityEntry {
+    #[serde(default)]
+    activity_type: String,
+}
+
+/// The `activity_type` value that marks a branch deletion.
+const BRANCH_DELETION: &str = "branch_deletion";
+
+impl GithubClient {
+    /// Whether the repository's activity log records a deletion of `branch`.
+    ///
+    /// `repo` is the full `owner/name`. `Ok(true)` means the branch existed
+    /// at some point and was deleted; `Ok(false)` means the log holds no such
+    /// event (a branch that never existed, or a deletion older than the
+    /// window GitHub retains). Any non-success response is an `Err` so the
+    /// caller can decide how to degrade — this is a *refinement* of a
+    /// classification, never the classification itself.
+    #[tracing::instrument(
+        name = "gh_http",
+        skip_all,
+        fields(method = "GET", kind = "activity", repo = %repo)
+    )]
+    pub async fn branch_deletion_recorded(
+        &self,
+        repo: &str,
+        branch: &str,
+        token: Option<&str>,
+    ) -> Result<bool> {
+        // The branch is percent-encoded, so the `/` in a `traject/<slug>`
+        // name reaches GitHub as part of the ref rather than splitting the
+        // query. One entry is enough: the question is "any deletion at all".
+        let url = format!(
+            "{}/repos/{}/activity?ref={}&activity_type={}&per_page=1",
+            self.api_base,
+            repo,
+            crate::repo_access::percent_encode_path_segment(&format!("refs/heads/{branch}")),
+            BRANCH_DELETION,
+        );
+        let headers = self.default_headers(token)?;
+        let response = self
+            .client
+            .get(&url)
+            .headers(headers)
+            .send()
+            .await
+            .map_err(|e| GithubError::Transport(format!("GitHub API request failed: {e}")))?;
+        self.track_rate_limit(&response);
+
+        let status = response.status();
+        tracing::debug!(status = %status, "gh activity GET response");
+        if !status.is_success() {
+            let code = status.as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(GithubError::Api {
+                status: code,
+                message: format!("Activity API for {repo}@{branch}: {body}"),
+            });
+        }
+
+        let entries: Vec<ActivityEntry> = response
+            .json()
+            .await
+            .map_err(|e| GithubError::Decode(format!("parse activity response: {e}")))?;
+        // Filter rather than trust the server-side `activity_type` filter:
+        // an enterprise host that ignores the parameter would otherwise turn
+        // "this branch was pushed to" into "this branch was deleted".
+        Ok(entries.iter().any(|e| e.activity_type == BRANCH_DELETION))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn client_for(server: &MockServer) -> GithubClient {
+        GithubClient::new().unwrap().with_base_url(server.uri())
+    }
+
+    #[tokio::test]
+    async fn deletion_in_the_log_is_reported() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/acme/foo/activity"))
+            // The slash in the branch name has to survive as part of the
+            // `ref` value, not split the query.
+            .and(query_param("ref", "refs/heads/traject/tarief-1a2b"))
+            .and(query_param("activity_type", "branch_deletion"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                { "activity_type": "branch_deletion", "ref": "refs/heads/traject/tarief-1a2b" }
+            ])))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        assert!(client_for(&server)
+            .branch_deletion_recorded("acme/foo", "traject/tarief-1a2b", Some("t"))
+            .await
+            .unwrap());
+    }
+
+    #[tokio::test]
+    async fn empty_log_means_never_deleted() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/acme/foo/activity"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(&server)
+            .await;
+
+        assert!(!client_for(&server)
+            .branch_deletion_recorded("acme/foo", "traject/tarief-1a2b", Some("t"))
+            .await
+            .unwrap());
+    }
+
+    #[tokio::test]
+    async fn other_activity_is_not_a_deletion() {
+        // A host that ignores the `activity_type` filter must not turn a
+        // push into a deletion.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/acme/foo/activity"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                { "activity_type": "force_push" }
+            ])))
+            .mount(&server)
+            .await;
+
+        assert!(!client_for(&server)
+            .branch_deletion_recorded("acme/foo", "main", Some("t"))
+            .await
+            .unwrap());
+    }
+
+    #[tokio::test]
+    async fn refused_log_is_an_error_not_a_verdict() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/acme/foo/activity"))
+            .respond_with(ResponseTemplate::new(403))
+            .mount(&server)
+            .await;
+
+        let err = client_for(&server)
+            .branch_deletion_recorded("acme/foo", "main", Some("t"))
+            .await
+            .expect_err("a refused activity log must not read as 'never deleted'");
+        assert!(matches!(err, GithubError::Api { status: 403, .. }));
+    }
+}

--- a/packages/github/src/lib.rs
+++ b/packages/github/src/lib.rs
@@ -35,6 +35,7 @@
 //! `std::sync::Mutex` so every method takes `&self`. The lock is never held
 //! across a `.await`.
 
+mod activity;
 mod archive;
 mod client;
 mod compare;

--- a/packages/github/src/repo_access.rs
+++ b/packages/github/src/repo_access.rs
@@ -228,8 +228,11 @@ fn truncate(s: &str, max: usize) -> String {
 /// chars (alphanumeric, `-._~`) pass through, everything else becomes `%XX`.
 ///
 /// Inline rather than a crate dep: the call is tiny, the rule is fixed by the
-/// RFC, and this crate carries no `percent_encoding`/`url` dependency.
-fn percent_encode_path_segment(s: &str) -> String {
+/// RFC, and this crate carries no `percent_encoding`/`url` dependency. Also
+/// safe for a query-string *value* — encoding more than strictly required
+/// there is always allowed — which is what `activity` uses it for (this crate
+/// builds reqwest without the feature behind `RequestBuilder::query`).
+pub(crate) fn percent_encode_path_segment(s: &str) -> String {
     use std::fmt::Write;
     let mut out = String::with_capacity(s.len());
     for &b in s.as_bytes() {


### PR DESCRIPTION
## Waarom

Laadt de bibliotheek van een traject niet, dan kreeg de gebruiker altijd dezelfde 502 met de ruwe scan-fout erin geplakt. Daarachter zitten minstens vijf situaties met totaal verschillende remedies:

| Situatie | Wat er nu staat |
|---|---|
| Traject-branch nooit gemint (vers traject) | Traject nog niet geïnitialiseerd — sla één wijziging op |
| Branch bestond en is verwijderd | Branch is weg, werk mogelijk verloren — laat hem herstellen |
| Repo hernoemd, overgedragen of verwijderd | Repo staat niet meer op het adres uit dit traject |
| Basisbranch bestaat niet meer | Basisbranch weg |
| Koppeling geeft geen toegang meer | Koppel je GitHub-account opnieuw |

Plus een expliciete restcategorie "onbekend", een aparte "GitHub is onbereikbaar" en een "er is helemaal geen GitHub-toegang". Geen enkele situatie valt nog terug op "De gegevens konden niet worden opgehaald".

## Waarom in-band, en niet in een beheerscherm

Van buitenaf zijn deze situaties niet te scheiden: GitHub geeft **404 voor zowel "repo bestaat niet" als "repo is privé en dit token ziet hem niet"**. Een beheerder die van buiten kijkt heeft geen bruikbaar token — en dat wordt in de richting van meer per-user tokens alleen maar sterker.

In het verzoek van het lid zélf zit precies het token dat het wél kan: het is zijn eigen repo. De diagnose staat daarom op het foutpad van het verzoek dat er tegenaan liep.

## Wat er verandert

- **`editor-api/src/traject_index_diagnosis.rs`** (nieuw) — classificeert de oorzaak met hetzelfde token als de gevallen scan, en mapt elke uitkomst op een korte Nederlandse melding die zegt wát er is én wat de gebruiker eraan kan doen. Dit is de lees-variant van het bestaande `repo_access_error_to_status`: dezelfde onderliggende `RepoAccessError`, ander publiek (een lid wiens bibliotheek niet opengaat, niet iemand die een repo configureert), andere remedie. Het proben zelf hergebruikt `validate_repo_access` en `branch_exists`; er wordt niets opnieuw geclassificeerd.
- **Statuscodes passen bij de situatie** (409/410/404/403/503/502) in plaats van altijd 502. **428 blijft gereserveerd voor de koppel-flow** en wordt alleen gegeven als GitHub de eigen koppeling van de gebruiker weigert — bewust *niet* bij te smalle rechten, want dan zou opnieuw koppelen een rondje worden.
- **"Nooit gemint" versus "verwijderd"** geven allebei een 404 op de Refs API. Het activiteitenlogboek van de repo maakt het verschil, zodat er alleen bij een echt verwijderde branch over mogelijk werkverlies wordt gepraat. Lukt die extra vraag niet, dan degradeert het naar de veruit meest voorkomende oorzaak in plaats van een dataverlies te claimen dat niet bevestigd is. Daarvoor spreekt de gedeelde GitHub-client nu ook de Activity API (`packages/github/src/activity.rs`).
- **Eén logregel per geval**, met een vaste veldenset: traject-id, source-id, de classificatie als eigen veld met vaste waardenverzameling, de token-herkomst, de status en de ruwe GitHub-fout. Zo is een storing terug te vinden op traject én op soort. Account-id erbij, geen naam of e-mailadres, en geen token of tokenfragment — niet in de log, niet in de melding. De bestaande logregels op dit leespad dragen nu ook het traject-id.
- **De meldingen blijven kort** en bevatten geen ruwe GitHub-payload, zodat de bibliotheek ze ongeschonden toont in plaats van ze weg te kappen.

Alle extra GitHub-calls staan uitsluitend op het foutpad; het gelukkige pad wordt geen call langer.

## Tests

`packages/editor-api/tests/traject_index_diagnosis_test.rs`: één test per situatie tegen een gemockte GitHub-client (wiremock, geen database), plus een test die voor élke classificatie bewaakt dat de melding binnen de grens van de bibliotheek blijft, niet op de generieke tekst terugvalt, uniek is, en dat 428 nergens anders vandaan komt dan een geweigerde eigen koppeling. In de GitHub-client vier tests rond het activiteitenlogboek, waaronder: een geweigerd logboek is een fout, geen "nooit verwijderd".

Twee bestaande integratietests verwachtten expliciet de oude blanket-502 op dit pad; die zijn bijgewerkt naar de scherpere uitkomst (404 die het repo-adres noemt).

`just check` groen, inclusief de testcontainer-suites.