### PR TITLE
ci: installeer npm-dependencies met --ignore-scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,10 +425,9 @@ jobs:
       # op, dus de PR is onschuldig; het venster zit hier, in de eerste install
       # op die branch.
       #
-      # Eén dependency heeft zijn install-hook wél nodig: puppeteer (via pa11y
-      # in docs/) haalde daarmee zijn Chrome binnen. Die download staat nu als
-      # expliciete stap in de docs-a11y-baan. De rest van de workspace heeft
-      # geen install-hooks nodig.
+      # Geen enkele install-hook in deze workspace levert iets op wat de build
+      # nodig heeft. De uitzondering zit in docs/ (puppeteer voor pa11y) en
+      # wordt daar in een eigen stap opgevangen.
       - name: Install frontend dependencies
         run: npm ci --ignore-scripts
 
@@ -746,15 +745,27 @@ jobs:
         working-directory: docs
         run: npx playwright install --with-deps chromium
 
-      # pa11y draait niet op Playwright maar op puppeteer, met een eigen
+      # pa11y draait niet op playwright maar op puppeteer, met een eigen
       # browsercache (~/.cache/puppeteer). Die download zat in puppeteers
       # postinstall en verdween met --ignore-scripts hierboven; hij hoort
       # daarom expliciet te staan. Zonder deze stap faalt de gate met
       # "Could not find Chrome".
+      #
+      # Deze stap haalt alleen de browser zelf binnen. De gedeelde libraries
+      # (libnss3, libgbm, libasound2, …) die pa11y straks nodig heeft om deze
+      # Chrome te starten komen van `playwright install --with-deps` hierboven;
+      # die stap moet dus blijven staan. `browsers install` heeft daar zelf wel
+      # een --install-deps voor, maar dat vereist root en dat is de runner niet.
+      #
+      # `--no` houdt npx bij de puppeteer uit docs/package-lock.json. Zonder
+      # die vlag zou npx bij een resolutiewijziging stilletjes puppeteer@latest
+      # van de registry halen — inclusief de postinstall die we hierboven net
+      # hebben uitgezet. De playwright-regel hierboven staat nog zonder --no;
+      # playwright heeft geen install-hook, dus daar valt niets uit te voeren.
       - name: Install Puppeteer Chrome
         if: needs.changes.outputs.docs == 'true'
         working-directory: docs
-        run: npx puppeteer browsers install chrome
+        run: npx --no puppeteer browsers install chrome
 
       # Alleen op een pull request: de lijst gewijzigde bestanden, waarmee
       # gen-pa11yci.mjs de gate tot de geraakte pagina's beperkt. Raakt de PR

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,8 +420,17 @@ jobs:
           cache: 'npm'
           cache-dependency-path: package-lock.json
 
+      # --ignore-scripts: een gekaapte release mag zijn preinstall/postinstall
+      # niet in onze CI draaien. Dependabot lost zelf al met --ignore-scripts
+      # op, dus de PR is onschuldig; het venster zit hier, in de eerste install
+      # op die branch.
+      #
+      # Eén dependency heeft zijn install-hook wél nodig: puppeteer (via pa11y
+      # in docs/) haalde daarmee zijn Chrome binnen. Die download staat nu als
+      # expliciete stap in de docs-a11y-baan. De rest van de workspace heeft
+      # geen install-hooks nodig.
       - name: Install frontend dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: BDD grammar codegen is in sync
         run: |
@@ -602,7 +611,7 @@ jobs:
 
       - name: Install workspace dependencies
         if: needs.changes.outputs.ci == 'true'
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       # De browserdownload (~150 MB) is de duurste stap; cache hem op de
       # playwright-versie uit de lockfile. De apt-kant van `--with-deps` is niet
@@ -686,7 +695,7 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Install workspace dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Install just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
@@ -727,15 +736,25 @@ jobs:
       - name: Install docs dependencies
         if: needs.changes.outputs.docs == 'true'
         working-directory: docs
-        run: npm ci
+        run: npm ci --ignore-scripts
 
-      # rehype-mermaid renders diagrams with a headless Chromium at build time,
-      # and pa11y drives Chromium too — install it (with system deps) the same
-      # way docs/Dockerfile does.
+      # rehype-mermaid rendert diagrammen met een headless Chromium tijdens de
+      # build — installeer die (met systeemdeps) op dezelfde manier als
+      # docs/Dockerfile.
       - name: Install Playwright Chromium
         if: needs.changes.outputs.docs == 'true'
         working-directory: docs
         run: npx playwright install --with-deps chromium
+
+      # pa11y draait niet op Playwright maar op puppeteer, met een eigen
+      # browsercache (~/.cache/puppeteer). Die download zat in puppeteers
+      # postinstall en verdween met --ignore-scripts hierboven; hij hoort
+      # daarom expliciet te staan. Zonder deze stap faalt de gate met
+      # "Could not find Chrome".
+      - name: Install Puppeteer Chrome
+        if: needs.changes.outputs.docs == 'true'
+        working-directory: docs
+        run: npx puppeteer browsers install chrome
 
       # Alleen op een pull request: de lijst gewijzigde bestanden, waarmee
       # gen-pa11yci.mjs de gate tot de geraakte pagina's beperkt. Raakt de PR

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -8,7 +8,12 @@
 FROM node:24-bookworm-slim@sha256:24dc26ef1e3c3690f27ebc4136c9c186c3133b25563ae4d7f0692e4d1fe5db0e AS builder
 WORKDIR /app
 COPY docs/package.json docs/package-lock.json* docs/.npmrc ./
