### PR TITLE
fix(editor): geef de execution trace een eigen scrollkader

### DIFF
--- a/frontend/e2e/trace-scroll-box.spec.js
+++ b/frontend/e2e/trace-scroll-box.spec.js
@@ -1,0 +1,130 @@
+/**
+ * The execution trace renders as a bounded scroll box, not a 3000px column.
+ *
+ * The trace is a box-drawing tree, so it must not wrap (a wrapped continuation
+ * restarts at column 0 and reads as depth 0). Without wrapping the block used to
+ * grow to its full content height, which parked its horizontal scrollbar
+ * thousands of pixels below the fold inside the sheet's own scroller — nobody
+ * could find it (#1101).
+ *
+ * The unit tests can't prove this: happy-dom does no layout, so they can only
+ * assert the strings we wrote, never that the block is actually short and
+ * actually scrolls. That takes a real browser, so it lives here.
+ *
+ * Asserted against a real engine run of wet_op_de_zorgtoeslag:
+ *   - the trace block is capped at 40% of the viewport, and
+ *   - its bottom edge — where the horizontal scrollbar lives — lands *inside*
+ *     the viewport, which is the property that actually matters and the one a
+ *     height-only assertion does not prove: the block starts ~356px down, so a
+ *     cap measured against the whole viewport can still end below the fold, and
+ *   - its scroller really does scroll (scrollHeight > clientHeight, and
+ *     scrollTop moves), so the content isn't merely clipped, and
+ *   - the scroll region is reachable by keyboard and announced (WCAG 2.1.1).
+ *
+ * This law's trace overflows on BOTH axes, so the design system marks the
+ * region itself here and only the label is ours. The case it misses — a trace
+ * that overflows vertically but not horizontally — has no long-line-free
+ * fixture in this corpus, so it is covered by the unit tests, which can dictate
+ * the overflow metrics.
+ *
+ * All corpus endpoints are mocked from the on-disk corpus; the engine is the
+ * real WASM build running client-side (frontend/public/wasm/pkg, via
+ * `just wasm-build`).
+ */
+import { test, expect } from '@playwright/test';
+import { loadCorpus, loadScenario, mockCorpusApi } from './helpers-corpus.js';
+import { gotoEditor, expectScenarioResult, clearOpenTabsStorage, openSheet } from './helpers.js';
+
+const MINOR = 'Minderjarige heeft geen recht';
+
+test.describe('Execution trace scroll box', () => {
+  test.beforeEach(async ({ page }) => {
+    await clearOpenTabsStorage(page);
+  });
+
+  test('the trace is a bounded scroll box, reachable by keyboard', async ({ page }) => {
+    // Full-corpus dependency loading plus every scenario auto-executing needs
+    // well over the default 30s budget.
+    test.setTimeout(180_000);
+
+    const corpus = loadCorpus();
+    const zorgtoeslag = corpus.get('wet_op_de_zorgtoeslag');
+    expect(zorgtoeslag, 'wet_op_de_zorgtoeslag must exist in the test corpus').toBeTruthy();
+
+    const scenarioFilename = 'eligibility.feature';
+    const scenarioText = loadScenario(zorgtoeslag.path, scenarioFilename);
+    expect(scenarioText, 'eligibility.feature must exist').toBeTruthy();
+
+    await mockCorpusApi(
+      page,
+      corpus,
+      { id: 'wet_op_de_zorgtoeslag', scenarioFilename },
+      scenarioText,
+    );
+
+    await gotoEditor(page, 'wet_op_de_zorgtoeslag', '2');
+
+    // Leaves the result sheet open on the executed scenario.
+    await expectScenarioResult(page, MINOR, 'Mislukt');
+
+    const trace = openSheet(page).locator('nldd-code-viewer.etv-trace');
+    await trace.waitFor({ state: 'visible', timeout: 10_000 });
+
+    // Wrapping is what destroyed the tree alignment; it must stay off.
+    expect(await trace.evaluate((el) => el.hasAttribute('wrap'))).toBe(false);
+
+    const box = await trace.evaluate(async (el) => {
+      const scroller = el.shadowRoot.querySelector('.cm-scroller');
+      scroller.scrollTop = 99_999;
+      await new Promise(requestAnimationFrame);
+      const scrolledTo = scroller.scrollTop;
+      scroller.scrollTop = 0;
+      const rect = el.getBoundingClientRect();
+      return {
+        blockTop: rect.top,
+        blockHeight: rect.height,
+        blockBottom: rect.bottom,
+        viewportHeight: window.innerHeight,
+        scrollHeight: scroller.scrollHeight,
+        clientHeight: scroller.clientHeight,
+        scrolledTo,
+        tabindex: scroller.getAttribute('tabindex'),
+        role: scroller.getAttribute('role'),
+        ariaLabel: scroller.getAttribute('aria-label'),
+      };
+    });
+    console.log('trace scroll box:', JSON.stringify(box));
+
+    // The trace this scenario produces has to be long enough to overflow,
+    // otherwise the rest of the assertions prove nothing.
+    expect(
+      box.scrollHeight,
+      'the trace must overflow its box, or this spec guards nothing',
+    ).toBeGreaterThan(box.clientHeight);
+
+    // The regression: the block must be bounded instead of growing to its full
+    // content height.
+    expect(box.blockHeight).toBeLessThanOrEqual(box.viewportHeight * 0.4 + 1);
+
+    // …and bounded is not enough on its own. The block starts partway down the
+    // sheet (356px on this fixture), so a cap measured against the whole
+    // viewport can still push the bottom edge — and with it the horizontal
+    // scrollbar — below the fold. This is the assertion that pins the cap to
+    // what actually fits: at max-height 60vh the block is 432px, well inside
+    // "60% of the viewport", yet it ends at 788px on a 720px screen. Measured
+    // here at 40vh: top 356, height 288, bottom 644.
+    expect(
+      box.blockBottom,
+      `the block's bottom edge (and its horizontal scrollbar) must be on screen; `
+      + `top ${box.blockTop}, height ${box.blockHeight}`,
+    ).toBeLessThanOrEqual(box.viewportHeight);
+
+    // Bounded AND scrollable - not merely clipped.
+    expect(box.scrolledTo).toBeGreaterThan(0);
+
+    // WCAG 2.1.1: the scroll region must be in the tab order and announced.
+    expect(box.tabindex).toBe('0');
+    expect(box.role).toBe('region');
+    expect(box.ariaLabel).toBe('Execution trace');
+  });
+});

