### PR TITLE
fix(editor): laat lange traceregels afbreken in het resultaatvenster

### DIFF
--- a/frontend/src/components/ExecutionTraceView.vue
+++ b/frontend/src/components/ExecutionTraceView.vue
@@ -110,16 +110,22 @@ const overallStatus = computed(() => {
       <nldd-spacer size="16"></nldd-spacer>
     </template>
 
+    <!-- `wrap` because the code-viewer only ever owns a *horizontal* scroller
+         and grows to its full content height. Inside the trace sheet that puts
+         its horizontal scrollbar thousands of pixels below the fold, so long
+         lines (a DEFINITION with a dozen enum values) read as truncated with no
+         hint that there is more to the right. Wrapping keeps every value
+         visible; the sheet's own scroller handles the vertical axis. -->
     <template v-if="result && traceText">
       <nldd-title size="5" class="etv-section-title"><span>Execution trace</span></nldd-title>
       <nldd-spacer size="8"></nldd-spacer>
-      <nldd-code-viewer>{{ traceText }}</nldd-code-viewer>
+      <nldd-code-viewer wrap>{{ traceText }}</nldd-code-viewer>
     </template>
 
     <template v-if="error && traceText && !result">
       <nldd-title size="5" class="etv-section-title"><span>Partial trace (tot fout)</span></nldd-title>
       <nldd-spacer size="8"></nldd-spacer>
-      <nldd-code-viewer>{{ traceText }}</nldd-code-viewer>
+      <nldd-code-viewer wrap>{{ traceText }}</nldd-code-viewer>
       <template v-if="canReload">
         <nldd-spacer size="12"></nldd-spacer>
         <nldd-button size="md" text="Opnieuw uitvoeren" @click="emit('reload')"></nldd-button>


### PR DESCRIPTION
## Wat

Eén attribuut: `wrap` op de twee `nldd-code-viewer`-instanties in `ExecutionTraceView.vue` (de volledige trace en de partiële trace bij een fout).

## Waarom

De `nldd-code-viewer` bezit alleen een **horizontale** scroller (`code-viewer.ts`: `const scrollable = !this.wrap && scroller.scrollWidth > scroller.clientWidth`) en groeit verder mee met zijn inhoud — verticale begrenzing is bewust aan de layout gelaten. In het resultaat-sheet levert dat een viewer van ~3100px op, waardoor zijn horizontale scrollbalk ruim 2000px onder de vouw belandt.

Gemeten op `wet_op_de_zorgtoeslag` in de editor:

| | zonder `wrap` | met `wrap` |
|---|---|---|
| Langste regel | 2594px | 1092px |
| Vensterbreedte | 1092px | 1092px |
| Horizontaal verborgen | **1502px** | 0px |

Concreet: `$GELDIGE_PARTNERTYPEN = ['HUWELIJK', 'GEREGISTREERD_PARTNERSCHAP', 'IB_PARTNERKEUZ` breekt af midden in een woord; zeven partnertypen zijn niet zichtbaar.

De inhoud was overigens wél bereikbaar — shift+scroll, trackpad-swipe en tabben naar de regio (`tabindex="0"`, `role="region"`) werken allemaal. Het probleem is vindbaarheid: er wordt geen scrollbalk-ruimte gereserveerd (`offsetHeight - clientHeight` = 0), dus niets verraadt dat er nog inhoud rechts staat.

## Afweging

`wrap` kost de boom-uitlijning op de doorgelopen regels: die beginnen op kolom 0. Een begrensde hoogte met een eigen, zichtbare scrollbalk houdt die uitlijning intact en zou beter zijn — maar `nldd-code-viewer` kent geen `height`/`max-height`-property, en geen enkele layout-component (`container`, `box`, `card`, `collection`, `window`, `page-sections`) biedt een begrensd scrollgebied. Dat vraagt dus eerst een toevoeging in het design system; die zet ik apart uit.

`YamlView.vue` gebruikt dezelfde component maar blijft bewust ongewijzigd: bij YAML is inspringing betekenisdragend, dus afbreken op kolom 0 is daar schadelijker.

## Design system

Geen extra CSS, geen eigen markup — `wrap` is een gedocumenteerde property van de component, met eigen story. `@nldd/design-system/code-viewer` was al geïmporteerd in `nldd-components.js`.

## Getest

`npm test` in `frontend/`: **723 tests groen, 65/66 bestanden**. Het ene falende bestand (`src/harvester/views/OverviewView.test.js`) valt om op een ontbrekende lokale devDependency (`jsdom`, wel in `package.json`, niet installeerbaar in deze omgeving) en faalt identiek op ongewijzigde `main`. Raakt deze wijziging niet.

Verder handmatig geverifieerd tegen productie op het `Development repo`-traject: voor/na-screenshots op dezelfde scrollpositie tonen de complete `GELDIGE_PARTNERTYPEN`-lijst in plaats van een afgekapte regel.