### PR TITLE
feat: skill voor statement-registers uit toelichting en uitvoeringsbeleid

### DIFF
--- a/.claude/skills/law-statement-register/SKILL.md
+++ b/.claude/skills/law-statement-register/SKILL.md
@@ -80,10 +80,19 @@ geen pagina-markers — zodat een citaat dat over een paginagrens loopt nog stee
 
 Twee takken, één contract (zelfde bytes in → zelfde tekst uit, geen oordeel):
 
-| Bron | Extractor | Furniture-regel | Pagina's |
+| Bron | Extractor | Furniture-regel | Zijsporen |
 |---|---|---|---|
 | `.pdf` | `pdftotext -layout` | regels die op de meeste pagina's boven-/onderaan terugkomen | `pages.tsv` |
-| `.html` | `scripts/html_canonical.py` (stdlib) | `nav`/`header`/`footer`/`aside`/`script`, en versmallen tot `<main>`/`<article>` | n.v.t. |
+| `.html` | `scripts/html_canonical.py` (stdlib) | `nav`/`header`/`footer`/`aside`/`script`, icoon- en schermlezerlabels (`sr-only`, `visually-hidden`, `icon-label`), en versmallen tot `<main>`/`<article>` | `links.tsv` |
+
+Twee dingen die de HTML-tak expliciet goed doet omdat ze anders stil misgaan:
+
+- **`colspan` telt mee.** Een cel die twee kolommen beslaat moet twee kolomposities
+  opschuiven, anders landt elke waarde erna onder de verkeerde kop — een fout antwoord,
+  geen opmaakdetail. Hetzelfde geldt voor een lege begincel: die blijft als tab staan.
+- **Links gaan naar `links.tsv`, niet de tekst in.** Een hyperlink op *"artikel 8 van de
+  Awir"* is het document dat zélf zegt welke norm het bedoelt — precies wat fase 5
+  reconstrueert. Weggooien is bewijs weggooien; inline zetten sloopt het verbatim citeren.
 
 Bij HTML wijst `--root '#content'` het inhoudsblok aan als de pagina geen `<main>` heeft, en
 laat `--keep-nav` zien wát er anders wegvalt. De HTML-tak bewaart structuur die de tiler nodig

--- a/.claude/skills/law-statement-register/SKILL.md
+++ b/.claude/skills/law-statement-register/SKILL.md
@@ -34,6 +34,37 @@ Het product is een **statement-register**: per statement een verbatim citaat, ee
 vastgelegde verankeringszoektocht, een afwijkingsklasse, een bucket, en een actie of
 jurist-vraag.
 
+## Wanneer je dit pakt, en wat het kost
+
+**Pak het** als er een document naast de wet ligt dat de uitvoering feitelijk stuurt, en je
+wilt weten wat erin staat dat de norm *niet* zegt. Dat is de vraag waar deze skill voor
+bestaat; de dekkingsgaranties zijn er alleen om het antwoord betrouwbaar te maken.
+
+**Pak het niet** als het document zelf een regeling is (verordening, ministeriële regeling,
+beleidsregel met artikelen). Dan is het een norm en loopt het via de gewone harvest-route —
+`law-download` plus `law-generate`.
+
+**Wat je nodig hebt:** het document als lokaal bestand (PDF of HTML), en een corpus met de
+bijbehorende **normteksten**. Zonder dat tweede werkt fase 0–4 wel, maar fase 5 en 6 niet:
+je kunt statements ontginnen en ankeren, maar niet vaststellen of ze in een norm staan — en
+dat is nu juist de bevinding. Een register zonder normcorpus is een nette samenvatting.
+
+**Wat het kost.** De machinerie is minuten; het leeswerk is het werk. Twee gemeten
+voorbeelden:
+
+| Document | Segmenten | Zinnen die het signaalnet raakt |
+|---|---|---|
+| toelichting van 17 pagina's | 34 | 93 |
+| één hoofdstuk uit een uitvoeringshandboek | 59 | 402 |
+
+Elk van die zinnen moet óf een statement worden óf een `disposition` met reden krijgen. Reken
+op een dagdeel voor het eerste soort document en ruim een dag voor het tweede. Dat is de
+prijs van "niets stil overslaan"; er is geen goedkopere variant die dezelfde garantie geeft.
+
+**Wat je krijgt:** een register per statement met bucket en actie, een dekkingscijfer dat een
+lezer kan narekenen, en bij een tweede versie van hetzelfde document een diff die laat zien
+wat er aan beleid veranderde zonder dat een norm veranderde.
+
 ## Kernprincipes
 
 > **De norm is leidend, de secundaire tekst is uitleg.** Een toelichting legt de bedoeling