--- a/frontend/src/components/ExecutionTraceView.test.js
+++ b/frontend/src/components/ExecutionTraceView.test.js
@@ -1,14 +1,40 @@
 import { mount } from '@vue/test-utils';
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
 import ExecutionTraceView from './ExecutionTraceView.vue';
 
+// Overflow metrics the stub viewer reports for the next mount. happy-dom does
+// no layout, so the numbers a real browser would measure are supplied here
+// instead. Defaults to a trace that overflows vertically but NOT horizontally —
+// the exact shape the design system's own scroll-region logic misses, because
+// it only ever measures the horizontal axis. The vertical numbers are the ones
+// the e2e prints for the capped block on wet_op_de_zorgtoeslag art. 2.
+const OVERFLOWS_VERTICALLY = { scrollHeight: 3114, clientHeight: 256, scrollWidth: 624, clientWidth: 624 };
+const FITS = { scrollHeight: 43, clientHeight: 43, scrollWidth: 624, clientWidth: 624 };
+let stubMetrics = OVERFLOWS_VERTICALLY;
+
+// happy-dom reports 0 for every layout metric, so the ones the directive reads
+// have to be planted on each scroller it will meet.
+function makeScroller(metrics) {
+  const scroller = document.createElement('div');
+  scroller.className = 'cm-scroller';
+  for (const [name, value] of Object.entries(metrics)) {
+    Object.defineProperty(scroller, name, { value, configurable: true });
+  }
+  return scroller;
+}
+
 // The real nldd-code-viewer isn't loaded under vitest, so stand in a minimal
-// element with the one thing the directive needs: a shadow root carrying
-// adoptedStyleSheets.
+// element with the parts the directive works against: the `.code-viewer` render
+// root, the `.cm-scroller` inside it, and Lit's `updateComplete`.
 class StubCodeViewer extends HTMLElement {
   constructor() {
     super();
-    this.attachShadow({ mode: 'open' });
+    const root = this.attachShadow({ mode: 'open' });
+    const block = document.createElement('div');
+    block.className = 'code-viewer';
+    block.appendChild(makeScroller(stubMetrics));
+    root.appendChild(block);
+    this.updateComplete = Promise.resolve(true);
   }
 }
 