-RUN npm ci
+# --ignore-scripts: een gekaapte release mag zijn install-hooks hier niet
+# draaien. Deze stage draait alleen `astro build`; de enige browser die daarbij
+# nodig is komt van de expliciete `playwright install` hieronder. Puppeteer
+# (dat zijn Chrome wél in een postinstall haalt) wordt hier niet gebruikt —
+# pa11y draait in de CI-baan, niet in dit image.
+RUN npm ci --ignore-scripts
 COPY docs/ .
 RUN npx playwright install --with-deps chromium
 RUN npm run build

--- a/frontend-lawmaking/Dockerfile
+++ b/frontend-lawmaking/Dockerfile
@@ -6,7 +6,9 @@ COPY package.json package-lock.json .npmrc ./
 COPY packages/frontend-shared/package.json packages/frontend-shared/
 COPY frontend/package.json frontend/
 COPY frontend-lawmaking/package.json frontend-lawmaking/
-RUN npm ci
+# --ignore-scripts: een gekaapte release mag zijn install-hooks hier niet
+# draaien; de build eronder heeft ze niet nodig.
+RUN npm ci --ignore-scripts
 # Source: the shared package + this frontend.
 COPY packages/frontend-shared/ packages/frontend-shared/
 COPY frontend-lawmaking/ frontend-lawmaking/

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -31,7 +31,9 @@ COPY package.json package-lock.json .npmrc ./
 COPY packages/frontend-shared/package.json packages/frontend-shared/
 COPY frontend/package.json frontend/
 COPY frontend-lawmaking/package.json frontend-lawmaking/
-RUN npm ci
+# --ignore-scripts: een gekaapte release mag zijn install-hooks hier niet
+# draaien; de build eronder heeft ze niet nodig.
+RUN npm ci --ignore-scripts
 # Source: the shared package + the editor frontend, plus the WASM module.
 COPY packages/frontend-shared/ packages/frontend-shared/
 COPY frontend/ frontend/


### PR DESCRIPTION
Zet `--ignore-scripts` op de vier `npm ci`-aanroepen in `ci.yml` en op de drie image-builds die hem nog niet hadden (`docs/`, `frontend/`, `frontend-lawmaking/`). `packages/pipeline/Dockerfile` deed dit al — dit trekt de rest gelijk.

## Waarom

Dependabot lost zelf al met `--ignore-scripts` op, dus de PR die hij opent is onschuldig. Het venster zit in de **eerste install op die branch**: `npm ci` draait de `preinstall`/`postinstall` van elke dependency, en dat gebeurt hier in CI en in de image-builds.

Elke registry-compromittering van het afgelopen jaar — chalk/debug, shai-hulud, en de keyv/cacheable-kaping van 2026-08-04 — leverde zijn payload via precies die hook af. De cooldown van 5 dagen (die deze repo al op alle ecosystems heeft) verkleint de kans dat zo'n versie hier binnenkomt; dit haalt de uitvoering weg als het tóch gebeurt.

## Eén hook was wél nodig: puppeteer

De eerste CI-run liet de a11y-gate vallen op `Could not find Chrome`. `pa11y` draait niet op Playwright maar op **puppeteer**, met een eigen browsercache (`~/.cache/puppeteer`); de bestaande `playwright install`-stap vult `~/.cache/ms-playwright` en dekt dat dus niet. Die Chrome-download zat in puppeteers `postinstall` en verdween met `--ignore-scripts`.

Daarom staat er nu een expliciete stap `Install Puppeteer Chrome` in de docs-a11y-baan, ná `playwright install --with-deps` (die apt-installeert de gedeelde libraries die ook deze Chrome nodig heeft om te starten). De aanroep gebruikt `npx --no`, zodat npx de puppeteer uit `docs/package-lock.json` pakt en niet stilletjes `puppeteer@latest` van de registry haalt.

Verder heeft niets install-hooks nodig die iets opleveren wat de build gebruikt:
- root-workspace: `@parcel/watcher` (alleen watch-mode, prebuilds in de lockfile), `vue-demi` (levert de Vue 3-shim al mee) en `fsevents` (alleen macOS);
- `docs/`: `esbuild` en `sharp` hebben hun platform-prebuilds in de lockfile staan;
- de Playwright-browsers worden overal al door een eigen stap geïnstalleerd (`ci.yml` én `docs/Dockerfile`);
- de builds draaien hun generators expliciet — `--ignore-scripts` geldt alleen voor `npm ci`, niet voor de `prebuild`-hooks van `npm run build`.

## Verificatie

CI levert het bewijs: de frontend-, docs- en lawmaking-images worden op deze PR gebouwd en de vier `npm ci`-stappen draaien allemaal. De a11y-gate is groen met de nieuwe puppeteer-stap.

Dezelfde wijziging is als losse PR gedaan in `MinBZK/storybook` (daar wél lokaal geverifieerd: build, lint, typecheck en 2820 tests groen), `MinBZK/poc-machine-law` en `MinBZK/regelrecht-mvp-private`.

## Bekende gaten (bewust buiten scope)

- `Justfile:258` roept `npx license-checker` aan in de Security Audit-baan. Dat pakket staat in geen enkele lockfile, dus npx haalt het ongepind van de registry en draait zijn lifecycle-scripts — precies het gat dat deze PR elders dicht. Vergt een `package.json`/lockfile-wijziging en hoort daarom in een eigen PR.
- `Justfile:641` (`docs-install`) gebruikt nog kaal `npm ci`, waardoor lokaal wél de postinstall draait. Onhandig — daardoor viel deze regressie pas in CI op — maar niet onveilig.