--- a/.claude/skills/law-statement-register/SKILL.md
+++ b/.claude/skills/law-statement-register/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: law-statement-register
+description: >
+  Mines statements verbatim from secondary legal texts - toelichting, beleidsregel,
+  werkinstructie, handboek, FAQ, circulaire - and turns them into an auditable
+  statement register: per statement a verbatim quote, a recorded search for its
+  anchoring in the norm corpus (verankerd / geparafraseerd / niet-gevonden, with the
+  search terms), a deviation class, and a bucket (MODELFOUT / WETTEKST-GEVOLG /
+  LETTER-vs-TOELICHTING / letter-getrouw / scope). Unlike a law, these documents have
+  no article structure, no version history and no separation between norm and
+  explanation, so the skill constructs all three: a canonical text with a source hash,
+  a 100% tiling of that text, and content-derived statement identity that survives a
+  reissued document. Four runnable gates (verbatim / coverage / anchor / signaalnet)
+  make "nothing was silently skipped" a checkable claim instead of a promise. Has a
+  second mode that diffs two versions of the same document to show what changed in
+  policy without any norm changing. Use when the user mentions uitvoeringsbeleid,
+  beleidsregels, werkinstructies, a toelichting or handbook, "statements ontginnen",
+  a statement register, or wants to know what a new version of a policy document
+  changed.
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob, WebFetch, AskUserQuestion
+user-invocable: true
+---
+
+# Law Statement Register — statements ontginnen uit secundaire teksten
+
+Uitvoeringsbeleid en toelichtingen bepalen in de praktijk hoe een wet uitpakt, maar ze
+missen alles wat een wettekst gratis meelevert: geen artikelstructuur, geen versiebeheer,
+geen citeerbaar URL-fragment, en geen scheiding tussen norm en uitleg. Elke bestaande
+pipeline-skill (`law-download`, `law-generate`, `law-letter-fidelity-audit`,
+`law-version-drift-check`) gaat uit van een gestructureerde, geversioneerde bron. Deze
+skill maakt die structuur zélf, en bewijst daarna mechanisch dat er niets is weggevallen.
+
+Het product is een **statement-register**: per statement een verbatim citaat, een
+vastgelegde verankeringszoektocht, een afwijkingsklasse, een bucket, en een actie of
+jurist-vraag.
+
+## Kernprincipes
+
+> **De norm is leidend, de secundaire tekst is uitleg.** Een toelichting legt de bedoeling
+> uit maar is geen norm. Modelleer de open norm zoals de regeling die stelt; gebruik de
+> toelichting als duiding, nooit als verkapt criterium.
+
+Vier regels die de rest van de methode dragen:
+
+1. **Een statement wordt nooit op eigen gezag een modelwijziging.** Een statement kan
+   hooguit leiden tot een fix *richting de letter*, een rapportage, of een jurist-vraag.
+   Nooit tot `machine_readable` dat de toelichting boven de norm zet. Zie
+   `references/classificatie.md`.
+2. **Uitgestelde relevantie.** Eerst betegelen, dán classificeren. Een lezer die de opdracht
+   "haal de regels eruit" krijgt, laat stil weg; een lezer die "betegel dit document" krijgt,
+   kan dat niet.
+3. **Overslaan mag, stil overslaan niet.** Elk niet-normatief fragment krijgt een expliciete
+   `disposition` mét reden. Elke negatieve verankeringsbevinding krijgt zijn zoektermen.
+4. **Blind her-ontginnen vóór diffen.** Bij een nieuwe versie gaat het vorige register pas
+   ná de nieuwe extractie open — anders erf je elke omissie van de vorige ronde.
+
+## Werkstroom — 7 fasen
+
+```
+0  BEVRIES      bron + sha256 + retrieved_at + documentstatus
+1  CANONISEER   scripts/canonicalize.sh  →  canonical.md + pages.tsv + manifest.yaml
+2  BETEGEL      scripts/tile.py  →  concept-ledger, 100% dekkend    ⟹ gate: coverage
+3  SWEEP        modaliteit-passes: proza · lijst · tabel · voetnoot · kader ·
+                voorbeeld · bijlage/formulier
+4  ANKER        statement = verbatim quote + {exact, prefix, suffix}  ⟹ gates: verbatim, anchor
+5  VERANKER     zoektocht in het norm-corpus, mét zoektermen        (references/verankering.md)
+6  CLASSIFICEER afwijkingsklasse → bucket → actie of jurist-vraag   (references/classificatie.md)
+7  TEGENLEES    signaalnet-audit + drop-pass                        ⟹ gate: signaalnet
+```
+
+**Fase 0 — bevriezen.** Hash de bronbytes. Beleids-PDF's worden op dezelfde URL vervangen
+zonder versiemarkering; de hash is het enige dat "dit register is uit dát document gelezen"
+toetsbaar maakt. Bepaal ook meteen de **documentstatus** — zoek expliciet naar een
+disclaimer ("aan deze toelichting kunnen geen rechten worden ontleend", "dit is een
+werkinstructie"). Eén zin herdefinieert de status van elk statement in het document.
+
+**Fase 1 — canoniseren.** `scripts/canonicalize.sh bron OUTDIR`. Deterministisch, met de
+normalisatie eenmalig en zichtbaar toegepast. `canonical.md` bevat géén ingevoegde tekens —
+geen pagina-markers — zodat een citaat dat over een paginagrens loopt nog steeds verbatim is.
+
+Twee takken, één contract (zelfde bytes in → zelfde tekst uit, geen oordeel):
+
+| Bron | Extractor | Furniture-regel | Pagina's |
+|---|---|---|---|
+| `.pdf` | `pdftotext -layout` | regels die op de meeste pagina's boven-/onderaan terugkomen | `pages.tsv` |
+| `.html` | `scripts/html_canonical.py` (stdlib) | `nav`/`header`/`footer`/`aside`/`script`, en versmallen tot `<main>`/`<article>` | n.v.t. |
+
+Bij HTML wijst `--root '#content'` het inhoudsblok aan als de pagina geen `<main>` heeft, en
+laat `--keep-nav` zien wát er anders wegvalt. De HTML-tak bewaart structuur die de tiler nodig
+heeft: koppen op een eigen regel, lijstitems met `- `, tabelrijen tab-gescheiden.
+
+Een webbron moet **lokaal opgeslagen** zijn. Een pagina die via een tussenlaag is opgehaald en
+samengevat is geen bron: er is dan niets om te hashen en niets om te herhalen.
+
+**Fase 2 — betegelen.** `python3 scripts/tile.py canonical.md > statements.yaml` knipt de
+segmenten uit de tekst zelf, langs de eigen nummering van het document. Dekking van 100% is
+dan een eigenschap van de constructie in plaats van handwerk — en daarmee geen klus die je
+gaat afsnijden. Het script beslist niets: alles komt eruit als `normative` zonder statements.
+
+Daarna is het leeswerk: niet-normatieve delen krijgen
+`disposition: informative | navigational | duplicate | non-textual` met reden.
+Inhoudsopgaven zijn `navigational`, colofons `informative`, een beslisboom-plaatje
+`non-textual` (nooit stil OCR-en en dat verbatim noemen — laat transcriberen en markeer dat).
+
+**Fase 3 — sweep.** Loop elk segment af per modaliteit. Eén lineaire lees-pass verliest
+systematisch tabelcellen, voetnoten en "let op"-kaders — juist de plekken waar de
+uitzondering staat. Bij een tabel: de tabel is één segment, elke zelfstandig normerende rij
+is één statement met de kolomkop in de `prefix`.
+
+**Fase 4 — ankeren.** Het citaat is verbatim; het anker is `{exact, prefix, suffix}` in de
+vorm van RFC-005 (`docs/src/content/rfcs/rfc-005.md`). Kies de kortste span die zelfstandig
+leesbaar is, en neem bij een opsomming de **aanhef** mee — een los onderdeel "b. ..." zonder
+chapeau is betekenisloos en is een klassieke bron van verkeerde modellering.
+
+**Fase 5 — verankeren.** Zoek per statement in het norm-corpus van het dossier en leg vast:
+`verankerd` (mét norm-citaat en vindplaats), `geparafraseerd` (beide teksten naast elkaar),
+of `niet-gevonden` (**mét de gebruikte zoektermen**). Die laatste eis is niet cosmetisch: de
+`niet-gevonden`-statements worden de jurist-vragen, en een negatieve bevinding die niemand
+kan overdoen is geen bevinding.
+
+**Fase 6 — classificeren.** Bucket + twee assen die wetteksten niet nodig hebben:
+**bindendheid** (`hard` / `soft-default` / `guidance` / `informative`) en **documentstatus**.
+"In de regel drie maanden" als harde drie maanden modelleren is een fideliteitsfout, geen
+detail — het neemt de afwijkbevoegdheid weg.
+
+**Fase 7 — tegenlezen.** Draai het signaalnet en beantwoord één vraag: *wat is er
+weggevallen?* Elke ongedekte treffer is óf een gemist statement óf een ontbrekende
+`disposition`.
+
+## De vier gates
+
+```bash
+python3 scripts/statement_gates.py all --canonical canonical.md --ledger statements.yaml
+python3 scripts/statement_gates.py explain      # toont de enige toegestane normalisatie
+```
+
+| Gate | Toetst | Vangt |
+|---|---|---|
+| `verbatim` | elk citaat is letterlijk een substring van `canonical.md` | parafrase, opgeschoonde weglating, overgetypt citaat, negatieve bevinding zonder zoektermen |
+| `coverage` | de segmenten betegelen `canonical.md` volledig | ongedekt fragment (met de eerste 80 tekens), disposition zonder reden |
+| `anchor` | elk `{prefix, exact, suffix}` resolvet uniek | ORPHANED (0 treffers) en AMBIGUOUS (>1) — beide onbruikbaar voor de diff |
+| `signaalnet` | elke normzin in een `normative` segment is gedekt | stil overgeslagen norm |
+
+Exit-code is het contract: 0 = schoon, 1 = bevindingen. `tests/run.sh` bewijst op een
+synthetische fixture dat elke gate zijn eigen defect pakt.
+
+Het signaalnet-lexicon staat in `references/signaalnet.md` en is te vervangen met
+`--lexicon`. Het is bewust ruw: liever een inhoudsopgave-regel als treffer (die je
+wegdisponeert) dan een gemiste uitzondering.
+
+## Modus 2 — versie-diff
+
+Bij een nieuwe versie van hetzelfde document is de diff het interessantste product: hij laat
+zien wat er aan **beleid** veranderde zonder dat een norm veranderde. Zie
+`references/diff.md`. Verkort:
+
+1. Her-ontgin het nieuwe document **blind** (fasen 0–7, vorige register dicht).
+2. Resolveer elk anker van v1 tegen `canonical(v2)`: exact → `unchanged` · fuzzy boven de
+   drempel → `reworded` · geen match → `candidate-removed`.
+3. Match de v2-statements op v1 via anker en slug; wat overblijft is `added`.
+4. Elke `reworded` krijgt een strekking-oordeel: `same-strekking` (redactioneel) of
+   `changed-strekking` (norm-relevant) — de tweede altijd met menselijke bevestiging.
+
+Statement-identiteit is gelaagd: een inhoud-afgeleide **slug** (`tweede-vrijlating-50pct`) is
+de sleutel, `S<n>` is alleen een weergavenummer, en het anker is het zoekmiddel. Nooit
+paginanummer of volgnummer als identiteit — een herzette PDF verschuift alles.
+
+## Bestanden
+
+**references/** — `classificatie.md` (buckets, afwijkingsklassen, bindendheid,
+documentstatus) · `signaalnet.md` (het lexicon + verantwoording) · `verankering.md` (de
+zoektocht en hoe je hem vastlegt) · `diff.md` (modus 2).
+
+**templates/** — `register.md`, het registersjabloon.
+
+**scripts/** — `canonicalize.sh` (bron → canonical.md + pages.tsv + manifest.yaml; PDF- en
+HTML-tak) · `html_canonical.py` (de HTML-lezer, stdlib) · `tile.py` (fase 2: concept-ledger,
+100% dekkend by construction) · `statement_gates.py` (de vier gates).
+
+**tests/** — synthetische fixture met vijf opzettelijke defecten + `run.sh`; zie
+`tests/README.md`.
+
+## Waar de output landt
+
+- **Werkbestanden** (`canonical.md`, `pages.tsv`, `manifest.yaml`, `statements.yaml`,
+  `coverage-report.md`) zijn scratch. Ze horen niet in een corpus-repo.
+- **Het register** (`templates/register.md`) landt in het dossier, naast de andere
+  audit-producten van de sessie.
+- **Bronbestanden blijven waar het dossier ze bewaart.** Haal nooit een dossier-document,
+  citaat of registerinhoud naar een publieke repo. De fixture in `tests/` is verzonnen en
+  moet dat blijven.
+
+## Belangrijke regels
+
+- **Classificeer nooit vóór je betegeld hebt.** De volgorde is de garantie.
+- **Een `niet-gevonden` zonder zoektermen is geen bevinding.** De gate dwingt dit af.
+- **Toelichting-statements worden geen `machine_readable`.** Wie een FAQ-antwoord van
+  executielogica voorziet, heeft de toelichting tot norm gepromoveerd. Als een statement
+  volgens de jurist bindend beleid is, hoort het in de regeling — dát is de aanbeveling,
+  niet een modelwijziging.
+- **Niets committen zonder toestemming**, in geen enkele repo.
+- Zusterskills: `law-letter-fidelity-audit` (dezelfde buckets, maar per wetsartikel in plaats
+  van per beleidsdocument), `law-mvt-research` (rekenvoorbeelden → Gherkin),
+  `regelrecht-stelselanalyse` (waar de bevindingen in de 4-weg-classificatie landen).

--- a/.claude/skills/law-statement-register/SKILL.md
+++ b/.claude/skills/law-statement-register/SKILL.md
@@ -136,13 +136,22 @@ python3 scripts/statement_gates.py explain      # toont de enige toegestane norm
 
 | Gate | Toetst | Vangt |
 |---|---|---|
+| `ledger` | het vocabulaire: `disposition`, `anchoring.status`, `type`, `bindingness`, `bucket`, `deviation_class` | een waarde buiten de lijst — inclusief een typefout die een regel stil uitschakelt |
 | `verbatim` | elk citaat is letterlijk een substring van `canonical.md` | parafrase, opgeschoonde weglating, overgetypt citaat, negatieve bevinding zonder zoektermen |
 | `coverage` | de segmenten betegelen `canonical.md` volledig | ongedekt fragment (met de eerste 80 tekens), disposition zonder reden |
 | `anchor` | elk `{prefix, exact, suffix}` resolvet uniek | ORPHANED (0 treffers) en AMBIGUOUS (>1) — beide onbruikbaar voor de diff |
 | `signaalnet` | elke normzin in een `normative` segment is gedekt | stil overgeslagen norm |
 
-Exit-code is het contract: 0 = schoon, 1 = bevindingen. `tests/run.sh` bewijst op een
-synthetische fixture dat elke gate zijn eigen defect pakt.
+**`ledger` draait bij élke aanroep**, ook bij een losse gate. De andere gates sleutelen op
+exact deze strings — het is `status == "niet-gevonden"` dat de zoektermen eist — dus een
+ledger die `nietgevonden` schrijft zet die regel uit en houdt drie groene gates over. Een
+vocabulaire dat alleen door spelling wordt gehandhaafd, wordt niet gehandhaafd.
+
+Exit-code is het contract: 0 = schoon, 1 = bevindingen. `canonicalize.sh` en `tile.py`
+gebruiken daarnaast **3** voor "buiten het getoetste bereik": een PDF zonder tekstlaag, of
+een betegeling die op één groot blok uitkomt. Die weigeren liever dan een leeg of
+misleidend-groen resultaat af te leveren. `tests/run.sh` bewijst op een synthetische fixture
+dat elke gate zijn eigen defect pakt.
 
 Het signaalnet-lexicon staat in `references/signaalnet.md` en is te vervangen met
 `--lexicon`. Het is bewust ruw: liever een inhoudsopgave-regel als treffer (die je

--- a/.claude/skills/law-statement-register/references/classificatie.md
+++ b/.claude/skills/law-statement-register/references/classificatie.md
@@ -1,0 +1,97 @@
+# Classificatie — buckets, afwijkingsklassen, bindendheid, documentstatus
+
+Elk statement krijgt precies één bucket. Het label bepaalt de actie, en een verkeerd label
+kost een ronde: een jurist-vraag die als "fix" in een fixes-plan belandt, wordt uitgevoerd
+zonder dat iemand hem heeft beslist.
+
+## De buckets
+
+Overgenomen uit `law-letter-fidelity-audit`, zodat een bevinding uit een beleidsdocument en
+een bevinding uit een wetsartikel in dezelfde taal landen.
+
+| Bucket | Betekenis | Actie |
+|---|---|---|
+| **MODELFOUT** | het model wijkt af van de letter van de norm | fix richting de letter |
+| **WETTEKST-GEVOLG** | het model volgt de letter getrouw, maar de letter geeft een vreemde of onbedoelde uitkomst | rapporteren, **niet** fixen |
+| **LETTER-vs-TOELICHTING** | de secundaire tekst zegt iets dat de norm niet zegt | jurist beslist wat leidend is + wetgevings-signaal |
+| **letter-getrouw** ✅ | statement en model dekken de norm | geen wijziging |
+| **scope** | het statement gaat over iets dat bewust niet gemodelleerd is | beslisvraag, geen fix |
+
+**De scherpste grens is MODELFOUT ↔ LETTER-vs-TOELICHTING.** Beide zien eruit als "het model
+klopt niet met wat hier staat". Het onderscheid is de bron van de eis:
+
+> Staat de eis in de **norm** en niet in het model → MODELFOUT.
+> Staat de eis in de **toelichting** en niet in de norm → LETTER-vs-TOELICHTING, en het
+> model is *goed zoals het is*.
+
+Die tweede is contra-intuïtief en wordt daarom stelselmatig verkeerd geklasseerd: het lijkt
+alsof je een gat dicht, terwijl je de toelichting boven de wet zet. De verankeringszoektocht
+(`verankering.md`) bestaat om precies deze twee uit elkaar te houden — zonder die zoektocht
+kún je het onderscheid niet maken, en dan wordt alles een "fix".
+
+## Afwijkingsklassen
+
+De klasse beschrijft *hoe* het statement en de norm uiteenlopen; de bucket beschrijft *wat
+je ermee doet*.
+
+| Klasse | Symptoom |
+|---|---|
+| `toelichting-bleed` | een criterium dat alleen in de secundaire tekst staat; de norm stelt het niet of alleen als open norm |
+| `ontbrekend-bestanddeel` | de norm bevat een kwalificatie ("uitsluitend", "tijdelijk", een "tenzij") die het statement of het model laat vallen |
+| `verkeerde-verankering` | het statement is opgehangen aan een kapstok-artikel terwijl de operatieve norm elders staat |
+| `herformulering` | het statement zegt hetzelfde als de norm in andere woorden (spiegelzijde, samenvatting) |
+| `bindendheid-vervlakking` | een `soft-default` uit de tekst is als harde regel overgenomen (of omgekeerd) |
+| `buitenwettelijk` | de secundaire tekst is strenger of ruimer dan de norm toestaat |
+| `geen` | geen afwijking |
+
+`buitenwettelijk` is de klasse die je nooit stil mag laten passeren. Beleid dat de wet
+inperkt of oprekt is geen modelleerdetail maar een bevinding voor het stelsel; hij landt in
+`regelrecht-stelselanalyse` als wetgevings-/beleidssignaal.
+
+## Bindendheid
+
+De as die wetteksten niet nodig hebben. Uitvoeringsbeleid mengt harde regels met vuistregels
+in dezelfde alinea, en het verschil verdwijnt zodra je het modelleert.
+
+| Waarde | Herkenning | Gevolg voor modellering |
+|---|---|---|
+| `hard` | onvoorwaardelijk geformuleerd | mag als regel |
+| `soft-default` | "in de regel", "in beginsel", "doorgaans", "als hoofdregel" | weerlegbare hoofdregel: modelleer mét de afwijkgrond, of markeer als untranslatable |
+| `guidance` | "wij adviseren", "het verdient aanbeveling", werkadvies aan de behandelaar | geen regel |
+| `informative` | uitleg, servicetekst, voorbeeld | geen regel |
+
+*"In de regel ten hoogste 1.200 euro"* als hard maximum modelleren neemt de
+afwijkbevoegdheid weg die de tekst juist geeft. Dat is een fideliteitsfout in het nadeel van
+de burger, en hij is onzichtbaar in tests: de gemiddelde casus komt er niet aan.
+
+## Documentstatus
+
+Bepaal in fase 0, geldt voor het hele document, en overschrijft de bindendheid van elk
+statement erin.
+
+| Status | Juridisch | Praktisch |
+|---|---|---|
+| `beleidsregel` | Awb 4:81: bindt het bestuursorgaan; afwijken vergt motivering (4:84) | statements zijn norm-achtig |
+| `verordening/regeling` | zelfstandige norm | dit is geen secundaire tekst — gebruik de gewone harvest-route |
+| `toelichting` | geen norm | statements zijn uitleg |
+| `werkinstructie` / `handboek` | formeel geen norm; feitelijk sturend, en via het vertrouwens- en gelijkheidsbeginsel alsnog relevant | statements zijn praktijk-bewijs, geen norm |
+| `faq` / `voorlichting` | geen norm | statements zijn uitleg, vaak vereenvoudigd |
+
+Zoek expliciet naar de disclaimerzin. Eén regel als *"Deze toelichting is informatief, u kunt
+er geen rechten aan ontlenen"* bepaalt de status van elk statement in het document en hoort
+als eerste statement in het register, ook al is hij zelf `informative`.
+
+## Van register naar vervolg
+
+- **MODELFOUT** → modellering-fixes-plan (`regelrecht-stelselanalyse` klasse 1).
+- **LETTER-vs-TOELICHTING** → jurist-vraag én wetgevings-signaal: als het beleid bindend is,
+  hoort het in de regeling, niet in de toelichting. Dat is de aanbeveling — niet een
+  modelwijziging.
+- **WETTEKST-GEVOLG** → wetgevings-fouten-analyse (klasse 2).
+- **buitenwettelijk** → beleid-vs-wet-conflict; behandel als klasse 2 met de aantekening dat
+  de conflictbron het beleid is, niet de wet.
+- **scope** → beslisvraag voor de workshop (`regelrecht-audit-products`).
+
+Een statement gaat nooit rechtstreeks naar `machine_readable`. Als een `niet-gevonden`
+statement volgens de jurist bindend beleid is, is de uitkomst een wijziging van de
+*regeling*, en pas daarna van het model.

--- a/.claude/skills/law-statement-register/references/diff.md
+++ b/.claude/skills/law-statement-register/references/diff.md
@@ -1,0 +1,115 @@
+# Modus 2 — de versie-diff
+
+Een beleidsdocument wordt herzien zonder dat er een norm verandert. De diff tussen twee
+registers laat zien wat er dan feitelijk is gewijzigd: welke uitspraken zijn toegevoegd,
+verdwenen, of van strekking veranderd. Dat is het beleid dat verschoof buiten het zicht van
+elk versiebeheer om.
+
+## De regel die de diff bruikbaar maakt
+
+> **Her-ontgin blind.** Verwerk het nieuwe document volledig (fasen 0–7) zonder het vorige
+> register open te hebben. Pas daarna matchen.
+
+De verleiding is het vorige register langs te lopen en per statement te kijken wat er in de
+nieuwe versie van geworden is. Dat is sneller en het is fout: je erft elke omissie van de
+vorige ronde, en "toegevoegd" betekent dan niet *nieuw in het document* maar *ditmaal wel
+opgemerkt*. De hele waarde van de categorie `added` staat of valt hiermee.
+
+Praktisch: doe de nieuwe extractie in een aparte werkmap, en open het oude register pas bij
+stap 2 hieronder.
+
+### Wél meteen: de mechanische tekst-diff
+
+De blind-regel geldt voor de **register**-diff, niet voor een `diff` van de twee
+`canonical.md`-bestanden. Dat is een ander soort ding: hij is *compleet by construction* —
+elk gewijzigd teken staat erin, hij kan niets missen, en hij bevat geen enkel oordeel. Draai
+hem dus gerust als eerste; hij vertelt je hoe groot de klus is.
+
+```bash
+diff -u v1/canonical.md v2/canonical.md
+```
+
+Twee dingen om te weten:
+
+- **Hij vervangt het her-ontginnen niet.** Als het vorige register maar een deel van het
+  document dekte, moet v2 alsnog volledig gelezen worden — anders meet je de vorige ronde.
+- **Hij is de scherpste test op de dekking van het vorige register.** Vallen de gewijzigde
+  regels buiten élk statement van v1, dan zou een register-diff "niets veranderd" hebben
+  gezegd terwijl het document wél wijzigde. Dat is geen theoretisch geval: een halfjaarlijks
+  geïndexeerde normbedragen-bijlage is precies zo'n sectie — hoog wijzigingstempo, laag
+  leestempo, en daardoor stelselmatig het eerste wat een selectieve lezer overslaat.
+
+## Statement-identiteit
+
+Gelaagd, omdat elke laag iets anders overleeft:
+
+| Laag | Rol | Overleeft |
+|---|---|---|
+| `slug` | de sleutel (`tweede-vrijlating-50pct`) | herformulering, herordening, hernummering |
+| `anchor` | het zoekmiddel (`{exact, prefix, suffix}`) | verplaatsing binnen het document |
+| `S<n>` | weergavenummer in één register | niets — puur presentatie |
+
+Nooit paginanummer of volgnummer als identiteit: een herzette PDF verschuift alles.
+
+De slug wordt bij de eerste registratie toegekend en daarna **overgedragen**, niet opnieuw
+bedacht. Een statement dat in v2 anders is geformuleerd maar dezelfde uitspraak doet, houdt
+zijn slug — anders leest de diff als "verdwenen + toegevoegd" terwijl er een zin is herschreven.
+
+## Het algoritme
+
+1. **Her-ontgin v2 blind.** Volledig register, eigen gates, eigen dekkingscijfers.
+
+2. **Resolveer v1-ankers tegen `canonical(v2)`.** Per v1-statement:
+
+   | Uitkomst | Categorie |
+   |---|---|
+   | exacte treffer van `prefix+exact+suffix` | `unchanged` |
+   | geen exacte treffer, fuzzy score ≥ drempel | `reworded` |
+   | niets boven de drempel | `candidate-removed` |
+
+   Voor fuzzy matching geldt de RFC-005-methode (`docs/src/content/rfcs/rfc-005.md`):
+   gewogen Levenshtein-similarity `exact × 0,5 + prefix × 0,25 + suffix × 0,25`, drempel 0,7.
+   De engine heeft die resolver al (`packages/engine/src/annotation/resolver.rs`); gebruik
+   hem in plaats van een tweede implementatie te schrijven.
+
+3. **Match v2 op v1** via slug en anker. Elk v2-statement zonder tegenhanger is `added`.
+
+4. **Oordeel de `reworded`.** Twee mogelijkheden, en het onderscheid is niet mechanisch:
+
+   - `same-strekking` — redactionele herschrijving. Zelfde eis, andere woorden.
+   - `changed-strekking` — de uitspraak zelf is veranderd: een ander bedrag, een andere
+     termijn, een verdwenen "tenzij", een `hard` die `soft-default` is geworden of andersom.
+
+   Een `changed-strekking` krijgt **altijd** menselijke bevestiging en is **altijd** een
+   bevinding, ook als het model niet verandert. Let in het bijzonder op de bindendheid: een
+   zin die van *"bedraagt ten hoogste"* naar *"bedraagt in de regel ten hoogste"* gaat, ziet
+   er als tekstwijziging onbeduidend uit en verandert de norm die je modelleert.
+
+5. **Beoordeel `candidate-removed` met de hand.** Een verdwenen statement is óf geschrapt
+   beleid, óf verplaatst naar een ander document, óf het anker was te specifiek. Alleen de
+   eerste is een bevinding; de derde is een defect in het vorige register en hoort daar
+   gerepareerd te worden.
+
+## Wat de diff oplevert
+
+Per categorie een tabel met slug, beide citaten en het oordeel. De vier die ertoe doen:
+
+- **`added` met bucket LETTER-vs-TOELICHTING** — nieuw beleid dat geen normgrondslag heeft.
+  Het sterkste signaal dat de diff kan geven: beleid dat is aangescherpt zonder dat de
+  regeling meebewoog.
+- **`candidate-removed` met bucket letter-getrouw** — een uitleg die is weggehaald terwijl de
+  norm bleef. Vaak een teken dat de praktijk is veranderd.
+- **`changed-strekking` op een kwantiteit** — bedrag of termijn gewijzigd; controleer of het
+  model die waarde hardcodeert.
+- **`changed-strekking` op bindendheid** — de stilste van allemaal.
+
+Noteer ook wat er *niet* veranderde: een statement dat in beide versies `niet-gevonden` is,
+is een jurist-vraag die een herziening lang heeft overleefd. Dat is zelf een bevinding.
+
+## Dekkingsvergelijking
+
+Zet de dekkingscijfers van beide registers naast elkaar (% betegeld, aantal
+signaalnet-treffers, aantal statements, aantal disposities). Springt het aantal statements
+omhoog terwijl het document niet groeide, dan meet je niet het document maar de vorige
+ronde — zeg dat dan ook zo in het register, in plaats van het als beleidswijziging te
+presenteren.

--- a/.claude/skills/law-statement-register/references/signaalnet.md
+++ b/.claude/skills/law-statement-register/references/signaalnet.md
@@ -1,0 +1,71 @@
+# Het signaalnet — de recall-net achter "niets overslaan"
+
+Het signaalnet is een set deterministische detectoren over `canonical.md`, onafhankelijk van
+de lezer. Elke zin die het net raakt moet gedekt zijn door een statement, óf in een segment
+staan met een niet-normatieve `disposition`. Alles wat overblijft is een stil overgeslagen
+norm, en dat is een gate-failure.
+
+Het net vervangt de lezer niet — het controleert hem. Een lezer die "haal de regels eruit"
+krijgt, laat weg wat hij niet interessant vindt, en niemand kan achteraf zien wát. Het net
+maakt die weglating zichtbaar zonder te oordelen of het weggelatene relevant was.
+
+## Waarom het bewust ruw is
+
+Het net kent geen grammatica en geen context. Een inhoudsopgave-regel "2.1 Wie kan er een
+aanvraag indienen?" is een treffer, omdat er "kan" in staat. Dat is geen bug: die
+treffer kost je één regel in het register (`disposition: navigational`), terwijl een gemiste
+uitzondering in een voetnoot je een verkeerd model kost. De asymmetrie is de ontwerpkeuze.
+
+Verwacht daarom veel treffers en veel disposities. Op een toelichting van 17 pagina's is
+ruwweg honderd treffers over enkele tientallen zinnen normaal.
+
+## Het lexicon
+
+| Categorie | Waarom | Patroon (regex, case-insensitive) |
+|---|---|---|
+| `deontisch` | draagt de verplichting, het recht of de bevoegdheid — de kern van elke norm | `moet(en)?`, `dient/dienen`, `verplicht`, `mag/mogen`, `kan/kunnen`, `wordt geacht`, `bevoegd`, `recht op`, `in aanmerking` |
+| `conditioneel` | markeert de voorwaarde of de uitzondering; "tenzij" is de klassieke weglating | `indien`, `tenzij`, `mits`, `voor zover`, `behoudens`, `met dien verstande`, `wanneer` |
+| `zachtheid` | markeert een `soft-default` of discretie; wordt anders als harde regel gemodelleerd | `in beginsel`, `in de regel`, `doorgaans`, `zoveel mogelijk`, `naar oordeel van`, `maatwerk`, `bijzondere omstandigheden`, `schrijnend` |
+| `kwantiteit` | bedragen, percentages en termijnen zijn de meest modelleerbare én meest verouderende statements | `€ n`, `n%`, `n (euro\|procent\|dagen\|weken\|maanden\|jaar)` |
+| `definitie` | een begripsbepaling in een beleidsstuk stuurt de uitleg van de norm | `wordt verstaan onder`, `geldt als`, `hieronder valt`, `wordt aangemerkt als` |
+| `verwijzing` | koppelt het statement aan een norm of een ander document; bron voor de verankering | `artikel n`, `bijlage x`, `zie hoofdstuk/paragraaf/artikel` |
+
+De canonieke definitie staat in `scripts/statement_gates.py` (`DEFAULT_LEXICON`); deze tabel
+legt uit waaróm elke categorie er staat.
+
+## Uitbreiden
+
+```bash
+python3 scripts/statement_gates.py signaalnet \
+    --canonical canonical.md --ledger statements.yaml --lexicon mijn-lexicon.yaml
+```
+
+Het bestand is een platte `naam: regex`-mapping en **vervangt** het standaardnet, dus neem
+de standaardcategorieën over als je alleen wilt aanvullen.
+
+Domein-uitbreidingen die zich in de praktijk lonen:
+
+```yaml
+bewijs: '\b(overleggen|aantonen|bewijsstuk|kopie|verklaring|formulier)\b'
+actor: '\b(college|dagelijks bestuur|behandelaar|ambtenaar|aanvrager|belanghebbende)\b'
+sanctie: '\b(niet in behandeling|afgewezen|buiten behandeling|terugvordering|boete)\b'
+temporeel: '\b(peildatum|met ingang van|met terugwerkende kracht|vervalt)\b'
+```
+
+Voeg een categorie toe zodra je in de tegenlees-pass een gemist statement vindt dat het
+bestaande net niet had kunnen vangen. Dat is de enige groeiregel die je nodig hebt: het net
+groeit door zijn eigen misses, niet door voorspelling.
+
+## Wat het net niet ziet
+
+Drie blinde vlekken die je met de hand moet afdekken; noteer ze in de tegenlees-pass:
+
+1. **Normen zonder signaalwoord.** *"De aanvraag gaat vergezeld van de laatste drie
+   loonstroken."* Geen modaal werkwoord, wel een harde eis. De `bewijs`-uitbreiding hierboven
+   vangt dit; zonder die uitbreiding niet.
+2. **Tabellen.** Een normbedragen-tabel bevat de kwantiteiten in cellen zonder zin. Het net
+   ziet de getallen wel maar de zinsafbakening klopt niet, waardoor één treffer een halve
+   tabel als "zin" rapporteert. Behandel tabellen in de sweep als aparte modaliteit.
+3. **Afbeeldingen en beslisbomen.** Tekst in een plaatje staat niet in `canonical.md` en is
+   voor het net onzichtbaar. Markeer zulke segmenten `non-textual` met een reden, en laat de
+   inhoud met de hand transcriberen — nooit stil OCR-en en dat verbatim noemen.

--- a/.claude/skills/law-statement-register/references/verankering.md
+++ b/.claude/skills/law-statement-register/references/verankering.md
@@ -42,6 +42,14 @@ formulering). Als de secundaire tekst een eis toevoegt die de norm niet stelt, i
      - '!regulation/**/uitvoeringsbeleid/**'   # de geanalyseerde tekst zelf
    ```
 
+   **Bij een HTML-bron: begin bij `links.tsv`.** Uitvoeringsteksten linken hun eigen
+   verwijzingen vaak rechtstreeks naar `wetten.overheid.nl`, mét BWB-ID en artikelanker. Dat
+   is de auteur die zegt welke norm hij bedoelt — je hoeft het niet te raden. Maar het is een
+   *claim*, geen bewijs: een link kan naar een kapstok-artikel wijzen terwijl de operatieve
+   norm elders staat, of naar een inmiddels gewijzigde versie. Gebruik hem als eerste spoor
+   en verifieer alsnog in de normtekst; noteer de link als `norm_ref`-kandidaat, niet als
+   uitkomst.
+
 2. **Zoek op meerdere formuleringen, niet op één.** Een norm gebruikt zelden het woord van de
    toelichting. Werk minstens drie sporen af:
    - de **kernterm** uit het statement (*"vrijlating"*)

--- a/.claude/skills/law-statement-register/references/verankering.md
+++ b/.claude/skills/law-statement-register/references/verankering.md
@@ -1,0 +1,91 @@
+# De verankeringszoektocht
+
+Per statement: staat wat hier beweerd wordt óók in een norm? Het antwoord bepaalt de bucket,
+en het is het enige onderdeel van de methode waar een *negatief* resultaat het waardevolste
+resultaat is — de `niet-gevonden`-statements worden de jurist-vragen.
+
+Daarom de harde eis: **een negatieve bevinding zonder vastgelegde zoektermen is geen
+bevinding.** De verbatim-gate weigert een `niet-gevonden` zonder `search_terms`. Zonder die
+termen kan niemand de zoektocht overdoen, en "ik kon het niet vinden" is dan niet te
+onderscheiden van "ik heb slecht gezocht".
+
+## De drie uitkomsten
+
+| Status | Betekenis | Verplicht vast te leggen |
+|---|---|---|
+| `verankerd` | de normtekst stelt het | `norm_ref` (vindplaats) + `norm_quote` (verbatim) |
+| `geparafraseerd` | de norm zegt iets aangrenzends in andere woorden | `norm_ref` + `norm_quote`, zodat beide teksten naast elkaar staan |
+| `niet-gevonden` | geen normtekst bevat het | `search_terms` + `searched_in` |
+
+`geparafraseerd` is geen tussencategorie voor twijfel. Gebruik hem als de norm *dezelfde*
+eis stelt in andere bewoordingen (een spiegelzijde, een samenvatting, een ruimere
+formulering). Als de secundaire tekst een eis toevoegt die de norm niet stelt, is het
+`niet-gevonden` — ook al gaat de norm over hetzelfde onderwerp. Dat verschil is precies wat
+`toelichting-bleed` van `herformulering` scheidt.
+
+## Werkwijze
+
+1. **Bepaal de zoekruimte** en leg hem vast in `searched_in`: welke regelingen, welke paden.
+   Neem de hele keten mee — de rijksregeling, de lagere regeling én de gemeentelijke of
+   waterschapsregeling. Een statement dat in de verordening niet staat, staat soms in de
+   uitvoeringsregeling erboven.
+
+   **Sluit het document dat je analyseert uit van de zoekruimte.** Secundaire teksten staan
+   vaak zélf in het corpus (een toelichting als `regulatory_layer: UITVOERINGSBELEID`). Zoek
+   je zonder uitsluiting, dan vindt de grep het statement terug in zijn eigen bron en label je
+   `verankerd` waar `niet-gevonden` hoort — precies de fout die de hele methode moet
+   voorkomen. Noteer de uitsluiting in `searched_in`:
+
+   ```yaml
+   searched_in:
+     - regulation/**/*.yaml
+     - '!regulation/**/uitvoeringsbeleid/**'   # de geanalyseerde tekst zelf
+   ```
+
+2. **Zoek op meerdere formuleringen, niet op één.** Een norm gebruikt zelden het woord van de
+   toelichting. Werk minstens drie sporen af:
+   - de **kernterm** uit het statement (*"vrijlating"*)
+   - het **getal of de eenheid** los (*"50"*, *"50%"*, *"vijftig"*)
+   - het **wettelijke synoniem** (*"aangewend"*, *"aanwending"*, *"buiten beschouwing"*)
+
+   Getallen zijn het betrouwbaarste spoor: normen schrijven ze soms voluit (*"ten minste
+   tachtig percent"*), dus zoek beide vormen.
+
+3. **Zoek in de verbatim `text:`-velden, niet in `machine_readable`.** Het model is precies
+   wat je toetst; als je erin zoekt bevestig je je eigen aanname. Beperk daarom tot de
+   normtekst:
+
+   ```bash
+   grep -rn --include='*.yaml' -i -e 'vrijlat' -e 'aangewend' -e '80 percent' regulation/
+   ```
+
+4. **Leg de uitkomst vast, ook als hij negatief is.** De zoektermen die *niets* opleverden
+   horen er net zo goed in als de term die wel raak was.
+
+## Vastleggingsformaat
+
+```yaml
+anchoring:
+  status: niet-gevonden
+  search_terms: ['50%', 'vijftig procent', 'vrijlating', 'vrijgelaten', 'aangewend']
+  searched_in: ['regulation/nl/**/*.yaml', 'regulation/local/**/*.yaml']
+```
+
+```yaml
+anchoring:
+  status: verankerd
+  norm_ref: fictieve_verordening art 3 lid 1
+  norm_quote: ten minste 80 percent van het besteedbaar inkomen is aangewend
+```
+
+Bij `verankerd` en `geparafraseerd` is het norm-citaat verbatim uit de normtekst. Dat maakt
+de vergelijking in het register controleerbaar zonder dat de lezer twee bestanden hoeft open
+te slaan — en het legt meteen bloot wanneer "verankerd" eigenlijk "geparafraseerd" was.
+
+## De valkuil
+
+De verleiding is om na een korte zoektocht `niet-gevonden` te noteren en het statement als
+MODELFOUT te classificeren, omdat "het model dit niet doet". Dat is de omkering: als het niet
+in de norm staat, is het model **goed** en is het statement een jurist-vraag. Elke
+`niet-gevonden` die je als MODELFOUT labelt, zet de toelichting boven de wet. Zie
+`classificatie.md`.

--- a/.claude/skills/law-statement-register/scripts/canonicalize.sh
+++ b/.claude/skills/law-statement-register/scripts/canonicalize.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Canonicalize a secondary-text source (PDF) into the evidence set the whole
+# register anchors on. Deterministic: same bytes in, same canonical.md out.
+#
+# Writes three files next to each other in OUTDIR:
+#   canonical.md  - pure reading text. NO page markers, NO injected characters:
+#                   every anchor in the register must be a literal substring of
+#                   this file, including quotes that run across a page break.
+#   pages.tsv     - page -> character offset in canonical.md, so a statement can
+#                   still be cited as "(p13)" without polluting the text.
+#   manifest.yaml - sha256 of the source bytes, sha256 of canonical.md, the
+#                   retrieval date and which normalization steps ran.
+#
+# The source hash is the point: policy PDFs get replaced at the same URL without
+# any version marker, so the hash is the only thing that makes "this register was
+# read from that document" a checkable claim.
+#
+# Usage: canonicalize.sh SOURCE OUTDIR [--retrieved YYYY-MM-DD] [--root SELECTOR]
+#        SOURCE is a .pdf, or a locally saved .html/.htm
+#
+# For an HTML source there are no pages, so no pages.tsv is written; --root
+# passes a content-block id/class through to html_canonical.py.
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+    sed -n '2,24p' "$0" | sed 's/^# \{0,1\}//'
+    exit 2
+fi
+
+SRC="$1"
+OUTDIR="$2"
+shift 2
+RETRIEVED="$(date +%F)"
+ROOT=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --retrieved) RETRIEVED="$2"; shift 2 ;;
+        --root) ROOT="$2"; shift 2 ;;
+        *) echo "onbekende optie: $1" >&2; exit 2 ;;
+    esac
+done
+
+[[ -f "$SRC" ]] || { echo "bron niet gevonden: $SRC" >&2; exit 2; }
+mkdir -p "$OUTDIR"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+EXT="$(printf '%s' "${SRC##*.}" | tr 'A-Z' 'a-z')"
+
+if [[ "$EXT" == "html" || "$EXT" == "htm" ]]; then
+    # -- HTML branch: no pages, no layout reconstruction, own furniture rule.
+    EXTRACTOR="html_canonical.py (stdlib)"
+    if [[ -n "$ROOT" ]]; then
+        python3 "$HERE/html_canonical.py" "$SRC" --root "$ROOT" > "$OUTDIR/canonical.md"
+    else
+        python3 "$HERE/html_canonical.py" "$SRC" > "$OUTDIR/canonical.md"
+    fi
+    rm -f "$OUTDIR/pages.tsv"
+    NORMALIZATION="  - unicode-NFC
+  - zacht-koppelteken-verwijderd
+  - navigatie-/kop-/voetelementen-verwijderd
+  - witruimte-genormaliseerd"
+else
+    EXTRACTOR="pdftotext -layout -enc UTF-8"
+    NORMALIZATION="  - unicode-NFC
+  - zacht-koppelteken-verwijderd
+  - regeleinde-afbreekstreepjes-samengevoegd
+  - lopende-kop-/voetteksten-verwijderd
+  - witruimte-genormaliseerd"
+    command -v pdftotext >/dev/null || { echo "pdftotext (poppler) ontbreekt" >&2; exit 2; }
+
+RAW="$OUTDIR/.raw.txt"
+pdftotext -layout -enc UTF-8 "$SRC" "$RAW"
+
+python3 - "$RAW" "$OUTDIR" <<'PY'
+import re, sys, unicodedata
+from collections import Counter
+from pathlib import Path
+
+raw_path, outdir = Path(sys.argv[1]), Path(sys.argv[2])
+pages = raw_path.read_text(encoding="utf-8").split("\f")
+if pages and not pages[-1].strip():
+    pages.pop()
+
+# --- running headers/footers -------------------------------------------------
+# A line that shows up in the top-2 or bottom-2 of most pages is furniture, not
+# text. Dropping it here (visibly, in one place) beats teaching every later step
+# to ignore it.
+edge = Counter()
+for p in pages:
+    lines = [ln.strip() for ln in p.splitlines() if ln.strip()]
+    for ln in lines[:2] + lines[-2:]:
+        edge[ln] += 1
+threshold = max(3, int(len(pages) * 0.6))
+furniture = {ln for ln, n in edge.items() if n >= threshold and len(pages) >= 3}
+bare_number = re.compile(r"^(pagina\s*)?\d+(\s*(van|/)\s*\d+)?$", re.IGNORECASE)
+
+cleaned, offsets, cursor = [], [], 0
+for n, page in enumerate(pages, start=1):
+    kept = []
+    for ln in page.splitlines():
+        s = ln.strip()
+        if s in furniture or bare_number.match(s):
+            continue
+        kept.append(ln.rstrip())
+    body = "\n".join(kept).strip("\n")
+    offsets.append((n, cursor))
+    cursor += len(body) + 1  # the "\n" that joins pages
+    cleaned.append(body)
+
+text = "\n".join(cleaned)
+
+# --- normalization, applied once and recorded --------------------------------
+steps = []
+text = unicodedata.normalize("NFC", text); steps.append("unicode-NFC")
+text = text.replace("­", ""); steps.append("zacht-koppelteken-verwijderd")
+# Join words broken over a line end ("betalings-\ncapaciteit"), but only when the
+# next line continues in lowercase - "wet- en regelgeving" must stay intact.
+text, n_hyphen = re.subn(r"(\w)-\n\s*([a-zà-ÿ])", r"\1\2", text)
+steps.append(f"regeleinde-afbreekstreepjes-samengevoegd({n_hyphen})")
+text = re.sub(r"[ \t]+\n", "\n", text); steps.append("regeleinde-witruimte-gestript")
+text = re.sub(r"\n{3,}", "\n\n", text); steps.append("lege-regels-samengevouwen")
+text = text.strip() + "\n"
+
+(outdir / "canonical.md").write_text(text, encoding="utf-8")
+(outdir / "pages.tsv").write_text(
+    "page\toffset\n" + "".join(f"{n}\t{min(o, len(text))}\n" for n, o in offsets),
+    encoding="utf-8")
+print("\n".join(steps))
+print(f"pages={len(pages)} furniture_lines={len(furniture)} chars={len(text)}")
+PY
+
+    rm -f "$RAW"
+fi
+
+SRC_HASH="$(shasum -a 256 "$SRC" | cut -d' ' -f1)"
+CAN_HASH="$(shasum -a 256 "$OUTDIR/canonical.md" | cut -d' ' -f1)"
+
+cat > "$OUTDIR/manifest.yaml" <<EOF
+---
+source_file: $(basename "$SRC")
+source_sha256: '$SRC_HASH'
+canonical_sha256: '$CAN_HASH'
+retrieved_at: '$RETRIEVED'
+extractor: '$EXTRACTOR'
+normalization:
+$NORMALIZATION
+EOF
+
+if [[ -f "$OUTDIR/pages.tsv" ]]; then
+    echo "geschreven: $OUTDIR/{canonical.md,pages.tsv,manifest.yaml}"
+else
+    echo "geschreven: $OUTDIR/{canonical.md,manifest.yaml}  (HTML-bron: geen pagina's)"
+fi
+echo "source_sha256=$SRC_HASH"

--- a/.claude/skills/law-statement-register/scripts/canonicalize.sh
+++ b/.claude/skills/law-statement-register/scripts/canonicalize.sh
@@ -49,9 +49,11 @@ if [[ "$EXT" == "html" || "$EXT" == "htm" ]]; then
     # -- HTML branch: no pages, no layout reconstruction, own furniture rule.
     EXTRACTOR="html_canonical.py (stdlib)"
     if [[ -n "$ROOT" ]]; then
-        python3 "$HERE/html_canonical.py" "$SRC" --root "$ROOT" > "$OUTDIR/canonical.md"
+        python3 "$HERE/html_canonical.py" "$SRC" --root "$ROOT" \
+                --links "$OUTDIR/links.tsv" > "$OUTDIR/canonical.md"
     else
-        python3 "$HERE/html_canonical.py" "$SRC" > "$OUTDIR/canonical.md"
+        python3 "$HERE/html_canonical.py" "$SRC" \
+                --links "$OUTDIR/links.tsv" > "$OUTDIR/canonical.md"
     fi
     rm -f "$OUTDIR/pages.tsv"
     NORMALIZATION="  - unicode-NFC

--- a/.claude/skills/law-statement-register/scripts/canonicalize.sh
+++ b/.claude/skills/law-statement-register/scripts/canonicalize.sh
@@ -70,6 +70,18 @@ else
 RAW="$OUTDIR/.raw.txt"
 pdftotext -layout -enc UTF-8 "$SRC" "$RAW"
 
+    # A scanned PDF has no text layer: pdftotext succeeds and returns almost
+    # nothing. Writing that out as canonical.md would give a register with 100%
+    # coverage over an empty document - green, and worthless. Refuse instead.
+    CHARS="$(wc -c < "$RAW" | tr -d ' ')"
+    if [[ "$CHARS" -lt 200 ]]; then
+        rm -f "$RAW"
+        echo "FOUT: pdftotext haalde slechts $CHARS tekens uit deze PDF." >&2
+        echo "Waarschijnlijk een scan zonder tekstlaag. OCR de bron eerst, of" >&2
+        echo "lever een tekstversie aan - een lege canonical.md is geen bron." >&2
+        exit 3
+    fi
+
 python3 - "$RAW" "$OUTDIR" <<'PY'
 import re, sys, unicodedata
 from collections import Counter

--- a/.claude/skills/law-statement-register/scripts/html_canonical.py
+++ b/.claude/skills/law-statement-register/scripts/html_canonical.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""HTML source -> reading text (the HTML branch of fase 1).
+
+The PDF branch has pdftotext; HTML needs its own deterministic reader. Same
+contract: same bytes in, same text out, no injected characters, no judgement.
+Stdlib only - a converter that needs an install is a converter that silently
+differs between machines, and then canonical.md stops being evidence.
+
+What it drops, and why that is the HTML equivalent of a running header: a
+handbook page carries a navigation tree, a breadcrumb, a search box and a
+footer on every page. Left in, they become "text" that trips the signal net on
+every single page and buries the actual content. They are furniture, so they go
+- but visibly, in one place, and counted in the report.
+
+Structure is preserved because the tiler needs it: headings on their own line,
+list items with a leading marker, table rows as tab-separated lines, blocks
+separated by a blank line.
+
+Usage:  python3 html_canonical.py page.html
+        python3 html_canonical.py page.html --keep-nav      (diagnose furniture)
+        python3 html_canonical.py page.html --root '#content'
+"""
+import argparse
+import re
+import sys
+import unicodedata
+from html.parser import HTMLParser
+
+DROP = {"script", "style", "noscript", "svg", "canvas", "iframe", "form",
+        "nav", "header", "footer", "aside", "button", "select", "template"}
+BLOCK = {"p", "div", "section", "article", "main", "ul", "ol", "dl", "dd", "dt",
+         "table", "thead", "tbody", "figure", "figcaption", "blockquote", "pre",
+         "h1", "h2", "h3", "h4", "h5", "h6", "tr", "li"}
+HEADING = {"h1", "h2", "h3", "h4", "h5", "h6"}
+VOID = {"br", "img", "hr", "input", "meta", "link", "source", "col"}
+# Content wrappers, most specific first: a page that marks its own main content
+# is telling us where the text is, and that beats any heuristic.
+PREFERRED_ROOTS = ["main", "article"]
+
+
+class Extract(HTMLParser):
+    def __init__(self, keep_nav=False):
+        super().__init__(convert_charrefs=True)
+        self.keep_nav = keep_nav
+        self.out = []
+        self.drop_depth = 0
+        self.dropped = 0
+        self.stack = []
+        self.in_cell = False
+
+    # -- helpers ----------------------------------------------------------
+    def nl(self, n=1):
+        while self.out and self.out[-1] in ("\n", " "):
+            self.out.pop()
+        self.out.append("\n" * n)
+
+    def handle_starttag(self, tag, attrs):
+        if tag in VOID:
+            if tag == "br":
+                self.out.append("\n")
+            return
+        self.stack.append(tag)
+        if tag in DROP and not self.keep_nav:
+            self.drop_depth += 1
+            self.dropped += 1
+            return
+        if self.drop_depth:
+            return
+        if tag in HEADING:
+            self.nl(2)
+        elif tag == "li":
+            self.nl()
+            self.out.append("- ")
+        elif tag in ("td", "th"):
+            if self.in_cell:
+                while self.out and self.out[-1] == " ":
+                    self.out.pop()
+                self.out.append("\t")
+            self.in_cell = True
+        elif tag in BLOCK:
+            self.nl(2)
+
+    def handle_endtag(self, tag):
+        if tag in VOID:
+            return
+        if tag in self.stack:
+            while self.stack and self.stack.pop() != tag:
+                pass
+        if tag in DROP and not self.keep_nav:
+            self.drop_depth = max(0, self.drop_depth - 1)
+            return
+        if self.drop_depth:
+            return
+        if tag == "tr":
+            self.in_cell = False
+            self.nl()
+        elif tag == "li":
+            self.nl()          # list items stay adjacent; a list is one block
+        elif tag in HEADING or tag in BLOCK:
+            self.nl(2)
+
+    def handle_data(self, data):
+        if self.drop_depth or not data.strip():
+            if data.strip() == "" and self.out and not self.out[-1].endswith("\n"):
+                self.out.append(" ")
+            return
+        self.out.append(re.sub(r"\s+", " ", data).strip())
+        self.out.append(" ")
+
+    def text(self):
+        raw = "".join(self.out)
+        raw = unicodedata.normalize("NFC", raw)
+        raw = raw.replace("­", "")
+        raw = re.sub(r"[ \t]+\n", "\n", raw)
+        raw = re.sub(r"\n[ \t]+", "\n", raw)
+        raw = re.sub(r"\n{3,}", "\n\n", raw)
+        return raw.strip() + "\n"
+
+
+def narrow_to_root(html: str, root: str | None) -> tuple[str, str]:
+    """Return (html, which-root-was-used). Cuts to <main>/<article> when present."""
+    if root:
+        m = re.search(rf'<[^>]*(?:id|class)="[^"]*{re.escape(root.lstrip("#."))}[^"]*"[^>]*>',
+                      html, re.I)
+        if m:
+            return html[m.end():], root
+        sys.stderr.write(f"waarschuwing: --root {root!r} niet gevonden, hele document gebruikt\n")
+        return html, "document"
+    for tag in PREFERRED_ROOTS:
+        m = re.search(rf"<{tag}\b[^>]*>(.*?)</{tag}>", html, re.I | re.S)
+        if m:
+            return m.group(1), f"<{tag}>"
+    return html, "document"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("source")
+    ap.add_argument("--keep-nav", action="store_true",
+                    help="laat navigatie/kop/voet staan - om te zien wat er anders wegvalt")
+    ap.add_argument("--root", help="CSS-achtige id/class van het inhoudsblok, bijv. '#content'")
+    args = ap.parse_args()
+
+    with open(args.source, encoding="utf-8", errors="replace") as fh:
+        html = fh.read()
+
+    body = re.search(r"<body\b[^>]*>(.*)</body>", html, re.I | re.S)
+    if body:
+        html = body.group(1)
+    html, used = narrow_to_root(html, args.root)
+
+    parser = Extract(keep_nav=args.keep_nav)
+    parser.feed(html)
+    text = parser.text()
+
+    sys.stdout.write(text)
+    sys.stderr.write(f"inhoudsblok={used} weggelaten_elementen={parser.dropped} "
+                     f"chars={len(text)}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/law-statement-register/scripts/html_canonical.py
+++ b/.claude/skills/law-statement-register/scripts/html_canonical.py
@@ -28,6 +28,12 @@ from html.parser import HTMLParser
 
 DROP = {"script", "style", "noscript", "svg", "canvas", "iframe", "form",
         "nav", "header", "footer", "aside", "button", "select", "template"}
+# Labels that exist for an icon or a screen reader and are not visible text.
+# A notification block typically renders an icon plus the word, but ships both
+# the icon's label and the word - which reads back as "Let op! Let op". These
+# class names are cross-framework conventions, not one site's markup.
+HIDDEN_CLASS = re.compile(r"\b(sr-only|visually-hidden|screen-reader(-text)?|"
+                          r"icon-label|a11y-hidden|hidden-visually)\b")
 BLOCK = {"p", "div", "section", "article", "main", "ul", "ol", "dl", "dd", "dt",
          "table", "thead", "tbody", "figure", "figcaption", "blockquote", "pre",
          "h1", "h2", "h3", "h4", "h5", "h6", "tr", "li"}
@@ -45,8 +51,14 @@ class Extract(HTMLParser):
         self.out = []
         self.drop_depth = 0
         self.dropped = 0
+        self.hidden_labels = 0
         self.stack = []
         self.in_cell = False
+        self.links = []          # [(anchor text, href)] in document order
+        self.link_href = None
+        self.link_start = None
+        self.hidden_open = []
+        self.pending_tabs = 0
 
     # -- helpers ----------------------------------------------------------
     def nl(self, n=1):
@@ -60,12 +72,21 @@ class Extract(HTMLParser):
                 self.out.append("\n")
             return
         self.stack.append(tag)
+        attr = dict(attrs)
         if tag in DROP and not self.keep_nav:
             self.drop_depth += 1
             self.dropped += 1
             return
+        if not self.keep_nav and HIDDEN_CLASS.search(attr.get("class") or ""):
+            self.drop_depth += 1
+            self.hidden_labels += 1
+            self.hidden_open.append(tag)
+            return
         if self.drop_depth:
             return
+        if tag == "a" and attr.get("href"):
+            self.link_href = attr["href"]
+            self.link_start = len(self.out)
         if tag in HEADING:
             self.nl(2)
         elif tag == "li":
@@ -77,11 +98,26 @@ class Extract(HTMLParser):
                     self.out.pop()
                 self.out.append("\t")
             self.in_cell = True
+            # A cell that spans N columns must still advance the column count,
+            # or every value after it shifts one column left and ends up under
+            # the wrong header. That is a silent wrong answer, not a layout nit.
+            try:
+                span = int(attr.get("colspan", "1"))
+            except ValueError:
+                span = 1
+            if span > 1:
+                self.pending_tabs = span - 1
+            else:
+                self.pending_tabs = 0
         elif tag in BLOCK:
             self.nl(2)
 
     def handle_endtag(self, tag):
         if tag in VOID:
+            return
+        if self.hidden_open and self.hidden_open[-1] == tag:
+            self.hidden_open.pop()
+            self.drop_depth = max(0, self.drop_depth - 1)
             return
         if tag in self.stack:
             while self.stack and self.stack.pop() != tag:
@@ -91,8 +127,17 @@ class Extract(HTMLParser):
             return
         if self.drop_depth:
             return
+        if tag == "a" and self.link_href:
+            anchor = "".join(self.out[self.link_start:]).strip()
+            if anchor:
+                self.links.append((anchor, self.link_href))
+            self.link_href = None
+        if tag in ("td", "th") and self.pending_tabs:
+            self.out.append("\t" * self.pending_tabs)
+            self.pending_tabs = 0
         if tag == "tr":
             self.in_cell = False
+            self.pending_tabs = 0
             self.nl()
         elif tag == "li":
             self.nl()          # list items stay adjacent; a list is one block
@@ -111,8 +156,11 @@ class Extract(HTMLParser):
         raw = "".join(self.out)
         raw = unicodedata.normalize("NFC", raw)
         raw = raw.replace("­", "")
-        raw = re.sub(r"[ \t]+\n", "\n", raw)
-        raw = re.sub(r"\n[ \t]+", "\n", raw)
+        # Spaces only, never tabs: a tab at the start or end of a line is an
+        # empty leading/trailing table cell. Stripping it collapses the column
+        # count and every value in the row lands under the wrong header.
+        raw = re.sub(r"[ ]+\n", "\n", raw)
+        raw = re.sub(r"\n[ ]+", "\n", raw)
         raw = re.sub(r"\n{3,}", "\n\n", raw)
         return raw.strip() + "\n"
 
@@ -140,6 +188,8 @@ def main() -> int:
     ap.add_argument("--keep-nav", action="store_true",
                     help="laat navigatie/kop/voet staan - om te zien wat er anders wegvalt")
     ap.add_argument("--root", help="CSS-achtige id/class van het inhoudsblok, bijv. '#content'")
+    ap.add_argument("--links", metavar="FILE",
+                    help="schrijf de hyperlinks weg als zijspoor (volgnr, ankertekst, href)")
     args = ap.parse_args()
 
     with open(args.source, encoding="utf-8", errors="replace") as fh:
@@ -155,7 +205,19 @@ def main() -> int:
     text = parser.text()
 
     sys.stdout.write(text)
+
+    # Links live beside the text, never in it. A hyperlink on "artikel 8 van de
+    # Awir" is the author saying which norm they mean - exactly what the
+    # verankering step reconstructs by hand - so throwing it away wastes
+    # evidence. Inlining the URL would wreck verbatim quoting, hence a sidecar.
+    if args.links:
+        with open(args.links, "w", encoding="utf-8") as fh:
+            fh.write("n\tanker\thref\n")
+            for n, (anchor, href) in enumerate(parser.links, start=1):
+                fh.write(f"{n}\t{anchor}\t{href}\n")
+
     sys.stderr.write(f"inhoudsblok={used} weggelaten_elementen={parser.dropped} "
+                     f"verborgen_labels={parser.hidden_labels} links={len(parser.links)} "
                      f"chars={len(text)}\n")
     return 0
 

--- a/.claude/skills/law-statement-register/scripts/statement_gates.py
+++ b/.claude/skills/law-statement-register/scripts/statement_gates.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+"""Statement-register gates (dossier-agnostic).
+
+Four gates prove that a statement register is a faithful, complete reading of a
+secondary text (toelichting, beleidsregel, werkinstructie). Each is a mechanical
+check on the ledger against the canonical text; none of them takes the author's
+word for anything.
+
+  VERBATIM   - every quote in the ledger is a literal substring of canonical.md
+               under the one documented normalization (see normalize()). A
+               paraphrase, a "cleaned up" ellipsis or a re-typed quote fails
+               here. Also enforces quote is inside its own segment's text, and
+               that a `niet-gevonden` anchoring records the search terms used
+               (a negative finding nobody can redo is not a finding).
+  COVERAGE   - the segments tile canonical.md completely: segment i starts where
+               segment i-1 ended. Any uncovered region is a GAP and is reported
+               with its first 80 characters, so silent skipping is impossible.
+               Also enforces that a non-normative disposition carries a reason.
+  ANCHOR     - every {prefix, exact, suffix} resolves to exactly ONE position in
+               canonical.md. Zero matches = orphaned, more than one = ambiguous;
+               both make the statement unusable for a cross-version diff (RFC-005
+               uniqueness requirement).
+  SIGNAALNET - every sentence in a `normative` segment that trips a detector
+               (deontic verb, condition word, softener, amount, term, definition,
+               cross-reference) must be covered by at least one statement. This
+               is the recall net: it does not care what the reader found
+               interesting, only that nothing norm-shaped was passed over in
+               silence.
+
+Exit code != 0 if any gate finds anything (usable as a CI gate).
+
+Usage:
+  python3 statement_gates.py all        --canonical canonical.md --ledger statements.yaml
+  python3 statement_gates.py verbatim   --canonical canonical.md --ledger statements.yaml
+  python3 statement_gates.py coverage   --canonical canonical.md --ledger statements.yaml
+  python3 statement_gates.py anchor     --canonical canonical.md --ledger statements.yaml
+  python3 statement_gates.py signaalnet --canonical canonical.md --ledger statements.yaml
+                                        [--lexicon lexicon.yaml]
+"""
+import argparse
+import re
+import sys
+import unicodedata
+
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write("statement_gates.py requires pyyaml (pip install pyyaml)\n")
+    sys.exit(2)
+
+# --------------------------------------------------------------------------
+# The one allowed normalization.
+#
+# Anything beyond this is drift, not formatting. Kept deliberately small and
+# printed by --explain so a reviewer can audit exactly what was folded away.
+# Line-break de-hyphenation is NOT here: it belongs to canonicalize.sh, which
+# writes it into canonical.md once, visibly, instead of hiding it at compare
+# time.
+# --------------------------------------------------------------------------
+CHAR_FOLD = {
+    "‘": "'", "’": "'", "‚": "'", "′": "'",
+    "“": '"', "”": '"', "„": '"',
+    "–": "-", "—": "-", "−": "-",
+    " ": " ", " ": " ", " ": " ", " ": " ",
+    "ﬁ": "fi", "ﬂ": "fl", "ﬀ": "ff",
+}
+SOFT_HYPHEN = "­"
+
+
+class Norm:
+    """Normalized view of a text, with an index map back to raw offsets.
+
+    Substring searching happens in normalized space (so whitespace and quote
+    style never cause a false 'not verbatim'), while every reported position is
+    a raw offset into canonical.md, so a human can find it in the file.
+    """
+
+    def __init__(self, raw: str):
+        self.raw = raw
+        out, idx = [], []
+        prev_space = False
+        for i, ch in enumerate(unicodedata.normalize("NFC", raw)):
+            if ch == SOFT_HYPHEN:
+                continue
+            ch = CHAR_FOLD.get(ch, ch)
+            if ch.isspace():
+                if prev_space or not out:
+                    continue
+                out.append(" ")
+                idx.append(i)
+                prev_space = True
+                continue
+            prev_space = False
+            for c in ch:  # a fold may expand (ﬁ -> fi)
+                out.append(c)
+                idx.append(i)
+        # drop a trailing collapsed space
+        while out and out[-1] == " ":
+            out.pop()
+            idx.pop()
+        self.text = "".join(out)
+        self.map = idx
+
+    def raw_pos(self, norm_pos: int) -> int:
+        if not self.map:
+            return 0
+        if norm_pos >= len(self.map):
+            return len(self.raw)
+        return self.map[norm_pos]
+
+    def raw_slice(self, start: int, end: int) -> str:
+        return self.raw[self.raw_pos(start):self.raw_pos(end)]
+
+
+def norm_str(s: str) -> str:
+    return Norm(s).text
+
+
+def excerpt(s: str, n: int = 80) -> str:
+    s = " ".join(s.split())
+    return s[:n] + ("…" if len(s) > n else "")
+
+
+# --------------------------------------------------------------------------
+# Ledger access
+# --------------------------------------------------------------------------
+def load(canonical_path: str, ledger_path: str):
+    with open(canonical_path, encoding="utf-8") as fh:
+        canonical = Norm(fh.read())
+    with open(ledger_path, encoding="utf-8") as fh:
+        ledger = yaml.safe_load(fh) or {}
+    return canonical, ledger
+
+
+def segments(ledger):
+    return ledger.get("segments") or []
+
+
+def statements(ledger):
+    return ledger.get("statements") or []
+
+
+NON_NORMATIVE = {"informative", "navigational", "duplicate", "non-textual"}
+VALID_DISPOSITIONS = {"normative"} | NON_NORMATIVE
+
+
+# --------------------------------------------------------------------------
+# Gate 1 - VERBATIM
+# --------------------------------------------------------------------------
+def gate_verbatim(canonical: Norm, ledger) -> list:
+    findings = []
+    seg_text = {s.get("id"): norm_str(s.get("text", "")) for s in segments(ledger)}
+
+    for seg in segments(ledger):
+        sid = seg.get("id", "?")
+        text = norm_str(seg.get("text", ""))
+        if not text:
+            findings.append(f"segment {sid}: lege text")
+        elif text not in canonical.text:
+            findings.append(f"segment {sid}: text niet verbatim in canonical ({excerpt(text)})")
+
+    for st in statements(ledger):
+        stid = st.get("id", "?")
+        quote = norm_str(st.get("quote", ""))
+        if not quote:
+            findings.append(f"{stid}: lege quote")
+            continue
+        if quote not in canonical.text:
+            findings.append(f"{stid}: quote niet verbatim in canonical ({excerpt(quote)})")
+        parent = seg_text.get(st.get("segment"))
+        if parent is None:
+            findings.append(f"{stid}: verwijst naar onbekend segment {st.get('segment')!r}")
+        elif quote not in parent:
+            findings.append(f"{stid}: quote valt buiten segment {st.get('segment')} ({excerpt(quote)})")
+
+        anchoring = st.get("anchoring") or {}
+        status = anchoring.get("status")
+        if status == "niet-gevonden" and not (anchoring.get("search_terms") or []):
+            findings.append(f"{stid}: anchoring niet-gevonden zonder search_terms "
+                            "(negatieve bevinding moet overdoenbaar zijn)")
+        if status in {"verankerd", "geparafraseerd"} and not anchoring.get("norm_ref"):
+            findings.append(f"{stid}: anchoring {status} zonder norm_ref")
+    return findings
+
+
+# --------------------------------------------------------------------------
+# Gate 2 - COVERAGE
+# --------------------------------------------------------------------------
+def gate_coverage(canonical: Norm, ledger) -> tuple:
+    """Walk the segments through the canonical text in order.
+
+    Each segment must start exactly where the previous one ended. A segment that
+    starts later leaves a GAP; a segment that cannot be found at all breaks the
+    chain and is reported as UNPLACED (the walk resumes from the cursor).
+    """
+    findings, cursor, covered = [], 0, 0
+    total = len(canonical.text)
+
+    for seg in segments(ledger):
+        sid = seg.get("id", "?")
+        disp = seg.get("disposition")
+        if disp not in VALID_DISPOSITIONS:
+            findings.append(f"segment {sid}: disposition {disp!r} onbekend "
+                            f"(kies uit {sorted(VALID_DISPOSITIONS)})")
+        if disp in NON_NORMATIVE and not seg.get("reason"):
+            findings.append(f"segment {sid}: disposition {disp} zonder reason "
+                            "(overslaan mag, stil overslaan niet)")
+
+        text = norm_str(seg.get("text", ""))
+        if not text:
+            continue
+        pos = canonical.text.find(text, cursor)
+        if pos < 0:
+            back = canonical.text.find(text)
+            if back >= 0:
+                findings.append(f"segment {sid}: staat vóór het vorige segment "
+                                f"(volgorde-fout, gevonden op {canonical.raw_pos(back)})")
+            else:
+                findings.append(f"segment {sid}: UNPLACED - niet gevonden in canonical")
+            continue
+        if pos > cursor:
+            gap = canonical.text[cursor:pos]
+            # Whitespace between two segments is the join, not content.
+            if gap.strip():
+                findings.append(f"GAP voor segment {sid}: {len(gap)} tekens ongedekt "
+                                f"op raw-offset {canonical.raw_pos(cursor)} -> {excerpt(gap)!r}")
+            covered += len(gap)
+        covered += len(text)
+        cursor = pos + len(text)
+
+    if cursor < total:
+        tail = canonical.text[cursor:]
+        if tail.strip():
+            findings.append(f"GAP aan het eind: {len(tail)} tekens ongedekt "
+                            f"op raw-offset {canonical.raw_pos(cursor)} -> {excerpt(tail)!r}")
+        else:
+            covered += len(tail)
+
+    pct = (covered / total * 100) if total else 100.0
+    return findings, pct
+
+
+# --------------------------------------------------------------------------
+# Gate 3 - ANCHOR
+# --------------------------------------------------------------------------
+def anchor_pattern(anchor) -> str:
+    return norm_str("{}{}{}".format(anchor.get("prefix", ""),
+                                    anchor.get("exact", ""),
+                                    anchor.get("suffix", "")))
+
+
+def count_occurrences(hay: str, needle: str) -> int:
+    if not needle:
+        return 0
+    n, start = 0, 0
+    while True:
+        p = hay.find(needle, start)
+        if p < 0:
+            return n
+        n += 1
+        start = p + 1
+
+
+def gate_anchor(canonical: Norm, ledger) -> list:
+    findings = []
+    for st in statements(ledger):
+        stid = st.get("id", "?")
+        anchor = st.get("anchor") or {}
+        if not anchor.get("exact"):
+            findings.append(f"{stid}: anchor zonder exact")
+            continue
+        hits = count_occurrences(canonical.text, anchor_pattern(anchor))
+        if hits == 0:
+            findings.append(f"{stid}: ORPHANED - prefix+exact+suffix niet gevonden")
+        elif hits > 1:
+            findings.append(f"{stid}: AMBIGUOUS - {hits} treffers, breid prefix/suffix uit")
+    return findings
+
+
+# --------------------------------------------------------------------------
+# Gate 4 - SIGNAALNET
+# --------------------------------------------------------------------------
+DEFAULT_LEXICON = {
+    "deontisch": r"\b(moet(en)?|dient|dienen|verplicht|mag|mogen|kan|kunnen|"
+                 r"wordt geacht|worden geacht|bevoegd|recht op|in aanmerking)\b",
+    "conditioneel": r"\b(indien|tenzij|mits|voor zover|behoudens|met dien verstande|"
+                    r"in het geval dat|wanneer)\b",
+    "zachtheid": r"\b(in beginsel|in de regel|doorgaans|zoveel mogelijk|"
+                 r"naar (het )?oordeel van|maatwerk|bijzondere omstandigheden|schrijnend)\b",
+    "kwantiteit": r"(€\s?\d|\d+\s?%|\b\d+(\.\d{3})*(,\d+)?\s?(euro|procent|dagen|weken|"
+                  r"maanden|jaar|jaren)\b)",
+    "definitie": r"\b(wordt verstaan onder|worden verstaan onder|geldt als|"
+                 r"hieronder valt|wordt aangemerkt als)\b",
+    "verwijzing": r"\b(artikel\s+\d|bijlage\s+\w|zie\s+(hoofdstuk|paragraaf|artikel))",
+}
+
+SENTENCE_END = re.compile(r"[.!?;]\s")
+
+
+def sentence_bounds(text: str, pos: int) -> tuple:
+    """Expand a position to the sentence containing it (normalized space)."""
+    start = 0
+    for m in SENTENCE_END.finditer(text, 0, pos):
+        start = m.end()
+    m = SENTENCE_END.search(text, pos)
+    end = m.end() if m else len(text)
+    return start, end
+
+
+def gate_signaalnet(canonical: Norm, ledger, lexicon=None) -> tuple:
+    lex = lexicon or DEFAULT_LEXICON
+    patterns = {k: re.compile(v, re.IGNORECASE) for k, v in lex.items()}
+
+    # Ranges the reader actually covered: each statement expanded to whole sentences.
+    covered = []
+    for st in statements(ledger):
+        quote = norm_str(st.get("quote", ""))
+        p = canonical.text.find(quote) if quote else -1
+        if p < 0:
+            continue  # already reported by the verbatim gate
+        s, _ = sentence_bounds(canonical.text, p)
+        _, e = sentence_bounds(canonical.text, max(p, p + len(quote) - 1))
+        covered.append((s, max(e, p + len(quote))))
+
+    # Regions the author explicitly dispositioned as non-normative are exempt:
+    # they were skipped on the record, which is what the method allows.
+    exempt, cursor = [], 0
+    for seg in segments(ledger):
+        text = norm_str(seg.get("text", ""))
+        if not text:
+            continue
+        p = canonical.text.find(text, cursor)
+        if p < 0:
+            p = canonical.text.find(text)
+            if p < 0:
+                continue
+        if seg.get("disposition") in NON_NORMATIVE:
+            exempt.append((p, p + len(text)))
+        cursor = p + len(text)
+
+    def inside(pos, ranges):
+        return any(a <= pos < b for a, b in ranges)
+
+    findings, hits, seen = [], 0, set()
+    for name, pat in patterns.items():
+        for m in pat.finditer(canonical.text):
+            hits += 1
+            if inside(m.start(), exempt) or inside(m.start(), covered):
+                continue
+            s, e = sentence_bounds(canonical.text, m.start())
+            if (s, e) in seen:
+                continue
+            seen.add((s, e))
+            findings.append(f"ONGEDEKT [{name}] raw-offset {canonical.raw_pos(s)}: "
+                            f"{excerpt(canonical.text[s:e], 110)!r}")
+    return findings, hits
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+def report(title: str, findings: list, extra: str = "") -> int:
+    status = "FAIL" if findings else "OK"
+    print(f"[{status}] {title}{(' ' + extra) if extra else ''} findings={len(findings)}")
+    for f in findings:
+        print("  " + f)
+    return 1 if findings else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("command",
+                    choices=["all", "verbatim", "coverage", "anchor", "signaalnet", "explain"])
+    ap.add_argument("--canonical", required=False)
+    ap.add_argument("--ledger", required=False)
+    ap.add_argument("--lexicon", help="YAML mapping name -> regex, replaces the default net")
+    args = ap.parse_args()
+
+    if args.command == "explain":
+        print("Toegestane normalisatie (en niets daarbuiten):")
+        print("  1. unicode NFC")
+        print("  2. zacht koppelteken (U+00AD) verwijderd")
+        print("  3. tekenvouwing: " + ", ".join(f"{k!r}->{v!r}" for k, v in CHAR_FOLD.items()))
+        print("  4. witruimte-reeksen samengevouwen tot één spatie, randen gestript")
+        print("Afbreekstreepjes over regeleinden horen in canonicalize.sh, niet hier.")
+        return 0
+
+    if not args.canonical or not args.ledger:
+        ap.error("--canonical en --ledger zijn verplicht")
+
+    canonical, ledger = load(args.canonical, args.ledger)
+    lexicon = None
+    if args.lexicon:
+        with open(args.lexicon, encoding="utf-8") as fh:
+            lexicon = yaml.safe_load(fh)
+
+    rc = 0
+    if args.command in ("all", "verbatim"):
+        rc |= report("VERBATIM", gate_verbatim(canonical, ledger))
+    if args.command in ("all", "coverage"):
+        findings, pct = gate_coverage(canonical, ledger)
+        rc |= report("COVERAGE", findings, f"dekking={pct:.1f}%")
+    if args.command in ("all", "anchor"):
+        rc |= report("ANCHOR", gate_anchor(canonical, ledger))
+    if args.command in ("all", "signaalnet"):
+        findings, hits = gate_signaalnet(canonical, ledger, lexicon)
+        rc |= report("SIGNAALNET", findings, f"treffers={hits}")
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/law-statement-register/scripts/statement_gates.py
+++ b/.claude/skills/law-statement-register/scripts/statement_gates.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python3
 """Statement-register gates (dossier-agnostic).
 
-Four gates prove that a statement register is a faithful, complete reading of a
+Gates prove that a statement register is a faithful, complete reading of a
 secondary text (toelichting, beleidsregel, werkinstructie). Each is a mechanical
 check on the ledger against the canonical text; none of them takes the author's
 word for anything.
 
+  LEDGER     - the controlled vocabulary. Runs on EVERY invocation, before the
+               rest, because the other gates key on these exact strings: it is
+               `status == "niet-gevonden"` that demands the search terms, so a
+               ledger spelling it "nietgevonden" turns that rule off silently
+               and the remaining three keep reporting green.
   VERBATIM   - every quote in the ledger is a literal substring of canonical.md
                under the one documented normalization (see normalize()). A
                paraphrase, a "cleaned up" ellipsis or a re-typed quote fails
@@ -31,6 +36,7 @@ Exit code != 0 if any gate finds anything (usable as a CI gate).
 
 Usage:
   python3 statement_gates.py all        --canonical canonical.md --ledger statements.yaml
+  python3 statement_gates.py ledger     --canonical canonical.md --ledger statements.yaml
   python3 statement_gates.py verbatim   --canonical canonical.md --ledger statements.yaml
   python3 statement_gates.py coverage   --canonical canonical.md --ledger statements.yaml
   python3 statement_gates.py anchor     --canonical canonical.md --ledger statements.yaml
@@ -143,6 +149,62 @@ def statements(ledger):
 NON_NORMATIVE = {"informative", "navigational", "duplicate", "non-textual"}
 VALID_DISPOSITIONS = {"normative"} | NON_NORMATIVE
 
+# The controlled vocabulary. Every value the method reasons with lives here,
+# because the gates key on these strings: `status == "niet-gevonden"` is what
+# demands the search terms, and a ledger that writes "nietgevonden" switches
+# that rule off without a word. A vocabulary that is only enforced by spelling
+# is not enforced.
+VOCABULARY = {
+    "anchoring.status": {"verankerd", "geparafraseerd", "niet-gevonden"},
+    "type": {"normatief", "kwantitatief", "definitie", "procedureel", "bewijs",
+             "discretie", "uitzondering", "voorbeeld", "verwijzing", "informatief"},
+    "bindingness": {"hard", "soft-default", "guidance", "informative"},
+    "bucket": {"MODELFOUT", "WETTEKST-GEVOLG", "LETTER-vs-TOELICHTING",
+               "letter-getrouw", "scope"},
+    "deviation_class": {"toelichting-bleed", "ontbrekend-bestanddeel",
+                        "verkeerde-verankering", "herformulering",
+                        "bindendheid-vervlakking", "buitenwettelijk", "geen"},
+}
+REQUIRED_ON_STATEMENT = ["type", "bindingness", "bucket"]
+
+
+# --------------------------------------------------------------------------
+# Gate 0 - LEDGER (always runs)
+# --------------------------------------------------------------------------
+def gate_ledger(ledger) -> list:
+    """Validate the ledger's vocabulary before any other gate reports anything.
+
+    Runs on every invocation, including a single-gate one. A green gate over a
+    ledger whose vocabulary is wrong is worse than a red one: the other three
+    gates keep checking text and keep passing, so the report reads clean while
+    the rule that was supposed to fire never looked at anything.
+    """
+    findings = []
+    for st in statements(ledger):
+        stid = st.get("id", "?")
+        for field in REQUIRED_ON_STATEMENT:
+            if not st.get(field):
+                findings.append(f"{stid}: {field} ontbreekt")
+        for field, allowed in VOCABULARY.items():
+            if field.startswith("anchoring."):
+                value = (st.get("anchoring") or {}).get(field.split(".", 1)[1])
+                if value is None:
+                    findings.append(f"{stid}: anchoring.status ontbreekt")
+                    continue
+            else:
+                value = st.get(field)
+                if value is None:
+                    continue  # optional; absence is handled above where required
+            if value not in allowed:
+                findings.append(f"{stid}: {field}={value!r} staat niet in het "
+                                f"vocabulaire ({', '.join(sorted(allowed))})")
+    for seg in segments(ledger):
+        disp = seg.get("disposition")
+        if disp not in VALID_DISPOSITIONS:
+            findings.append(f"segment {seg.get('id', '?')}: disposition={disp!r} staat niet "
+                            f"in het vocabulaire ({', '.join(sorted(VALID_DISPOSITIONS))})")
+    return findings
+
 
 # --------------------------------------------------------------------------
 # Gate 1 - VERBATIM
@@ -198,10 +260,7 @@ def gate_coverage(canonical: Norm, ledger) -> tuple:
 
     for seg in segments(ledger):
         sid = seg.get("id", "?")
-        disp = seg.get("disposition")
-        if disp not in VALID_DISPOSITIONS:
-            findings.append(f"segment {sid}: disposition {disp!r} onbekend "
-                            f"(kies uit {sorted(VALID_DISPOSITIONS)})")
+        disp = seg.get("disposition")   # validity is the ledger gate's job
         if disp in NON_NORMATIVE and not seg.get("reason"):
             findings.append(f"segment {sid}: disposition {disp} zonder reason "
                             "(overslaan mag, stil overslaan niet)")
@@ -371,7 +430,8 @@ def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("command",
-                    choices=["all", "verbatim", "coverage", "anchor", "signaalnet", "explain"])
+                    choices=["all", "ledger", "verbatim", "coverage", "anchor",
+                             "signaalnet", "explain"])
     ap.add_argument("--canonical", required=False)
     ap.add_argument("--ledger", required=False)
     ap.add_argument("--lexicon", help="YAML mapping name -> regex, replaces the default net")
@@ -395,7 +455,13 @@ def main() -> int:
         with open(args.lexicon, encoding="utf-8") as fh:
             lexicon = yaml.safe_load(fh)
 
-    rc = 0
+    # The ledger gate always runs: the other three key on these exact strings,
+    # so a wrong vocabulary makes their green meaningless rather than merely
+    # incomplete.
+    rc = report("LEDGER", gate_ledger(ledger))
+    if args.command == "ledger":
+        return rc
+
     if args.command in ("all", "verbatim"):
         rc |= report("VERBATIM", gate_verbatim(canonical, ledger))
     if args.command in ("all", "coverage"):

--- a/.claude/skills/law-statement-register/scripts/tile.py
+++ b/.claude/skills/law-statement-register/scripts/tile.py
@@ -107,6 +107,21 @@ def main() -> int:
     segments = build_segments(text, re.compile(args.heading_regex),
                               merge_empty=not args.no_merge_empty)
 
+    # Degrading silently is the failure mode that matters here. A document
+    # without numbered headings produces one segment of 40.000 characters, the
+    # coverage gate reports a cheerful 100%, and nothing looks wrong until
+    # someone notices the whole document is a single tile. Say so, in the file
+    # as well as on stderr - a stderr line disappears into a `>` redirect.
+    warning = None
+    if segments and len(text) > 4000:
+        biggest = max(len(s["text"]) for s in segments)
+        if len(segments) == 1:
+            warning = (f"1 segment voor {len(text)} tekens: dit document heeft waarschijnlijk "
+                       f"geen genummerde koppen. Geef --heading-regex mee.")
+        elif biggest > len(text) * 0.6:
+            warning = (f"één segment beslaat {biggest * 100 // len(text)}% van de tekst: de "
+                       f"koppenherkenning pakt waarschijnlijk niet de echte structuur.")
+
     ledger = {
         "document": {
             "id": args.doc_id,
@@ -120,14 +135,22 @@ def main() -> int:
         "segments": segments,
         "statements": [],
     }
+    if warning:
+        ledger["document"]["_waarschuwing_betegeling"] = warning
+
     print("---")
     print("# Concept-ledger uit tile.py. Nog te doen per segment: disposition zetten")
     print("# (met reason als hij niet normative is) en de statements schrijven.")
+    if warning:
+        print(f"# WAARSCHUWING: {warning}")
     print(yaml.safe_dump(ledger, allow_unicode=True, sort_keys=False, width=100), end="")
 
     covered = sum(len(s["text"]) for s in segments)
     sys.stderr.write(f"segmenten={len(segments)} tekens_in_segmenten={covered} "
                      f"tekens_in_canonical={len(text)}\n")
+    if warning:
+        sys.stderr.write(f"WAARSCHUWING: {warning}\n")
+        return 3
     return 0
 
 

--- a/.claude/skills/law-statement-register/scripts/tile.py
+++ b/.claude/skills/law-statement-register/scripts/tile.py
@@ -34,12 +34,26 @@ except ImportError:
 DEFAULT_HEADING = r"^(\d+(?:\.\d+)*)\s+(\S.*)$"
 
 
+# A numbered heading needs a title. A table's header row ("2019 2020 2021 …")
+# matches the same pattern and, left alone, becomes a section heading that cuts
+# the table in half - coverage stays at 100% and the structure is quietly wrong.
+# Two cheap rejections catch it: a tab means table cells (that is what the HTML
+# reader emits), and a "title" without a single three-letter word is not a title.
+WORD = re.compile(r"[A-Za-zÀ-ÿ]{3}")
+
+
+def looks_like_heading(number: str, title: str) -> bool:
+    if "\t" in title:
+        return False
+    return bool(WORD.search(title))
+
+
 def find_headings(lines, pattern):
     """Return [(line_index, number, title)] for every line that looks like a heading."""
     out = []
     for i, line in enumerate(lines):
         m = pattern.match(line.strip())
-        if m:
+        if m and looks_like_heading(m.group(1), m.group(2).strip()):
             out.append((i, m.group(1), m.group(2).strip()))
     return out
 

--- a/.claude/skills/law-statement-register/scripts/tile.py
+++ b/.claude/skills/law-statement-register/scripts/tile.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Tile canonical.md into segments (fase 2) - a draft ledger, by construction complete.
+
+The tiling is mechanical on purpose. If a human types the segments by hand, the
+100%-coverage rule becomes a chore and the chore becomes a shortcut. Here the
+segments are cut from the text itself, so `concat(segments) == canonical` holds
+before anyone has made a single judgement call.
+
+What the script does NOT do is decide anything: every segment comes out as
+`disposition: normative` with no statements. Setting dispositions (with a reason),
+writing statements and doing the verankering is the reading work, and that is
+where the judgement belongs.
+
+Headings are detected as numbered lines ("4", "4.3", "4.3.1 Titel"); the heading
+path is derived from the numbering depth. Consecutive headings with no body
+between them are merged into one segment, which collapses a table of contents
+into a single block instead of forty empty ones.
+
+Usage:
+  python3 tile.py canonical.md > statements.draft.yaml
+  python3 tile.py canonical.md --heading-regex '^(\\d+(?:\\.\\d+)*)\\s+(\\S.*)$'
+  python3 tile.py canonical.md --no-merge-empty
+"""
+import argparse
+import re
+import sys
+
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write("tile.py requires pyyaml (pip install pyyaml)\n")
+    sys.exit(2)
+
+DEFAULT_HEADING = r"^(\d+(?:\.\d+)*)\s+(\S.*)$"
+
+
+def find_headings(lines, pattern):
+    """Return [(line_index, number, title)] for every line that looks like a heading."""
+    out = []
+    for i, line in enumerate(lines):
+        m = pattern.match(line.strip())
+        if m:
+            out.append((i, m.group(1), m.group(2).strip()))
+    return out
+
+
+def build_segments(text, pattern, merge_empty=True):
+    lines = text.split("\n")
+    heads = find_headings(lines, pattern)
+
+    # Cut points: start of the text, then every heading line.
+    cuts = [0] + [i for i, _, _ in heads]
+    blocks = []
+    for n, start in enumerate(cuts):
+        end = cuts[n + 1] if n + 1 < len(cuts) else len(lines)
+        head = next((h for h in heads if h[0] == start), None)
+        body = "\n".join(lines[start:end]).strip("\n")
+        if body:
+            blocks.append({"head": head, "text": body})
+
+    if merge_empty:
+        merged = []
+        for b in blocks:
+            body_lines = [ln for ln in b["text"].split("\n")[1:] if ln.strip()]
+            heading_only = b["head"] is not None and not body_lines
+            if heading_only and merged:
+                merged[-1]["text"] += "\n" + b["text"]
+                merged[-1]["merged"] = merged[-1].get("merged", 0) + 1
+            else:
+                merged.append(b)
+        blocks = merged
+
+    # Heading path: keep a stack keyed on numbering depth.
+    segments, stack = [], []
+    for n, b in enumerate(blocks, start=1):
+        seg = {"id": f"s{n:03d}"}
+        if b["head"]:
+            _, number, title = b["head"]
+            depth = number.count(".")
+            stack = stack[:depth]
+            stack.append(f"{number} {title}")
+            seg["number"] = number
+            seg["path"] = list(stack)
+        else:
+            seg["path"] = list(stack)
+        seg["disposition"] = "normative"
+        seg["text"] = b["text"]
+        if b.get("merged"):
+            seg["_note"] = (f"{b['merged']} kop(pen) zonder eigen tekst hierin samengevoegd "
+                            "- controleer of dit een inhoudsopgave is")
+        segments.append(seg)
+    return segments
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("canonical")
+    ap.add_argument("--heading-regex", default=DEFAULT_HEADING)
+    ap.add_argument("--no-merge-empty", action="store_true")
+    ap.add_argument("--doc-id", default="CHANGE_ME")
+    args = ap.parse_args()
+
+    with open(args.canonical, encoding="utf-8") as fh:
+        text = fh.read()
+
+    segments = build_segments(text, re.compile(args.heading_regex),
+                              merge_empty=not args.no_merge_empty)
+
+    ledger = {
+        "document": {
+            "id": args.doc_id,
+            "title": "CHANGE_ME",
+            "source_url": "CHANGE_ME",
+            "source_sha256": "zie manifest.yaml",
+            "retrieved_at": "zie manifest.yaml",
+            "status": "CHANGE_ME: beleidsregel | toelichting | werkinstructie | handboek | faq",
+            "canonical": args.canonical.split("/")[-1],
+        },
+        "segments": segments,
+        "statements": [],
+    }
+    print("---")
+    print("# Concept-ledger uit tile.py. Nog te doen per segment: disposition zetten")
+    print("# (met reason als hij niet normative is) en de statements schrijven.")
+    print(yaml.safe_dump(ledger, allow_unicode=True, sort_keys=False, width=100), end="")
+
+    covered = sum(len(s["text"]) for s in segments)
+    sys.stderr.write(f"segmenten={len(segments)} tekens_in_segmenten={covered} "
+                     f"tekens_in_canonical={len(text)}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/law-statement-register/templates/register.md
+++ b/.claude/skills/law-statement-register/templates/register.md
@@ -1,0 +1,110 @@
+# Statement-register — {{DOCUMENT}} ({{VERSIE}})
+
+> **Methode.** Statements ontgonnen uit *{{DOCUMENT_TITEL}}* volgens de skill
+> `law-statement-register`: betegelen → ankeren → verankeren → classificeren, met vier
+> gates (verbatim / coverage / anchor / signaalnet) als bewijs.
+>
+> **Kernprincipe.** *De norm is leidend; deze tekst is uitleg, géén norm.* Per statement:
+> **verbatim citaat → verankering in een norm? → classificatie → actie.** Buckets:
+> **MODELFOUT** (model ≠ letter → fix richting de letter) · **WETTEKST-GEVOLG** (model =
+> letter, letter geeft een vreemde uitkomst → rapporteren, niet fixen) ·
+> **LETTER-vs-TOELICHTING** (tekst en norm divergeren → jurist beslist + wetgevings-signaal).
+>
+> **Een statement wordt nooit op eigen gezag een modelwijziging.**
+
+## Bron en dekking
+
+| | |
+|---|---|
+| Document | {{DOCUMENT_TITEL}} |
+| Status | {{beleidsregel / toelichting / werkinstructie / handboek / faq}} |
+| Bindendheidsclausule | *"{{verbatim disclaimerzin, of: geen}}"* |
+| URL | {{URL}} |
+| `source_sha256` | `{{HASH}}` |
+| Opgehaald | {{YYYY-MM-DD}} |
+| Grondslag | {{regeling + artikel waar dit document uitvoering aan geeft}} |
+
+| Dekking | |
+|---|---|
+| Betegeld | {{100,0}}% van {{N}} tekens |
+| Segmenten | {{N}} normatief · {{N}} informative · {{N}} navigational · {{N}} duplicate · {{N}} non-textual |
+| Signaalnet | {{N}} treffers, {{N}} ongedekt |
+| Statements | {{N}} |
+| Gates | verbatim ✅ · coverage ✅ · anchor ✅ · signaalnet ✅ |
+
+*Als een gate niet schoon is, staat hier waarom en wat er open blijft — niet een vinkje.*
+
+---
+
+## S1 — {{korte titel}}
+
+- **Slug.** `{{slug}}` · **{{§-verwijzing}} (p{{n}})**
+- **Verbatim.** *"{{letterlijk citaat uit canonical.md}}"*
+- **Verankering.** {{verankerd / geparafraseerd / niet-gevonden}}.
+  - *verankerd/geparafraseerd*: {{norm_ref}} — *"{{verbatim norm-citaat}}"*
+  - *niet-gevonden*: gezocht op {{zoektermen}} in {{zoekruimte}} — geen normtekst bevat dit.
+- **Bindendheid.** {{hard / soft-default / guidance / informative}}{{, met toelichting als de
+  formulering zacht is}}
+- **Afwijkingsklasse.** {{toelichting-bleed / ontbrekend-bestanddeel / verkeerde-verankering /
+  herformulering / bindendheid-vervlakking / buitenwettelijk / geen}}
+- **Classificatie: {{BUCKET}}.** {{waarom dit label en niet het aangrenzende}}
+- **Actie / jurist-vraag.** {{concreet; bij LETTER-vs-TOELICHTING: de vraag zelf, plus het
+  wetgevings-signaal (hoort dit in de regeling?), plus wat het model tot die beslissing doet}}
+
+## S2 — {{...}}
+
+{{herhaal}}
+
+---
+
+## Samenvatting per bucket
+
+| Bucket | Statements | Actie |
+|---|---|---|
+| **MODELFOUT (fix richting letter)** | {{S…}} | {{}} |
+| **WETTEKST-GEVOLG (rapporteren)** | {{S…}} | geen fix; model is letter-getrouw |
+| **LETTER-vs-TOELICHTING (jurist)** | {{S…}} | {{de vraag + wetgevings-signaal}} |
+| **Letter-getrouw ✅** | {{S…}} | geen wijziging |
+| **Scope** | {{S…}} | {{beslisvraag}} |
+
+## Bewust niet als statement opgenomen
+
+Segmenten met een niet-normatieve `disposition`, zodat zichtbaar is wát is overgeslagen en
+waarom. Dit is geen bijlage maar het bewijs dat er niets stil is weggevallen.
+
+| Segment | Disposition | Reden |
+|---|---|---|
+| {{s0nn}} {{kop}} | {{informative}} | {{reden}} |
+
+## Rekenvoorbeelden
+
+{{Genummerde rekenvoorbeelden met bedragen zijn direct bruikbaar als BDD-scenario
+(`law-mvt-research`, `regelrecht-scenario-traces`). Als het document er geen bevat, zeg dat
+expliciet — een lege sectie is een bevinding, geen weglating.}}
+
+## Open punten
+
+{{Wat deze ronde niet is opgelost, met wie het moet beslissen. Bij een tweede versie: zie
+de diff-sectie hieronder.}}
+
+---
+
+## Diff ten opzichte van {{VORIGE_VERSIE}}
+
+*Alleen bij een herziening. Het nieuwe register is blind ontgonnen; dit is de vergelijking
+achteraf. Zie `references/diff.md`.*
+
+| Categorie | Slug | v{{1}} | v{{2}} | Oordeel |
+|---|---|---|---|---|
+| `added` | {{slug}} | — | *"{{citaat}}"* | {{bucket + betekenis}} |
+| `candidate-removed` | {{slug}} | *"{{citaat}}"* | — | {{geschrapt / verplaatst / anker te specifiek}} |
+| `changed-strekking` | {{slug}} | *"{{citaat}}"* | *"{{citaat}}"* | {{wat er inhoudelijk wijzigde}} |
+| `reworded` | {{slug}} | *"{{citaat}}"* | *"{{citaat}}"* | same-strekking |
+| `unchanged` | {{n}} statements | | | |
+
+**Dekkingsvergelijking.** v1: {{N}} statements bij {{N}} signaalnet-treffers · v2: {{N}} bij
+{{N}}. {{Als het aantal statements stijgt zonder dat het document groeide: dat meet de vorige
+ronde, geen beleidswijziging — zeg dat hier.}}
+
+**Blijvend open.** {{Statements die in beide versies `niet-gevonden` zijn: een jurist-vraag
+die een herziening heeft overleefd.}}

--- a/.claude/skills/law-statement-register/tests/README.md
+++ b/.claude/skills/law-statement-register/tests/README.md
@@ -41,10 +41,17 @@ met anker, verankering, bindendheid en bucket.
 | C | S5 ankert op het kale woord "vrijgelaten" (twee treffers) | `anchor` |
 | D | S8 ontbreekt, de "Indien ..."-zin is stil overgeslagen | `signaalnet` |
 | E | S3 noteert `niet-gevonden` zonder zoektermen | `verbatim` |
+| F | S6 draagt een `bindingness` buiten het vocabulaire | `ledger` |
 
 A en E zitten allebei op de verbatim-gate omdat ze dezelfde belofte breken: wat het register
-beweert over de tekst is niet na te lopen. D is de belangrijkste van de vijf — het is de enige
+beweert over de tekst is niet na te lopen. D is de belangrijkste van de zes — het is de enige
 die niemand opmerkt zonder gate, want het register ziet er volledig uit.
+
+F is er bijgekomen nadat bleek dat een ledger met vier verzonnen vocabulaire-waarden schoon
+door alle gates kwam. De ernstigste variant is een typefout in `anchoring.status`: de
+zoektermen-eis kijkt naar de string `niet-gevonden`, dus `nietgevonden` schakelt hem uit
+zonder een woord. Daarom draait de ledger-gate bij élke aanroep, en test `run.sh` dat ook
+apart — een losse `anchor`-aanroep moet nog steeds de LEDGER-regel tonen.
 
 ## Bij het aanpassen van de fixture
 

--- a/.claude/skills/law-statement-register/tests/README.md
+++ b/.claude/skills/law-statement-register/tests/README.md
@@ -1,0 +1,54 @@
+# Fixture en gate-tests
+
+```bash
+bash tests/run.sh
+```
+
+Bewijst dat elke gate zijn eigen defect pakt. Een gate die faalt op een ándere reden dan de
+zijne telt als testfout — anders zou een kapotte gate groen kunnen lijken zolang er *iets*
+misgaat.
+
+## De fixture
+
+`canonical.md` is een **verzonnen** toelichting op een **verzonnen** regeling, in een
+**verzonnen** norm-corpus. Dat is een harde eis, geen gemak: deze repo is publiek, en de
+leak-guard `script/check-skills-no-casus.sh` bewaakt dat skills dossier-agnostisch blijven.
+Gebruik nooit een echt dossier-document, echt citaat of echte organisatienaam in deze map.
+
+Het document is klein maar bevat met opzet elk ding dat de methode moet aankunnen:
+
+| In de fixture | Waarom |
+|---|---|
+| een disclaimerzin ("geen rechten worden ontleend") | documentstatus die alle statements erin bindt |
+| een colofon en een titelregel | segmenten die `informative` / `navigational` moeten worden |
+| "in de regel ten hoogste 1.200 euro" | `soft-default`: de bindendheid-vervlakking-val |
+| een tweede vrijlating die in geen norm staat | `niet-gevonden` → LETTER-vs-TOELICHTING |
+| het woord "vrijgelaten" dat twee keer voorkomt | maakt een ambigu anker mogelijk |
+| een gevolg-zin met "Indien ..." | normzin die het signaalnet moet redden als de lezer hem mist |
+
+## De twee ledgers
+
+`statements.clean.yaml` betegelt `canonical.md` voor 100% en haalt alle vier gates. Het is
+ook het uitgewerkte voorbeeld van het ledger-formaat: segmenten met `disposition`, statements
+met anker, verankering, bindendheid en bucket.
+
+`statements.broken.yaml` is hetzelfde bestand met vijf opzettelijke defecten:
+
+| | Defect | Gate |
+|---|---|---|
+| A | S4 citeert "twintig procent" waar het document "20%" zegt | `verbatim` |
+| B | het colofon-segment ontbreekt | `coverage` |
+| C | S5 ankert op het kale woord "vrijgelaten" (twee treffers) | `anchor` |
+| D | S8 ontbreekt, de "Indien ..."-zin is stil overgeslagen | `signaalnet` |
+| E | S3 noteert `niet-gevonden` zonder zoektermen | `verbatim` |
+
+A en E zitten allebei op de verbatim-gate omdat ze dezelfde belofte breken: wat het register
+beweert over de tekst is niet na te lopen. D is de belangrijkste van de vijf — het is de enige
+die niemand opmerkt zonder gate, want het register ziet er volledig uit.
+
+## Bij het aanpassen van de fixture
+
+Verander je `canonical.md`, dan moeten beide ledgers mee: de segmentteksten worden letterlijk
+in de canonieke tekst gezocht en moeten elkaar aansluitend opvolgen. Draai daarna
+`tests/run.sh` én yamllint (`--strict -c .yamllint`) — de fixture-YAML's vallen onder dezelfde
+pre-commit-hooks als de rest van de repo.

--- a/.claude/skills/law-statement-register/tests/fixture/canonical.md
+++ b/.claude/skills/law-statement-register/tests/fixture/canonical.md
@@ -1,0 +1,26 @@
+Toelichting fictieve tegemoetkoming
+
+1 Inleiding
+
+Deze toelichting legt uit hoe de fictieve tegemoetkoming wordt vastgesteld. Aan deze
+toelichting kunnen geen rechten worden ontleend.
+
+2 Wie komt in aanmerking
+
+De aanvrager moet op de peildatum ingezetene zijn van het werkgebied. Een aanvrager die
+in het buitenland woont komt niet in aanmerking.
+
+3 Berekening
+
+Van het besteedbaar inkomen wordt 20% vrijgelaten. Omdat er ook andere heffingen worden
+opgelegd, wordt van het bedrag dat overblijft nog eens 50% vrijgelaten. De tegemoetkoming
+bedraagt in de regel ten hoogste 1.200 euro per jaar.
+
+4 Aanvraag
+
+Het verzoek wordt binnen 6 weken na dagtekening ingediend. Indien het verzoek te laat
+wordt ingediend, wordt het niet in behandeling genomen.
+
+5 Colofon
+
+Vastgesteld door het fictieve bestuur. Vragen? Bel het informatienummer.

--- a/.claude/skills/law-statement-register/tests/fixture/statements.broken.yaml
+++ b/.claude/skills/law-statement-register/tests/fixture/statements.broken.yaml
@@ -1,0 +1,193 @@
+---
+# Same fixture, with five deliberate defects - one per failure mode the gates
+# exist to catch. tests/run.sh asserts that each gate reports its own defect.
+#
+#   A  VERBATIM   S4 quote is paraphrased ("twintig procent" for "20%")
+#   B  COVERAGE   segment s006 (colofon) is missing entirely -> gap at the end
+#   C  ANCHOR     S5 anchors on the bare word "vrijgelaten" -> two matches
+#   D  SIGNAALNET S8 is missing -> the "Indien ..." sentence is passed over
+#   E  VERBATIM   S3 records a niet-gevonden anchoring without search terms
+document:
+  id: toelichting_fictieve_tegemoetkoming
+  title: Toelichting fictieve tegemoetkoming
+  source_url: https://example.org/fictief/toelichting.pdf
+  source_sha256: '0000000000000000000000000000000000000000000000000000000000000000'
+  retrieved_at: '2026-01-01'
+  status: toelichting
+  canonical: canonical.md
+
+segments:
+  - id: s001
+    path: []
+    disposition: navigational
+    reason: Titelregel, geen normatieve inhoud.
+    text: Toelichting fictieve tegemoetkoming
+
+  - id: s002
+    number: '1'
+    path: [1 Inleiding]
+    disposition: normative
+    text: |-
+      1 Inleiding
+
+      Deze toelichting legt uit hoe de fictieve tegemoetkoming wordt vastgesteld. Aan deze
+      toelichting kunnen geen rechten worden ontleend.
+
+  - id: s003
+    number: '2'
+    path: [2 Wie komt in aanmerking]
+    disposition: normative
+    text: |-
+      2 Wie komt in aanmerking
+
+      De aanvrager moet op de peildatum ingezetene zijn van het werkgebied. Een aanvrager die
+      in het buitenland woont komt niet in aanmerking.
+
+  - id: s004
+    number: '3'
+    path: [3 Berekening]
+    disposition: normative
+    text: |-
+      3 Berekening
+
+      Van het besteedbaar inkomen wordt 20% vrijgelaten. Omdat er ook andere heffingen worden
+      opgelegd, wordt van het bedrag dat overblijft nog eens 50% vrijgelaten. De tegemoetkoming
+      bedraagt in de regel ten hoogste 1.200 euro per jaar.
+
+  - id: s005
+    number: '4'
+    path: [4 Aanvraag]
+    disposition: normative
+    text: |-
+      4 Aanvraag
+
+      Het verzoek wordt binnen 6 weken na dagtekening ingediend. Indien het verzoek te laat
+      wordt ingediend, wordt het niet in behandeling genomen.
+
+  # DEFECT B: segment s006 (colofon) ontbreekt.
+
+statements:
+  - id: S1
+    slug: documentstatus-geen-rechten
+    segment: s002
+    quote: Aan deze toelichting kunnen geen rechten worden ontleend.
+    anchor:
+      exact: geen rechten worden ontleend
+      prefix: 'Aan deze toelichting kunnen '
+      suffix: . 2 Wie komt
+    type: informatief
+    bindingness: informative
+    anchoring:
+      status: niet-gevonden
+      search_terms: [rechten ontlenen, geen rechten]
+      searched_in: [regulation/**/*.yaml]
+    bucket: letter-getrouw
+    action: Geen actie.
+
+  - id: S2
+    slug: ingezetene-op-peildatum
+    segment: s003
+    quote: De aanvrager moet op de peildatum ingezetene zijn van het werkgebied.
+    anchor:
+      exact: moet op de peildatum ingezetene zijn
+      prefix: 'De aanvrager '
+      suffix: ' van het werkgebied.'
+    type: normatief
+    bindingness: hard
+    anchoring:
+      status: verankerd
+      norm_ref: fictieve_verordening art 2 lid 1
+      norm_quote: ingezetene van het werkgebied op de peildatum
+    bucket: letter-getrouw
+    action: Geen wijziging.
+
+  - id: S3
+    slug: uitsluiting-buitenland
+    segment: s003
+    quote: Een aanvrager die in het buitenland woont komt niet in aanmerking.
+    anchor:
+      exact: komt niet in aanmerking
+      prefix: 'in het buitenland woont '
+      suffix: . 3 Berekening
+    type: uitzondering
+    bindingness: hard
+    anchoring:
+      # DEFECT E: negatieve bevinding zonder zoektermen - niet overdoenbaar.
+      status: niet-gevonden
+      searched_in: [regulation/**/*.yaml]
+    bucket: LETTER-vs-TOELICHTING
+    action: Jurist-vraag.
+
+  - id: S4
+    slug: eerste-vrijlating-20pct
+    segment: s004
+    # DEFECT A: geparafraseerd citaat, niet verbatim.
+    quote: Van het besteedbaar inkomen wordt twintig procent vrijgelaten.
+    anchor:
+      exact: wordt 20% vrijgelaten
+      prefix: 'Van het besteedbaar inkomen '
+      suffix: . Omdat er ook
+    type: kwantitatief
+    bindingness: hard
+    anchoring:
+      status: verankerd
+      norm_ref: fictieve_verordening art 3 lid 1
+      norm_quote: ten minste 80 percent van het besteedbaar inkomen is aangewend
+    bucket: letter-getrouw
+    action: Geen wijziging.
+
+  - id: S5
+    slug: tweede-vrijlating-50pct
+    segment: s004
+    quote: >-
+      Omdat er ook andere heffingen worden opgelegd, wordt van het bedrag dat overblijft
+      nog eens 50% vrijgelaten.
+    anchor:
+      # DEFECT C: geen context, "vrijgelaten" komt twee keer voor.
+      exact: vrijgelaten
+      prefix: ''
+      suffix: ''
+    type: kwantitatief
+    bindingness: hard
+    anchoring:
+      status: niet-gevonden
+      search_terms: [50%, vrijlating]
+      searched_in: [regulation/**/*.yaml]
+    bucket: LETTER-vs-TOELICHTING
+    action: Jurist-vraag.
+
+  - id: S6
+    slug: maximum-per-jaar
+    segment: s004
+    quote: De tegemoetkoming bedraagt in de regel ten hoogste 1.200 euro per jaar.
+    anchor:
+      exact: in de regel ten hoogste 1.200 euro per jaar
+      prefix: 'De tegemoetkoming bedraagt '
+      suffix: . 4 Aanvraag
+    type: kwantitatief
+    bindingness: soft-default
+    anchoring:
+      status: niet-gevonden
+      search_terms: ['1.200', ten hoogste]
+      searched_in: [regulation/**/*.yaml]
+    bucket: LETTER-vs-TOELICHTING
+    action: Jurist-vraag.
+
+  - id: S7
+    slug: indieningstermijn-6-weken
+    segment: s005
+    quote: Het verzoek wordt binnen 6 weken na dagtekening ingediend.
+    anchor:
+      exact: binnen 6 weken na dagtekening
+      prefix: 'Het verzoek wordt '
+      suffix: ' ingediend.'
+    type: procedureel
+    bindingness: hard
+    anchoring:
+      status: verankerd
+      norm_ref: fictieve_verordening art 5 lid 1
+      norm_quote: binnen zes weken na de dagtekening van de beschikking
+    bucket: letter-getrouw
+    action: Geen wijziging.
+
+# DEFECT D: S8 (gevolg te late indiening) ontbreekt.

--- a/.claude/skills/law-statement-register/tests/fixture/statements.broken.yaml
+++ b/.claude/skills/law-statement-register/tests/fixture/statements.broken.yaml
@@ -7,6 +7,7 @@
 #   C  ANCHOR     S5 anchors on the bare word "vrijgelaten" -> two matches
 #   D  SIGNAALNET S8 is missing -> the "Indien ..." sentence is passed over
 #   E  VERBATIM   S3 records a niet-gevonden anchoring without search terms
+#   F  LEDGER     S6 carries a bindingness outside the controlled vocabulary
 document:
   id: toelichting_fictieve_tegemoetkoming
   title: Toelichting fictieve tegemoetkoming
@@ -165,7 +166,8 @@ statements:
       prefix: 'De tegemoetkoming bedraagt '
       suffix: . 4 Aanvraag
     type: kwantitatief
-    bindingness: soft-default
+    # DEFECT F: buiten het vocabulaire - de bindendheid-as wordt hiermee zinloos.
+    bindingness: heel-hard
     anchoring:
       status: niet-gevonden
       search_terms: ['1.200', ten hoogste]

--- a/.claude/skills/law-statement-register/tests/fixture/statements.clean.yaml
+++ b/.claude/skills/law-statement-register/tests/fixture/statements.clean.yaml
@@ -1,0 +1,228 @@
+---
+# Reference ledger for the fixture: tiles canonical.md completely and passes all
+# four gates. Fictional document, fictional norm corpus - see tests/README.md.
+document:
+  id: toelichting_fictieve_tegemoetkoming
+  title: Toelichting fictieve tegemoetkoming
+  source_url: https://example.org/fictief/toelichting.pdf
+  source_sha256: '0000000000000000000000000000000000000000000000000000000000000000'
+  retrieved_at: '2026-01-01'
+  status: toelichting
+  binding_note: Aan deze toelichting kunnen geen rechten worden ontleend.
+  canonical: canonical.md
+
+segments:
+  - id: s001
+    path: []
+    disposition: navigational
+    reason: Titelregel, geen normatieve inhoud.
+    text: Toelichting fictieve tegemoetkoming
+
+  - id: s002
+    number: '1'
+    path: [1 Inleiding]
+    disposition: normative
+    text: |-
+      1 Inleiding
+
+      Deze toelichting legt uit hoe de fictieve tegemoetkoming wordt vastgesteld. Aan deze
+      toelichting kunnen geen rechten worden ontleend.
+
+  - id: s003
+    number: '2'
+    path: [2 Wie komt in aanmerking]
+    disposition: normative
+    text: |-
+      2 Wie komt in aanmerking
+
+      De aanvrager moet op de peildatum ingezetene zijn van het werkgebied. Een aanvrager die
+      in het buitenland woont komt niet in aanmerking.
+
+  - id: s004
+    number: '3'
+    path: [3 Berekening]
+    disposition: normative
+    text: |-
+      3 Berekening
+
+      Van het besteedbaar inkomen wordt 20% vrijgelaten. Omdat er ook andere heffingen worden
+      opgelegd, wordt van het bedrag dat overblijft nog eens 50% vrijgelaten. De tegemoetkoming
+      bedraagt in de regel ten hoogste 1.200 euro per jaar.
+
+  - id: s005
+    number: '4'
+    path: [4 Aanvraag]
+    disposition: normative
+    text: |-
+      4 Aanvraag
+
+      Het verzoek wordt binnen 6 weken na dagtekening ingediend. Indien het verzoek te laat
+      wordt ingediend, wordt het niet in behandeling genomen.
+
+  - id: s006
+    number: '5'
+    path: [5 Colofon]
+    disposition: informative
+    reason: Vaststellingsregel en contactgegevens; geen norm en geen uitleg van een norm.
+    text: |-
+      5 Colofon
+
+      Vastgesteld door het fictieve bestuur. Vragen? Bel het informatienummer.
+
+statements:
+  - id: S1
+    slug: documentstatus-geen-rechten
+    segment: s002
+    quote: Aan deze toelichting kunnen geen rechten worden ontleend.
+    anchor:
+      exact: geen rechten worden ontleend
+      prefix: 'Aan deze toelichting kunnen '
+      suffix: . 2 Wie komt
+    type: informatief
+    bindingness: informative
+    anchoring:
+      status: niet-gevonden
+      search_terms: [rechten ontlenen, geen rechten, status toelichting]
+      searched_in: [regulation/**/*.yaml]
+    deviation_class: geen
+    bucket: letter-getrouw
+    action: >-
+      Geen actie. Bepaalt wel de status van het hele document: statements hieruit zijn
+      uitleg, nooit zelfstandige norm.
+
+  - id: S2
+    slug: ingezetene-op-peildatum
+    segment: s003
+    quote: De aanvrager moet op de peildatum ingezetene zijn van het werkgebied.
+    anchor:
+      exact: moet op de peildatum ingezetene zijn
+      prefix: 'De aanvrager '
+      suffix: ' van het werkgebied.'
+    type: normatief
+    bindingness: hard
+    anchoring:
+      status: verankerd
+      norm_ref: fictieve_verordening art 2 lid 1
+      norm_quote: ingezetene van het werkgebied op de peildatum
+    deviation_class: geen
+    bucket: letter-getrouw
+    action: Geen wijziging.
+
+  - id: S3
+    slug: uitsluiting-buitenland
+    segment: s003
+    quote: Een aanvrager die in het buitenland woont komt niet in aanmerking.
+    anchor:
+      exact: komt niet in aanmerking
+      prefix: 'in het buitenland woont '
+      suffix: . 3 Berekening
+    type: uitzondering
+    bindingness: hard
+    anchoring:
+      status: geparafraseerd
+      norm_ref: fictieve_verordening art 2 lid 1
+      norm_quote: ingezetene van het werkgebied op de peildatum
+    deviation_class: herformulering
+    bucket: letter-getrouw
+    action: >-
+      Geen wijziging; de uitsluiting is de spiegelzijde van de ingezetene-eis, geen
+      zelfstandig criterium.
+
+  - id: S4
+    slug: eerste-vrijlating-20pct
+    segment: s004
+    quote: Van het besteedbaar inkomen wordt 20% vrijgelaten.
+    anchor:
+      exact: wordt 20% vrijgelaten
+      prefix: 'Van het besteedbaar inkomen '
+      suffix: . Omdat er ook
+    type: kwantitatief
+    bindingness: hard
+    anchoring:
+      status: verankerd
+      norm_ref: fictieve_verordening art 3 lid 1
+      norm_quote: ten minste 80 percent van het besteedbaar inkomen is aangewend
+    deviation_class: geen
+    bucket: letter-getrouw
+    action: Geen wijziging.
+
+  - id: S5
+    slug: tweede-vrijlating-50pct
+    segment: s004
+    quote: >-
+      Omdat er ook andere heffingen worden opgelegd, wordt van het bedrag dat overblijft
+      nog eens 50% vrijgelaten.
+    anchor:
+      exact: nog eens 50% vrijgelaten
+      prefix: 'dat overblijft '
+      suffix: . De tegemoetkoming
+    type: kwantitatief
+    bindingness: hard
+    anchoring:
+      status: niet-gevonden
+      search_terms: [50%, vrijlating, nog eens, andere heffingen]
+      searched_in: [regulation/**/*.yaml]
+    deviation_class: toelichting-bleed
+    bucket: LETTER-vs-TOELICHTING
+    action: >-
+      Jurist-vraag: is de tweede vrijlating bindend beleid? Zo ja, hoort hij in de
+      verordening, niet in de toelichting. Model blijft tot dat besluit op 80%.
+
+  - id: S6
+    slug: maximum-per-jaar
+    segment: s004
+    quote: De tegemoetkoming bedraagt in de regel ten hoogste 1.200 euro per jaar.
+    anchor:
+      exact: in de regel ten hoogste 1.200 euro per jaar
+      prefix: 'De tegemoetkoming bedraagt '
+      suffix: . 4 Aanvraag
+    type: kwantitatief
+    bindingness: soft-default
+    anchoring:
+      status: niet-gevonden
+      search_terms: ['1.200', ten hoogste, maximum tegemoetkoming]
+      searched_in: [regulation/**/*.yaml]
+    deviation_class: toelichting-bleed
+    bucket: LETTER-vs-TOELICHTING
+    action: >-
+      Jurist-vraag. Let op de bindendheid: "in de regel" is een weerlegbare hoofdregel,
+      geen hard maximum. Als harde grens modelleren zou de afwijkbevoegdheid wegnemen.
+
+  - id: S7
+    slug: indieningstermijn-6-weken
+    segment: s005
+    quote: Het verzoek wordt binnen 6 weken na dagtekening ingediend.
+    anchor:
+      exact: binnen 6 weken na dagtekening
+      prefix: 'Het verzoek wordt '
+      suffix: ' ingediend.'
+    type: procedureel
+    bindingness: hard
+    anchoring:
+      status: verankerd
+      norm_ref: fictieve_verordening art 5 lid 1
+      norm_quote: binnen zes weken na de dagtekening van de beschikking
+    deviation_class: geen
+    bucket: letter-getrouw
+    action: Geen wijziging.
+
+  - id: S8
+    slug: gevolg-te-late-indiening
+    segment: s005
+    quote: >-
+      Indien het verzoek te laat wordt ingediend, wordt het niet in behandeling genomen.
+    anchor:
+      exact: wordt het niet in behandeling genomen
+      prefix: 'te laat wordt ingediend, '
+      suffix: . 5 Colofon
+    type: procedureel
+    bindingness: hard
+    anchoring:
+      status: niet-gevonden
+      search_terms: [niet in behandeling, termijnoverschrijding, te laat]
+      searched_in: [regulation/**/*.yaml]
+    deviation_class: toelichting-bleed
+    bucket: LETTER-vs-TOELICHTING
+    action: >-
+      Jurist-vraag: de verordening kent de sanctie niet-ontvankelijk niet expliciet;
+      Awb 4:5 zou een herstelmogelijkheid vergen. Signaal voor de verordening.

--- a/.claude/skills/law-statement-register/tests/fixture/tabelkop.md
+++ b/.claude/skills/law-statement-register/tests/fixture/tabelkop.md
@@ -1,0 +1,10 @@
+1 Bijdrage
+
+De bijdrage wordt jaarlijks vastgesteld.
+
+2025	2026
+€ 1.200,00	€ 1.230,00
+
+2 Aanvraag
+
+Het verzoek wordt schriftelijk ingediend.

--- a/.claude/skills/law-statement-register/tests/run.sh
+++ b/.claude/skills/law-statement-register/tests/run.sh
@@ -71,6 +71,26 @@ else
     fails=$((fails + 1))
 fi
 
+# Gevonden op een echt handboek: een tabelkopregel ("2025<tab>2026") matcht de
+# koppenregex en wordt dan een sectiekop die dwars door de tabel snijdt. De
+# dekking blijft 100%, dus geen enkele gate ziet het - alleen de structuur klopt
+# niet meer.
+echo
+echo "== tabelkoppen worden niet voor sectiekoppen aangezien =="
+tile_out="$(python3 "$HERE/../scripts/tile.py" "$FIX/tabelkop.md" 2>/dev/null)"
+if grep -qE "^\s+- 2025 2026$|number: '2025'" <<<"$tile_out"; then
+    echo "FAIL  tabelkopregel werd een sectiekop"
+    fails=$((fails + 1))
+else
+    n_seg="$(grep -cE '^- id: s[0-9]+' <<<"$tile_out")"
+    if [[ "$n_seg" -ne 2 ]]; then
+        echo "FAIL  verwacht 2 segmenten (de twee echte koppen), kreeg $n_seg"
+        fails=$((fails + 1))
+    else
+        echo "ok    tabelkopregel blijft inhoud; 2 segmenten, de twee echte koppen"
+    fi
+fi
+
 echo
 if [[ $fails -eq 0 ]]; then
     echo "ALLE TESTS OK"

--- a/.claude/skills/law-statement-register/tests/run.sh
+++ b/.claude/skills/law-statement-register/tests/run.sh
@@ -23,7 +23,7 @@ expect_pass() {  # gate
         echo "$out" | sed 's/^/      /'
         fails=$((fails + 1))
     else
-        echo "ok    $gate  clean   -> $(echo "$out" | head -1)"
+        echo "ok    $gate  clean   -> $(grep -i -m1 "$gate" <<<"$out" || echo "$out" | head -1)"
     fi
 }
 
@@ -44,7 +44,7 @@ expect_fail() {  # gate, marker
 }
 
 echo "== schone ledger: alle gates slagen =="
-for g in verbatim coverage anchor signaalnet; do expect_pass "$g"; done
+for g in ledger verbatim coverage anchor signaalnet; do expect_pass "$g"; done
 
 echo
 echo "== kapotte ledger: elke gate pakt zijn eigen defect =="
@@ -53,6 +53,23 @@ expect_fail verbatim   "zonder search_terms"              # E: negatieve bevindi
 expect_fail coverage   "GAP aan het eind"                 # B: colofon-segment ontbreekt
 expect_fail anchor     "AMBIGUOUS"                        # C: anker zonder context
 expect_fail signaalnet "Indien het verzoek te laat"       # D: normzin stil overgeslagen
+expect_fail ledger     "staat niet in het vocabulaire"    # F: vocabulaire-afwijking
+
+# De ledger-gate draait bij élke aanroep, ook bij een losse gate. Anders zou een
+# ledger met een typefout in het vocabulaire drie groene gates opleveren terwijl
+# de regel die had moeten vuren nergens naar keek.
+echo
+echo "== ledger-gate draait ook bij een losse gate-aanroep =="
+# Let op: geen pipe naar grep hier - met `pipefail` zou de exit-code van de gate
+# (1, want er zijn bevindingen) de uitkomst van de grep overschrijven.
+solo_out="$(python3 "$GATES" anchor --canonical "$CANON" \
+            --ledger "$FIX/statements.broken.yaml" 2>&1)"
+if grep -q "LEDGER" <<<"$solo_out"; then
+    echo "ok    ledger-gate meldt zich ook bij 'anchor'"
+else
+    echo "FAIL  ledger-gate ontbreekt bij een losse gate-aanroep"
+    fails=$((fails + 1))
+fi
 
 echo
 if [[ $fails -eq 0 ]]; then

--- a/.claude/skills/law-statement-register/tests/run.sh
+++ b/.claude/skills/law-statement-register/tests/run.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Proves the gates catch what they claim to catch.
+#
+# For each gate: it must pass on statements.clean.yaml, and it must fail on
+# statements.broken.yaml *for its own reason*. The second half matters - a gate
+# that fails for the wrong reason would still look green in a plain exit-code
+# test, and the whole point of these gates is that a specific failure mode is
+# impossible to pass over.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+GATES="$HERE/../scripts/statement_gates.py"
+FIX="$HERE/fixture"
+CANON="$FIX/canonical.md"
+fails=0
+
+expect_pass() {  # gate
+    local gate="$1" out rc
+    out="$(python3 "$GATES" "$gate" --canonical "$CANON" --ledger "$FIX/statements.clean.yaml" 2>&1)"
+    rc=$?
+    if [[ $rc -ne 0 ]]; then
+        echo "FAIL  $gate hoort te slagen op de schone ledger"
+        echo "$out" | sed 's/^/      /'
+        fails=$((fails + 1))
+    else
+        echo "ok    $gate  clean   -> $(echo "$out" | head -1)"
+    fi
+}
+
+expect_fail() {  # gate, marker
+    local gate="$1" marker="$2" out rc
+    out="$(python3 "$GATES" "$gate" --canonical "$CANON" --ledger "$FIX/statements.broken.yaml" 2>&1)"
+    rc=$?
+    if [[ $rc -eq 0 ]]; then
+        echo "FAIL  $gate hoort te falen op de kapotte ledger"
+        fails=$((fails + 1))
+    elif ! grep -qi -- "$marker" <<<"$out"; then
+        echo "FAIL  $gate faalt, maar niet op '$marker'"
+        echo "$out" | sed 's/^/      /'
+        fails=$((fails + 1))
+    else
+        echo "ok    $gate  broken  -> $(grep -i -m1 -- "$marker" <<<"$out" | sed 's/^ *//')"
+    fi
+}
+
+echo "== schone ledger: alle gates slagen =="
+for g in verbatim coverage anchor signaalnet; do expect_pass "$g"; done
+
+echo
+echo "== kapotte ledger: elke gate pakt zijn eigen defect =="
+expect_fail verbatim   "niet verbatim"                    # A: geparafraseerd citaat
+expect_fail verbatim   "zonder search_terms"              # E: negatieve bevinding niet overdoenbaar
+expect_fail coverage   "GAP aan het eind"                 # B: colofon-segment ontbreekt
+expect_fail anchor     "AMBIGUOUS"                        # C: anker zonder context
+expect_fail signaalnet "Indien het verzoek te laat"       # D: normzin stil overgeslagen
+
+echo
+if [[ $fails -eq 0 ]]; then
+    echo "ALLE TESTS OK"
+    exit 0
+fi
+echo "$fails TEST(S) GEFAALD"
+exit 1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,3 +70,13 @@ repos:
         language: system
         pass_filenames: false
         files: ^\.claude/skills/
+
+      # De vier gates zijn de hele waardepropositie van deze skill: ze horen te
+      # falen op een register dat iets stil overslaat. Zonder deze hook zou een
+      # kapotte gate er precies zo uitzien als een werkende - groen, en blind.
+      - id: statement-register-gates
+        name: Statement-register gates doen wat ze beloven
+        entry: .claude/skills/law-statement-register/tests/run.sh
+        language: system
+        pass_filenames: false
+        files: ^\.claude/skills/law-statement-register/


### PR DESCRIPTION
Voegt de skill `law-statement-register` toe: verbatim statements ontginnen uit teksten die
náást de wet staan — toelichtingen, beleidsregels, werkinstructies, handboeken, FAQ's — en
ze classificeren tegen de normtekst.

## Waarom

Die documenten bepalen in de praktijk hoe een wet uitpakt, maar missen alles waar de
bestaande `law-*`-skills op rekenen: artikelstructuur, versiebeheer, een citeerbaar
URL-fragment en een scheiding tussen norm en uitleg. De skill construeert die drie zelf.

De methode zelf is niet nieuw — die is één keer met de hand uitgevoerd in een dossier en
corrigeerde daar een fixes-plan door twee bevindingen uit de "fix"-bak te halen en tot
jurist-vraag te promoveren. Wat ontbrak was reproduceerbaarheid: geen dekkingsbewijs, geen
vastgelegde zoektermen bij een negatieve bevinding, en geen identiteit die een herziene
versie overleeft.

## Wat erin zit

- `canonicalize.sh` — bron → leestekst met sha256 van de bronbytes. PDF via `pdftotext`,
  HTML via `html_canonical.py` (stdlib, bewust geen dependency: een converter die
  geïnstalleerd moet worden verschilt stil per machine, en dan is de canonieke tekst geen
  bewijsstuk meer).
- `tile.py` — betegelt de tekst volledig, zodat 100% dekking een eigenschap van de
  constructie is en geen handwerk dat je afsnijdt.
- `statement_gates.py` — vijf gates met exit-code: `ledger` (vocabulaire), `verbatim`,
  `coverage`, `anchor`, `signaalnet`.
- `references/` — classificatie (buckets, bindendheid, documentstatus), het
  signaalnet-lexicon, de verankeringszoektocht, en de versie-diff.

Kernprincipe: de norm is leidend, de secundaire tekst is uitleg. **Een statement wordt
nooit op eigen gezag een modelwijziging** — hooguit een fix richting de letter, een
rapportage, of een vraag aan een jurist.

## Wat bewezen is

Twee genres, allebei end-to-end gedraaid: een toelichting-PDF van 17 pagina's (34
segmenten, 100% dekking) en een hoofdstuk uit een uitvoeringshandboek in HTML (59
segmenten, 100% dekking, 269 links naar het zijspoor).

Drie defecten gevonden door de skill tegen zichzelf en tegen een handmatige steekproef te
draaien, alle gerepareerd met een regressietest:

1. een ledger met verzonnen vocabulaire-waarden kwam schoon door alle gates — een typefout
   in `anchoring.status` schakelde de zoektermen-eis stil uit;
2. een tabelkopregel (`2025<tab>2026`) werd als sectiekop gelezen en sneed segmentgrenzen
   dwars door tabellen;
3. `colspan` werd genegeerd, waardoor een bedrag onder het verkeerde jaartal terechtkwam.

Die derde is het punt van de hele skill in het klein: geen enkele gate zag het — dekking
100%, elk citaat verbatim — en toch stond er een fout antwoord. Alleen een mens die de
leestekst naast de bronpagina legt vindt dat. Die stap staat daarom expliciet in de methode.

## Wat níet bewezen is

**Fases 5 en 6 (verankeringszoektocht en classificatie) hebben nooit end-to-end gedraaid.**
De scripts zijn getest, de methode-helft niet: er is met deze skill nog geen volledig
register gemaakt. Dat werk levert dossier-artefacten op die in een private corpus-repo
horen en dus nooit in deze PR kunnen zitten. Lees dit als gereedschap, niet als bewijs dat
de methode af is.

## Verifiëren

```bash
bash .claude/skills/law-statement-register/tests/run.sh
```

Draait op een verzonnen document met zes ingebouwde defecten en controleert dat elke gate
zijn eigen defect pakt — en dat een gate die faalt op een ándere reden als testfout telt.

## Buiten de skill

Eén bestand: `.pre-commit-config.yaml`, +10 regels voor een hook die `tests/run.sh` draait.
De gates zijn de hele waardepropositie; zonder die hook ziet een kapotte gate er precies zo
uit als een werkende.