@@ -20,49 +46,112 @@ beforeAll(() => {
 
 const TRACE = 'wet_op_de_zorgtoeslag\n└──Result: heeft_recht = True';
 
-const viewerIn = (w) => w.element.parentElement.querySelector('nldd-code-viewer');
+// This component has several root nodes, so `w.element` is the wrapper DIV that
+// vue-test-utils puts around them — the query has to stay inside it. Reaching
+// for `w.element.parentElement` lands on document.body, where every still-mounted
+// wrapper's viewer lives, and the assertion silently reads the first test's.
+const viewerIn = (w) => w.find('nldd-code-viewer').element;
 
-const adoptedCss = (viewer) =>
-  Array.from(viewer.shadowRoot.adoptedStyleSheets)
-    .flatMap((s) => Array.from(s.cssRules).map((r) => r.cssText))
-    .join('\n');
+const scrollerIn = (w) => viewerIn(w).shadowRoot.querySelector('.cm-scroller');
 
 describe('ExecutionTraceView trace block', () => {
-  it('does not wrap the trace, so the box-drawing columns stay aligned', () => {
-    const w = mount(ExecutionTraceView, {
-      props: { result: { outputs: {} }, traceText: TRACE },
-      attachTo: document.body,
-    });
+  const wrappers = [];
+
+  // Every wrapper is attached to document.body, so leaving them mounted would
+  // pile up nldd-code-viewer elements there and let one test observe another's.
+  afterEach(() => {
+    while (wrappers.length) wrappers.pop().unmount();
+    document.body.innerHTML = '';
+    stubMetrics = OVERFLOWS_VERTICALLY;
+  });
+
+  async function mountView(props) {
+    const w = mount(ExecutionTraceView, { props, attachTo: document.body });
+    wrappers.push(w);
+    // The directive awaits customElements/updateComplete before it observes.
+    await w.vm.$nextTick();
+    await Promise.resolve();
+    return w;
+  }
+
+  it('does not wrap the trace, so the box-drawing columns stay aligned', async () => {
+    const w = await mountView({ result: { outputs: {} }, traceText: TRACE });
     expect(viewerIn(w).hasAttribute('wrap')).toBe(false);
   });
 
-  it('bounds the block so its scrollbars land inside the viewport', async () => {
-    const w = mount(ExecutionTraceView, {
-      props: { result: { outputs: {} }, traceText: TRACE },
-      attachTo: document.body,
-    });
-    await w.vm.$nextTick();
+  it('makes the bounded scroll box reachable by keyboard and announceable', async () => {
+    const w = await mountView({ result: { outputs: {} }, traceText: TRACE });
 
-    const viewer = viewerIn(w);
-    const css = adoptedCss(viewer);
-    // CodeMirror only takes a height through its own elements: a definite
-    // height on .cm-editor and an overflow on .cm-scroller. Without both, the
-    // block grows to its full content height and parks the horizontal
-    // scrollbar thousands of pixels below the fold.
-    expect(css).toMatch(/\.cm-editor[^}]*height:\s*100%/);
-    expect(css).toMatch(/\.cm-scroller[^}]*overflow:\s*auto/);
-    // .code-viewer is a flex child of the host; without min-height: 0 it
-    // refuses to shrink below its content and the max-height does nothing.
-    expect(css).toMatch(/\.code-viewer[^}]*min-height:\s*0/);
+    // The height cap turns the block into a vertical scroll container. The
+    // design system only marks its scroll region on HORIZONTAL overflow, so on
+    // a trace like this one the region would otherwise be skipped when tabbing
+    // (WCAG 2.1.1).
+    const scroller = scrollerIn(w);
+    expect(scroller.getAttribute('tabindex')).toBe('0');
+    expect(scroller.getAttribute('role')).toBe('region');
+    expect(scroller.getAttribute('aria-label')).toBe('Execution trace');
   });
 
-  it('bounds the partial trace shown after a failed run too', async () => {
-    const w = mount(ExecutionTraceView, {
-      props: { error: 'boem', traceText: TRACE },
-      attachTo: document.body,
-    });
-    await w.vm.$nextTick();
+  it('re-marks the region after the design system strips it', async () => {
+    const w = await mountView({ result: { outputs: {} }, traceText: TRACE });
+    const scroller = scrollerIn(w);
 
-    expect(adoptedCss(viewerIn(w))).toMatch(/\.cm-scroller/);
+    // _updateScrollable() runs again on a rAF-debounced ResizeObserver, on
+    // slot changes and on several property changes, and removes these whenever
+    // the content isn't overflowing horizontally. A one-shot set is undone.
+    scroller.removeAttribute('tabindex');
+    scroller.removeAttribute('role');
+    scroller.removeAttribute('aria-label');
+    await Promise.resolve();
+
+    expect(scroller.getAttribute('tabindex')).toBe('0');
+    expect(scroller.getAttribute('role')).toBe('region');
+    expect(scroller.getAttribute('aria-label')).toBe('Execution trace');
+  });
+
+  it('follows the scroll region to the scroller a re-mount builds', async () => {
+    const w = await mountView({ result: { outputs: {} }, traceText: TRACE });
+    const block = viewerIn(w).shadowRoot.querySelector('.code-viewer');
+
+    // A detach/reattach makes the design system tear down its EditorView and
+    // build a brand-new `.cm-scroller` inside the same `.code-viewer`. Marking
+    // only the scroller we found at mount time would leave the live one bare,
+    // which is why the observer watches childList/subtree and re-binds.
+    block.querySelector('.cm-scroller').remove();
+    const remounted = makeScroller(OVERFLOWS_VERTICALLY);
+    block.appendChild(remounted);
+    await Promise.resolve();
+
+    expect(remounted.getAttribute('tabindex')).toBe('0');
+    expect(remounted.getAttribute('role')).toBe('region');
+    expect(remounted.getAttribute('aria-label')).toBe('Execution trace');
+  });
+
+  it('leaves a trace that fits alone, so it is not a bogus tab stop', async () => {
+    stubMetrics = FITS;
+    const w = await mountView({ result: { outputs: {} }, traceText: TRACE });
+
+    expect(scrollerIn(w).hasAttribute('tabindex')).toBe(false);
+    expect(scrollerIn(w).hasAttribute('role')).toBe(false);
+  });
+
+  it('marks the partial trace shown after a failed run too', async () => {
+    const w = await mountView({ error: 'boem', traceText: TRACE });
+
+    const scroller = scrollerIn(w);
+    expect(scroller.getAttribute('tabindex')).toBe('0');
+    expect(scroller.getAttribute('aria-label')).toBe('Execution trace');
+  });
+
+  it('stops observing once the view is unmounted', async () => {
+    const w = await mountView({ result: { outputs: {} }, traceText: TRACE });
+    const scroller = scrollerIn(w);
+
+    w.unmount();
+    wrappers.pop();
+    scroller.removeAttribute('tabindex');
+    await Promise.resolve();
+
+    expect(scroller.hasAttribute('tabindex')).toBe(false);
   });
 });

--- a/frontend/src/components/ExecutionTraceView.test.js
+++ b/frontend/src/components/ExecutionTraceView.test.js
@@ -1,0 +1,68 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect, beforeAll } from 'vitest';
+import ExecutionTraceView from './ExecutionTraceView.vue';
+
+// The real nldd-code-viewer isn't loaded under vitest, so stand in a minimal
+// element with the one thing the directive needs: a shadow root carrying
+// adoptedStyleSheets.
+class StubCodeViewer extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+}
+
+beforeAll(() => {
+  if (!customElements.get('nldd-code-viewer')) {
+    customElements.define('nldd-code-viewer', StubCodeViewer);
+  }
+});
+
+const TRACE = 'wet_op_de_zorgtoeslag\n└──Result: heeft_recht = True';
+
+const viewerIn = (w) => w.element.parentElement.querySelector('nldd-code-viewer');
+
+const adoptedCss = (viewer) =>
+  Array.from(viewer.shadowRoot.adoptedStyleSheets)
+    .flatMap((s) => Array.from(s.cssRules).map((r) => r.cssText))
+    .join('\n');
+
+describe('ExecutionTraceView trace block', () => {
+  it('does not wrap the trace, so the box-drawing columns stay aligned', () => {
+    const w = mount(ExecutionTraceView, {
+      props: { result: { outputs: {} }, traceText: TRACE },
+      attachTo: document.body,
+    });
+    expect(viewerIn(w).hasAttribute('wrap')).toBe(false);
+  });
+
+  it('bounds the block so its scrollbars land inside the viewport', async () => {
+    const w = mount(ExecutionTraceView, {
+      props: { result: { outputs: {} }, traceText: TRACE },
+      attachTo: document.body,
+    });
+    await w.vm.$nextTick();
+
+    const viewer = viewerIn(w);
+    const css = adoptedCss(viewer);
+    // CodeMirror only takes a height through its own elements: a definite
+    // height on .cm-editor and an overflow on .cm-scroller. Without both, the
+    // block grows to its full content height and parks the horizontal
+    // scrollbar thousands of pixels below the fold.
+    expect(css).toMatch(/\.cm-editor[^}]*height:\s*100%/);
+    expect(css).toMatch(/\.cm-scroller[^}]*overflow:\s*auto/);
+    // .code-viewer is a flex child of the host; without min-height: 0 it
+    // refuses to shrink below its content and the max-height does nothing.
+    expect(css).toMatch(/\.code-viewer[^}]*min-height:\s*0/);
+  });
+
+  it('bounds the partial trace shown after a failed run too', async () => {
+    const w = mount(ExecutionTraceView, {
+      props: { error: 'boem', traceText: TRACE },
+      attachTo: document.body,
+    });
+    await w.vm.$nextTick();
+
+    expect(adoptedCss(viewerIn(w))).toMatch(/\.cm-scroller/);
+  });
+});

