### PR TITLE
chore(deps): bump brace-expansion tegen GHSA-rgw5-rvv9-x895

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -4151,9 +4151,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5984,6 +5984,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2251,9 +2251,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Maakt de `Security Audit`-check weer groen. Die is rood op **elke** open PR in deze repo, ongeacht wat die PR doet.

## Wat er aan de hand is

`just audit` draait `npm audit` op de root-workspace, en die valt over [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) — high severity, DoS via unbounded intermediate arrays in `brace-expansion`, omzeilt de mitigatie van CVE-2026-14257. De advisory is 3 augustus gepubliceerd, dus het is niets dat een PR heeft veroorzaakt.

| lockfile | van | naar | dev-only |
|---|---|---|---|
| root | 5.0.8 | **5.0.9** | ja |
| docs | 1.1.15 | **1.1.18** | ja |

Na de bump geeft `npm audit` op de root-workspace — de enige die `just audit` controleert — nul bevindingen. Controle-test: dezelfde audit op `main` geeft 1 high.

De docs-bump rolt er drie advisories in één keer mee op: 1.1.15 lag onder de ondergrens van GHSA-3jxr-9vmj-r5cp (1.1.16), GHSA-mh99-v99m-4gvg (1.1.17) én deze (1.1.18). De root had alleen de laatste nodig.

## Herkomst van de bump, gezien vandaag

Een lockfile bijwerken tijdens een actieve npm-campagne verdient een blik op de diff, dus:

- **5.0.9 en 1.1.18 zijn allebei op 2026-07-30 gepubliceerd** — vóór de advisory van 3 augustus en vóór de keyv/cacheable-kaping van 4 augustus.
- Maintainers: `juliangruber` en `isaacs`. `brace-expansion` valt buiten de `keyv`/`cacheable`-namespaces.
- De diff bevat alleen `version`, `resolved` en `integrity` van dit ene pakket, plus één regel `"dev": true` die npm bijwerkt op `fsevents@2.3.2` (metadata). Geen nieuw `hasInstallScript`, geen nieuwe transitieve pakketten, `resolved` nog steeds op `registry.npmjs.org`.
- De integrity-hashes zijn nageslagen tegen wat de registry serveert, en de tarballs zijn byte-identiek aan de GitHub-tags. Geen van de vier versies draagt overigens een npm-provenance-attestatie — die verificatie liep dus via de tags, niet via provenance.

## Twee correcties op een eerdere versie van deze tekst

1. **"Beide patch-bumps, geen API-verandering" klopte niet voor de docs-helft.** 1.1.15 → 1.1.18 herschreef `expand()` en introduceerde defaults `max=100000` en `maxLength=4000000`, die extreem grote expansies stilzwijgend afkappen. De signature is ongewijzigd, het gedrag in het uiterste geval niet. Voor deze repo niet relevant (dev-only, via glob/minimatch), maar het hoort er te staan.
2. De kwetsbaarheid zit in een dev-dependency, dus er stond niets in productie open — het was de gate die klemde.

## Wat hier bewust niet in zit

- **`package.json:12` heeft een override `brace-expansion: ^5.0.8`** die 5.x forceert in `minimatch@9.0.9`, terwijl die `^2.0.2` wil en de CJS-default-export aanroept die 5.x niet heeft. Dat is kapot — maar het was al kapot vóór deze PR (identiek op 5.0.8 en 5.0.9), en de fix hoort in `package.json`, dat deze PR niet aanraakt. Beste vervolg: die override op `^2.1.4` zetten.
- De docs-lockfile heeft nog zes andere openstaande bevindingen (o.a. `undici`). `just audit` controleert die lockfile niet.
- `Justfile:258` draait `npx license-checker` ongepind en buiten elke lockfile — in uitgerekend de Security Audit-baan. Eigen PR waard.

## Volgorde

Mergen vóór Dependabot-PR #1113, die de docs-helft dupliceert; die sluit daarna vanzelf.