--- a/frontend/src/components/ExecutionTraceView.vue
+++ b/frontend/src/components/ExecutionTraceView.vue
@@ -36,6 +36,57 @@ const overallStatus = computed(() => {
   }
   return 'passed';
 });
+
+/* The trace is a box-drawing tree, so every line's meaning sits in its column:
+ * wrapping restarts a continuation at column 0 and it reads as if it lives at
+ * depth 0, cutting straight through the tree gutters. So no `wrap` — the long
+ * lines have to scroll sideways instead.
+ *
+ * But `nldd-code-viewer` grows to its full content height (3167px on
+ * wet_op_de_zorgtoeslag art. 2), which parks its horizontal scrollbar thousands
+ * of pixels below the fold, inside the sheet's own scroller. Unfindable — the
+ * reason the `wrap` went on in the first place (#1101).
+ *
+ * The component owns no height API, so we bound it from here. CodeMirror won't
+ * take a height through the host (it lays the scroller out itself), so the rule
+ * has to land inside the shadow root: `.cm-editor` needs a definite height and
+ * `.cm-scroller` an overflow, per CodeMirror's own fixed-height recipe. That
+ * gives the block its own two scrollbars at the edges of a visible box, with
+ * the column alignment intact.
+ *
+ * Remove this once `nldd-code-viewer` grows a height/rows property of its own
+ * (nldd-code-editor already has `rows`); then this becomes an attribute.
+ */
+const TRACE_SCROLL_BOX_CSS = `
+  .code-viewer { display: flex; flex-direction: column; min-height: 0; }
+  .cm-editor { height: 100%; min-height: 0; }
+  .cm-scroller { overflow: auto; }
+`;
+
+function applyTraceScrollBox(el) {
+  const root = el?.shadowRoot;
+  if (!root) return false;
+  const sheet = new CSSStyleSheet();
+  sheet.replaceSync(TRACE_SCROLL_BOX_CSS);
+  // Appended last so it wins over the component's own styles at equal
+  // specificity. Lit keeps its static styles in the same list, so replacing the
+  // array wholesale would strip them.
+  root.adoptedStyleSheets = [...root.adoptedStyleSheets, sheet];
+  return true;
+}
+
+const vTraceScrollBox = {
+  async mounted(el) {
+    // The element only has a shadow root once its definition is registered and
+    // it has upgraded. It normally is by now (the design system is imported at
+    // startup), so this awaits nothing; but under a lazy registration the block
+    // would silently stay unbounded, and a 3000px trace is the exact failure
+    // we're fixing.
+    if (applyTraceScrollBox(el)) return;
+    await customElements.whenDefined('nldd-code-viewer');
+    applyTraceScrollBox(el);
+  },
+};
 </script>
 
 <template>
@@ -110,22 +161,16 @@ const overallStatus = computed(() => {
       <nldd-spacer size="16"></nldd-spacer>
     </template>
 
-    <!-- `wrap` because the code-viewer only ever owns a *horizontal* scroller
-         and grows to its full content height. Inside the trace sheet that puts
-         its horizontal scrollbar thousands of pixels below the fold, so long
-         lines (a DEFINITION with a dozen enum values) read as truncated with no
-         hint that there is more to the right. Wrapping keeps every value
-         visible; the sheet's own scroller handles the vertical axis. -->
     <template v-if="result && traceText">
       <nldd-title size="5" class="etv-section-title"><span>Execution trace</span></nldd-title>
       <nldd-spacer size="8"></nldd-spacer>
-      <nldd-code-viewer wrap>{{ traceText }}</nldd-code-viewer>
+      <nldd-code-viewer v-trace-scroll-box class="etv-trace">{{ traceText }}</nldd-code-viewer>
     </template>
 
     <template v-if="error && traceText && !result">
       <nldd-title size="5" class="etv-section-title"><span>Partial trace (tot fout)</span></nldd-title>
       <nldd-spacer size="8"></nldd-spacer>
-      <nldd-code-viewer wrap>{{ traceText }}</nldd-code-viewer>
+      <nldd-code-viewer v-trace-scroll-box class="etv-trace">{{ traceText }}</nldd-code-viewer>
       <template v-if="canReload">
         <nldd-spacer size="12"></nldd-spacer>
         <nldd-button size="md" text="Opnieuw uitvoeren" @click="emit('reload')"></nldd-button>
@@ -133,3 +178,12 @@ const overallStatus = computed(() => {
     </template>
   </template>
 </template>
+
+<style scoped>
+/* The ceiling the shadow-root rules in v-trace-scroll-box scroll against. A
+   short trace still renders at its own height; only a long one gets capped,
+   and then its scrollbars sit at the edges of a box that fits on screen. */
+.etv-trace {
+  max-height: 60vh;
+}
+</style>

--- a/frontend/src/components/ExecutionTraceView.vue
+++ b/frontend/src/components/ExecutionTraceView.vue
@@ -42,49 +42,164 @@ const overallStatus = computed(() => {
  * depth 0, cutting straight through the tree gutters. So no `wrap` — the long
  * lines have to scroll sideways instead.
  *
- * But `nldd-code-viewer` grows to its full content height (3167px on
- * wet_op_de_zorgtoeslag art. 2), which parks its horizontal scrollbar thousands
- * of pixels below the fold, inside the sheet's own scroller. Unfindable — the
- * reason the `wrap` went on in the first place (#1101).
+ * But `nldd-code-viewer` grows to its full content height — on
+ * wet_op_de_zorgtoeslag art. 2 the e2e measures a `scrollHeight` of 3114px of
+ * trace content — which parks its horizontal scrollbar thousands of pixels
+ * below the fold, inside the sheet's own scroller. Unfindable — the reason the
+ * `wrap` went on in the first place (#1101).
  *
- * The component owns no height API, so we bound it from here. CodeMirror won't
- * take a height through the host (it lays the scroller out itself), so the rule
- * has to land inside the shadow root: `.cm-editor` needs a definite height and
- * `.cm-scroller` an overflow, per CodeMirror's own fixed-height recipe. That
- * gives the block its own two scrollbars at the edges of a visible box, with
- * the column alignment intact.
+ * Bounding it takes nothing but the `max-height` in `.etv-trace` below: the
+ * component's own CodeMirror theme already ships `.cm-editor { height: 100% }`
+ * and `.cm-scroller { overflow: auto }`, so a capped host is exactly
+ * CodeMirror's fixed-height recipe. Both scrollbars then sit at the edges of a
+ * box that starts *and ends* inside the viewport on the reference fixture, with
+ * the column alignment intact — see `.etv-trace` below for the measurement that
+ * fixes the cap, and for the one case where a short sheet-scroll is still
+ * needed. No shadow-root styling needed.
  *
- * Remove this once `nldd-code-viewer` grows a height/rows property of its own
- * (nldd-code-editor already has `rows`); then this becomes an attribute.
+ * What the component does not do is notice that it now scrolls *vertically*.
+ * `_updateScrollable()` measures only the horizontal axis, so on a trace whose
+ * lines all fit the width it leaves the scroll region without
+ * tabindex/role/aria-label: measured on such a trace the accessibility tree has
+ * no region for it at all, so a screen reader announces nothing to enter, and
+ * only browsers that make overflowing scrollers focusable by themselves put it
+ * in the tab order (WCAG 2.1.1). The height cap is what opened that gap, so
+ * closing it is ours: `v-trace-scroll-box` marks the region from here.
+ *
+ * Remove the directive once `nldd-code-viewer` marks its scroll region on both
+ * axes; drop `.etv-trace` once it grows a height/rows property of its own
+ * (nldd-code-editor already has `rows`), which would make this an attribute.
  */
-const TRACE_SCROLL_BOX_CSS = `
-  .code-viewer { display: flex; flex-direction: column; min-height: 0; }
-  .cm-editor { height: 100%; min-height: 0; }
-  .cm-scroller { overflow: auto; }
-`;
+const TRACE_REGION_LABEL = 'Execution trace';
 
-function applyTraceScrollBox(el) {
-  const root = el?.shadowRoot;
-  if (!root) return false;
-  const sheet = new CSSStyleSheet();
-  sheet.replaceSync(TRACE_SCROLL_BOX_CSS);
-  // Appended last so it wins over the component's own styles at equal
-  // specificity. Lit keeps its static styles in the same list, so replacing the
-  // array wholesale would strip them.
-  root.adoptedStyleSheets = [...root.adoptedStyleSheets, sheet];
-  return true;
+/**
+ * Keep the viewer's scroll region focusable and labelled for as long as it
+ * overflows on *either* axis, and return a teardown.
+ *
+ * The design system marks the region itself, but only on horizontal overflow,
+ * and it recomputes on a rAF-debounced ResizeObserver, on every slot change and
+ * on several property changes — stripping the attributes again each time it
+ * finds no horizontal overflow. A one-shot set would therefore be undone, so we
+ * watch and re-apply.
+ *
+ * Re-applying is asynchronous, and that costs something: our MutationObserver
+ * callback only runs a microtask after the design system has already called
+ * `removeAttribute('tabindex')`. In that window the scroller is not focusable,
+ * so if the user's keyboard focus was *inside* it the HTML focus-fixup rule has
+ * moved focus to `<body>` — re-adding the attribute cannot bring it back. A
+ * design-system recompute (new trace text after a re-run, its ResizeObserver, a
+ * variant/background/no-copy change) can therefore drop focus out of the trace.
+ * That is inherent to marking the region from the app side; it goes away when
+ * `nldd-code-viewer` measures both axes itself. Known cost, not a bug to hunt.
+ *
+ * Two observers, because both triggers exist: content that
+ * starts overflowing produces no attribute mutation at all (nothing was there to
+ * remove), and a detach/reattach re-mount builds a brand-new `.cm-scroller`.
+ * `.code-viewer` is the component's own render root and survives that re-mount,
+ * so it is the stable thing to observe.
+ *
+ * Add-only on purpose: removal stays the design system's call, which keeps the
+ * two from fighting, and re-setting an attribute that is already there is a
+ * no-op — so the MutationObserver settles instead of looping. The label is the
+ * one exception: it is written whenever it differs, because on a trace that
+ * *also* overflows horizontally the design system gets there first and labels
+ * the region with its own generic default. `translations` (below) makes that
+ * default our label too, so in practice both write the same string and there is
+ * nothing to correct.
+ */
+function watchScrollRegion(el, label) {
+  const root = el.shadowRoot;
+  const block = root?.querySelector('.code-viewer');
+  if (!block) return null;
+
+  let scroller = null;
+
+  function markRegion() {
+    // A 0-width measure (mid-reflow, or before first layout) is never a
+    // trustworthy overflow signal — the design system bails on it for the same
+    // reason. A later observer tick re-measures once the width is real.
+    if (!scroller || scroller.clientWidth === 0) return;
+    const overflows = scroller.scrollHeight > scroller.clientHeight
+      || scroller.scrollWidth > scroller.clientWidth;
+    if (!overflows) return;
+    if (!scroller.hasAttribute('tabindex')) scroller.setAttribute('tabindex', '0');
+    if (!scroller.hasAttribute('role')) scroller.setAttribute('role', 'region');
+    if (scroller.getAttribute('aria-label') !== label) scroller.setAttribute('aria-label', label);
+  }
+
+  const resizeObserver = new ResizeObserver(markRegion);
+
+  function bindScroller() {
+    const next = root.querySelector('.cm-scroller');
+    if (next === scroller) return;
+    if (scroller) resizeObserver.unobserve(scroller);
+    scroller = next;
+    if (scroller) resizeObserver.observe(scroller);
+  }
+
+  const attributeObserver = new MutationObserver(() => {
+    bindScroller();
+    markRegion();
+  });
+  attributeObserver.observe(block, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ['tabindex', 'role', 'aria-label'],
+  });
+
+  bindScroller();
+  markRegion();
+
+  return () => {
+    attributeObserver.disconnect();
+    resizeObserver.disconnect();
+  };
 }
 
+async function markTraceScrollRegion(el, state) {
+  // The element only has a shadow root once its definition is registered and it
+  // has upgraded; CodeMirror only exists after Lit's first render. The design
+  // system is imported at startup, so this normally awaits a microtask.
+  if (!el.shadowRoot) await customElements.whenDefined('nldd-code-viewer');
+  await el.updateComplete;
+  if (state.stopped) return;
+  const stop = watchScrollRegion(el, TRACE_REGION_LABEL);
+  if (!stop) throw new Error('nldd-code-viewer exposes no .code-viewer to observe');
+  if (state.stopped) stop();
+  else state.stop = stop;
+}
+
+/** Per-element observer state, so `unmounted` can stop what `mounted` started. */
+const scrollRegionWatchers = new WeakMap();
+
 const vTraceScrollBox = {
-  async mounted(el) {
-    // The element only has a shadow root once its definition is registered and
-    // it has upgraded. It normally is by now (the design system is imported at
-    // startup), so this awaits nothing; but under a lazy registration the block
-    // would silently stay unbounded, and a 3000px trace is the exact failure
-    // we're fixing.
-    if (applyTraceScrollBox(el)) return;
-    await customElements.whenDefined('nldd-code-viewer');
-    applyTraceScrollBox(el);
+  mounted(el) {
+    // `translations` is the component's own knob for the scroll region's label,
+    // so the region reads as this block rather than as generic "Code" when the
+    // component labels it itself. Set before its first render, so its first
+    // measure already uses it.
+    el.translations = { 'components.code-viewer.region-label': TRACE_REGION_LABEL };
+    const state = { stopped: false, stop: null };
+    scrollRegionWatchers.set(el, state);
+    // Not an `async mounted`: a rejection there is an unhandled rejection, and
+    // the failure mode is silent either way — the trace block would keep
+    // scrolling under the mouse while staying unreachable by keyboard.
+    markTraceScrollRegion(el, state).catch((error) => {
+      console.warn(
+        'ExecutionTraceView: kon het scrollgebied van de execution trace niet '
+        + 'markeren. Het blok blijft met de muis scrollbaar, maar is niet met '
+        + 'het toetsenbord te bereiken of aan te kondigen.',
+        error,
+      );
+    });
+  },
+  unmounted(el) {
+    const state = scrollRegionWatchers.get(el);
+    if (!state) return;
+    state.stopped = true;
+    state.stop?.();
+    scrollRegionWatchers.delete(el);
   },
 };
 </script>
@@ -180,10 +295,34 @@ const vTraceScrollBox = {
 </template>
 
 <style scoped>
-/* The ceiling the shadow-root rules in v-trace-scroll-box scroll against. A
-   short trace still renders at its own height; only a long one gets capped,
-   and then its scrollbars sit at the edges of a box that fits on screen. */
+/* The whole scroll box. `nldd-code-viewer` has no height API. CodeMirror's own
+   `.cm-editor { height: 100% }` does not resolve against the host but against
+   `.code-viewer` — that is the element `mountEditor` hands to
+   `new EditorView({ parent })`. The cap still reaches it, one step further out:
+   `:host { display: flex }` makes a *row* container, so `.code-viewer` stretches
+   to the host's height on the cross axis — that default `align-items: stretch`
+   is what carries the cap down, not the `flex-grow: 1` the design system sets
+   (that one sizes the width). Clamping the host therefore makes
+   `.code-viewer`'s height definite and the editor's 100% has something to
+   resolve against. So what would break this is `align-items` or a
+   `flex-direction: column` appearing on `:host`, not a change to `flex-grow`.
+   (Measured: host 288px → scroller clientHeight 256px, the difference being
+   `.code-viewer`'s 2×16px block padding.)
+
+   40vh, not more, because the block does not start at the top of the screen. On
+   the reference fixture (wet_op_de_zorgtoeslag art. 2, 1280×720) it starts
+   356px down — top bar, expectations list, section heading — so 40vh = 288px
+   puts its bottom edge at 644px, some 76px above the fold: both scrollbars are
+   on screen without scrolling the sheet first. 60vh would end at 788px, i.e.
+   below the fold, which is the #1101 symptom in miniature.
+
+   Those 76px of headroom are worth exactly one extra expectation row (measured:
+   45px each). So the honest claim is not "always fits": on a scenario with a
+   longer expectations list the block starts lower, and reaching its bottom edge
+   still takes one short sheet-scroll. Bounded, though — tens of pixels, not the
+   ~2700px of #1101. A short trace renders at its own height untouched; only a
+   long one gets capped. */
 .etv-trace {
-  max-height: 60vh;
+  max-height: 40vh;
 }
 </style>


### PR DESCRIPTION
## Wat

`wrap` uit #1101 maakte elke lange traceregel zichtbaar, maar CodeMirror begint een doorgelopen regel op **kolom 0**. De trace ontleent zijn hele betekenis aan zijn kolommen, dus zo'n vervolgregel hangt visueel op diepte 0 en snijdt dwars door de boomgoten heen.

Gemeten op `wet_op_de_zorgtoeslag` art. 2, scenario "Meerderjarige met actieve polis": 145 traceregels, waarvan er **1** wrapt (`Resolving from DEFINITION: $GELDIGE_PARTNERTYPEN = [...]`, 304 tekens bij 127 kolommen → 3 visuele regels). Die ene regel breekt de uitlijning van het blok eromheen.

Dus `wrap` er weer af, en in plaats daarvan het probleem opgelost dat de wrap moest maskeren: zonder begrenzing groeide het blok door tot ~3145px, waardoor zijn horizontale scrollbalk ver onder de vouw belandde in de scroller van het sheet. Onvindbaar — precies de klacht die tot #1101 leidde.

## Extra CSS bovenop het design system

Eén declaratie, in de scoped `<style>` van `ExecutionTraceView.vue`:

```css
.etv-trace { max-height: 40vh; }
```

Meer is niet nodig. `nldd-code-viewer` kent geen hoogte-API, maar zijn eigen CodeMirror-theme levert `.cm-editor { height: 100% }` en `.cm-scroller { overflow: auto }` al. `:host { display: flex }` is een rij-container, dus `.code-viewer` rekt op de dwarsas mee tot de geklemde hoogte van de host — daarmee is de hoogte definitief en heeft de 100% van de editor iets om tegen op te lossen. Geen shadow-root-CSS, geen `adoptedStyleSheets`, geen `::part`, geen `!important`.

**40vh en niet meer**, omdat het blok niet bovenaan het scherm begint:

| | 60vh | 40vh |
|---|---|---|
| bovenkant blok | 356px | 356px |
| hoogte | 432px | 288px |
| onderkant | **788px** (68px onder de vouw) | **644px** (76px erboven) |
| viewport | 720px | 720px |

Bij 60vh staat de horizontale scrollbalk dus nog steeds buiten beeld bij eerste weergave — het symptoom van #1101 in het klein. Restbeperking, ook zo in de comment vastgelegd: die 76px marge is ongeveer één extra verwachtingsregel, dus een scenario met een langere verwachtingenlijst vraagt alsnog één korte scroll van het sheet. Tientallen pixels, niet ~2700.

## Shadow-DOM-manipulatie (geen CSS)

De directive `v-trace-scroll-box`. De hoogtebegrenzing maakt het blok verticaal scrollbaar, en `_updateScrollable()` van de component meet alleen `scrollWidth > clientWidth`. Op een trace waarvan alle regels binnen de breedte passen — bij ~20 zichtbare regels is dat niet zeldzaam — blijft het scrollgebied dan zonder `tabindex`/`role`/`aria-label` achter. Gemeten via `Accessibility.getFullAXTree`: geen enkele region op de pagina, dus een schermlezer kondigt niets aan om binnen te gaan (WCAG 2.1.1). Die leemte is door de begrenzing ontstaan, dus die dichten wij:

- `el.translations = { 'components.code-viewer.region-label': 'Execution trace' }` — de publieke knop van de component, geen omweg
- een `MutationObserver` op de shadow-`.code-viewer` plus een `ResizeObserver` op `.cm-scroller`, die `tabindex="0"` / `role="region"` / `aria-label` zetten zolang het blok op **een van beide** assen overloopt

Alleen toevoegend: verwijderen blijft aan het design system, zodat de twee elkaar niet tegenwerken en de observer tot rust komt. `unmounted` koppelt beide observers los.

Beide ingrepen zijn in de code gemarkeerd met de voorwaarde die ze overbodig maakt: een height/rows-property op `nldd-code-viewer` (`nldd-code-editor` heeft `rows` al), en markering op beide assen in `_updateScrollable()`.

## Getest

- **Nieuw: `frontend/e2e/trace-scroll-box.spec.js`** — draait de echte WASM-engine op `wet_op_de_zorgtoeslag` en meet dat het blok begrensd is, dat de onderrand binnen de viewport valt, dat het écht scrollt (`scrollTop` beweegt, dus niet slechts afgekapt) en dat het scrollgebied bereikbaar en aangekondigd is. De unittests kunnen dit niet bewijzen: happy-dom doet geen layout.
- **`ExecutionTraceView.test.js`** (7 tests) — dekt wat unittests wel kunnen bewijzen, inclusief het verticaal-alleen-geval dat de component mist, het opnieuw markeren nadat het design system de attributen weghaalt, en het volgen van de scroller die een re-mount opbouwt
- `npm test`: 68 bestanden, 758 tests groen
- Mutatiegetest: cap terug naar 60vh laat de nieuwe onderrand-assertie falen; `max-height` weghalen laat de e2e falen; `bindScroller` alleen de eerste scroller laten binden laat de re-mount-test falen; de directive uit de fouttak halen laat zijn unittest falen
- Onafhankelijk geverifieerd tegen de gedeployde editor (1600×1000): kader boven 422 / onder 822, scroller 508 zichtbaar op 3093, scrollt tot 2585 verticaal en 1502 horizontaal

Drie rondes `ralph-review` verwerkt; de laatste ronde kwam schoon terug.