### PR TITLE
feat(editor): instellingen-sheet, review per artikel en recent bekeken per traject

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@astrojs/markdown-remark": "^7.2.2",
         "@astrojs/mdx": "^7.0.5",
-        "@nldd/design-system": "^0.8.77",
+        "@nldd/design-system": "^0.8.78",
         "astro": "^7.1.6",
         "astro-pagefind": "^2.0.1",
         "rehype-mermaid": "^3",
@@ -2012,9 +2012,9 @@
       }
     },
     "node_modules/@nldd/design-system": {
-      "version": "0.8.77",
-      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.77.tgz",
-      "integrity": "sha512-s8g6BVzIpeK3wBgA5/rjQ6tZ6U4u9d/8STXBlXabUd4si6oddc9WFIAJLvGegnZrjQN7QQ8qJJhmDqV3K0WZJA==",
+      "version": "0.8.78",
+      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.78.tgz",
+      "integrity": "sha512-qRR2/SUbqM2NIYLVWOlDRiRMf8YDAw0Dl7lLiSfZK9au2TBQkOsUhX+JxNev0XkYTx/9jro9M9cGVgWAbB7d3w==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.3",
@@ -5984,7 +5984,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@astrojs/markdown-remark": "^7.2.2",
     "@astrojs/mdx": "^7.0.5",
-    "@nldd/design-system": "^0.8.77",
+    "@nldd/design-system": "^0.8.78",
     "astro": "^7.1.6",
     "astro-pagefind": "^2.0.1",
     "rehype-mermaid": "^3",

--- a/docs/src/components/LandingSections.astro
+++ b/docs/src/components/LandingSections.astro
@@ -100,10 +100,7 @@ function exampleImage(key: string): ImageMetadata {
           lg-padding-top="24"
         >
           <nldd-title size="1" color="inherit">
-            <h1>RegelRecht</h1>
-          </nldd-title>
-          <nldd-title size="2" color="inherit">
-            <p>{t.hero.titleSmall}</p>
+            <h1>{t.hero.title}</h1>
           </nldd-title>
           <nldd-spacer size="16" />
           <nldd-rich-text color="inherit">

--- a/docs/src/components/LandingSections.astro
+++ b/docs/src/components/LandingSections.astro
@@ -77,10 +77,6 @@ function exampleImage(key: string): ImageMetadata {
         <nldd-title size="2">
           <h1>{t.signup.pageTitle}</h1>
         </nldd-title>
-        <nldd-spacer size="8" />
-        <nldd-rich-text>
-          <p>{t.signup.lede}</p>
-        </nldd-rich-text>
         <nldd-spacer size="24" />
         <SignupForm lang={lang} />
         <noscript>

--- a/docs/src/components/LandingSections.astro
+++ b/docs/src/components/LandingSections.astro
@@ -123,23 +123,6 @@ function exampleImage(key: string): ImageMetadata {
               text={t.feedback.cta}
             />
           </nldd-button-group>
-          <nldd-spacer size="16" />
-          <nldd-rich-text color="inherit">
-            <p>
-              {t.partners.label}{' '}
-              {t.partners.items.map((p, i) => {
-                const sep =
-                  i === 0
-                    ? ''
-                    : i === t.partners.items.length - 1
-                      ? lang === 'en'
-                        ? ', and '
-                        : ' en '
-                      : ', ';
-                return (<Fragment>{sep}<a href={p.href}>{p.label}</a></Fragment>);
-              })}
-            </p>
-          </nldd-rich-text>
         </nldd-hero>
 
         <nldd-simple-section

--- a/docs/src/components/SignupForm.astro
+++ b/docs/src/components/SignupForm.astro
@@ -12,7 +12,6 @@
  *  - bijdragen: nldd-form-field (group label) > nldd-radio-button-group >
  *    nldd-radio-button-field. The group renders role=radiogroup with the label
  *    forwarded as aria-label.
- *  - opDeHoogte: nldd-checkbox-field (self-labelled).
  *
  * The <form> is wrapped in <nldd-form> in user-provided-form mode: nldd-form
  * is a shadow-less plain element that renders a real light-DOM <form>, and when
@@ -94,15 +93,6 @@ const successUrl = lang === 'en' ? '/en/signup/thanks' : '/aanmelden/bedankt';
         <nldd-radio-button-field value="Ja" label={s.radioYes} checked />
         <nldd-radio-button-field value="Nee" label={s.radioNo} />
       </nldd-radio-button-group>
-    </nldd-form-field>
-
-    <nldd-form-field>
-      <nldd-checkbox-field
-        name="opDeHoogte"
-        label={s.updates}
-        data-field="opDeHoogte"
-        checked
-      ></nldd-checkbox-field>
     </nldd-form-field>
 
     <nldd-form-field label={s.emailLabel}>
@@ -248,9 +238,6 @@ const successUrl = lang === 'en' ? '/en/signup/thanks' : '/aanmelden/bedankt';
     const radioFields = Array.from(
       bijdragenGroup.querySelectorAll('nldd-radio-button-field')
     ) as NlddCheckedField[];
-    const opDeHoogte = form.querySelector(
-      '[data-field="opDeHoogte"]'
-    ) as NlddCheckedField;
     const emailErr = form.querySelector('#rr-email-error') as HTMLElement;
     const naamErr = form.querySelector('#rr-naam-error') as HTMLElement;
     const submitting = form.querySelector(
@@ -349,8 +336,7 @@ const successUrl = lang === 'en' ? '/en/signup/thanks' : '/aanmelden/bedankt';
         `| **E-mail** | ${emailField.value} |\n` +
         `| **Organisatie** | ${orgField.value || '-'} |\n` +
         `| **Functie** | ${functieField.value || '-'} |\n` +
-        `| **Bijdragen aan validatie** | ${bijdragen} |\n` +
-        `| **Op de hoogte blijven** | ${opDeHoogte.checked ? 'Ja' : 'Nee'} |`;
+        `| **Meedenken over validatie** | ${bijdragen} |`;
 
       try {
         await fetch(WEBHOOK, {

--- a/docs/src/layouts/Base.astro
+++ b/docs/src/layouts/Base.astro
@@ -40,9 +40,9 @@ const isNotFound = kind === 'notfound';
 const t = content[lang];
 // Landing is bilingual (path-driven); docs are English-only.
 const home = isLanding ? (lang === 'en' ? '/en/' : '/') : '/en/';
-// One brand subtitle everywhere (per language): the same tagline on the
-// landing and the docs, not a separate docs string.
-const brandSubtitle = t.nav.brandTagline;
+// The logo carries the ministry, not the product: that is what the wordmark
+// next to the rijkslogo stands for. RegelRecht itself is the website title.
+const brandMinistry = t.nav.brandMinistry;
 // The signup variant of the landing has no in-page anchor nav.
 const showSignup = isLanding && /\/aanmelden|\/en\/signup/.test(pathname);
 // Status pages (the thank-you page and error pages like 404) present an
@@ -344,8 +344,8 @@ const legalLinks = [
           id needed, so there is no separate skip target div. */}
       <nldd-skip-link slot="header" text={skipText}>
       <nldd-top-navigation-bar
-          logo-title="RegelRecht"
-          logo-subtitle={brandSubtitle}
+          logo-title={brandMinistry}
+          website-title="RegelRecht"
           logo-href={home}
           website-href={home}
           back-href={backHref || undefined}

--- a/docs/src/lib/landing-content.ts
+++ b/docs/src/lib/landing-content.ts
@@ -25,7 +25,7 @@ export interface LandingContent {
     signup: string
     docs: string
   }
-  hero: { titleSmall: string; intro: string; cta: string }
+  hero: { title: string; intro: string; cta: string }
   partners: { label: string; items: NavLink[] }
   whatIsIt: { title: string; lede: string; cards: { h: string; p: string }[] }
   whyImportant: {
@@ -153,7 +153,7 @@ export const content: Record<'nl' | 'en', LandingContent> = {
       docs: 'Documentatie',
     },
     hero: {
-      titleSmall: 'van wet naar digitale werking',
+      title: 'Van wet naar digitale werking',
       intro:
         'RegelRecht verkent of wetgeving als uitvoerbare code geschreven kan worden, zodat verschillende organisaties dezelfde wet ook hetzelfde toepassen en burgers kunnen volgen hoe een besluit tot stand komt.',
       cta: 'Verken de mogelijkheden',
@@ -608,7 +608,7 @@ export const content: Record<'nl' | 'en', LandingContent> = {
       docs: 'Documentation',
     },
     hero: {
-      titleSmall: 'from statute to digital execution',
+      title: 'From statute to digital execution',
       intro:
         'RegelRecht explores whether legislation can be written as executable code, so that different organisations apply the same law the same way and citizens can follow how a decision is reached.',
       cta: 'Explore the possibilities',

--- a/docs/src/lib/landing-content.ts
+++ b/docs/src/lib/landing-content.ts
@@ -99,12 +99,11 @@ export interface LandingContent {
   }
   signup: {
     pageTitle: string
-    lede: string
+    metaDescription: string
     noscript: string
     legend: string
     radioYes: string
     radioNo: string
-    updates: string
     emailLabel: string
     nameLabel: string
     orgLabel: string
@@ -556,14 +555,13 @@ export const content: Record<'nl' | 'en', LandingContent> = {
       ],
     },
     signup: {
-      pageTitle: 'Op de hoogte blijven of bijdragen aan RegelRecht?',
-      lede: 'Laat je gegevens achter als je updates wilt ontvangen of wilt meedenken over de (juridische) validatie van RegelRecht.',
+      pageTitle: 'Op de hoogte blijven of meedenken',
+      metaDescription: 'Laat je gegevens achter als je updates wilt ontvangen of wilt meedenken over de juridische validatie van RegelRecht.',
       noscript:
         'Dit formulier heeft JavaScript nodig. Stuur in plaats daarvan een e-mail naar regelrecht@minbzk.nl.',
-      legend: 'Wil je bijdragen?',
-      radioYes: 'Ja, ik wil bijdragen aan de validatie van RegelRecht',
-      radioNo: 'Nee, ik wil niet bijdragen',
-      updates: 'Updates ontvangen over de ontwikkelingen van RegelRecht',
+      legend: 'Wil je meedenken over de juridische validatie?',
+      radioYes: 'Ja, ik wil meedenken en updates ontvangen',
+      radioNo: 'Nee, alleen updates ontvangen',
       emailLabel: 'E-mailadres',
       nameLabel: 'Volledige naam',
       orgLabel: 'Organisatie',
@@ -575,9 +573,9 @@ export const content: Record<'nl' | 'en', LandingContent> = {
       submit: 'Meld me aan',
       submitting: 'Bezig met versturen…',
       companyHoneypot: 'Bedrijf (niet invullen)',
-      errEmailEmpty: 'Vul je e-mailadres in.',
-      errEmailInvalid: 'Vul een geldig e-mailadres in.',
-      errName: 'Vul je volledige naam in.',
+      errEmailEmpty: 'Vul je e-mailadres in. Hiermee sturen we je updates en kunnen we contact opnemen.',
+      errEmailInvalid: 'Controleer je e-mailadres, er lijkt een @ of een punt te ontbreken.',
+      errName: 'Vul je volledige naam in. Zodat we weten wie zich aanmeldt.',
       successTitle: 'Bedankt voor je aanmelding!',
       successBody:
         'We hebben je gegevens verstuurd. Je ontvangt bevestiging per e-mail zodra je aanmelding is verwerkt. Klopt er iets niet? Mail ons.',
@@ -1010,14 +1008,13 @@ export const content: Record<'nl' | 'en', LandingContent> = {
       ],
     },
     signup: {
-      pageTitle: 'Stay informed or contribute to RegelRecht?',
-      lede: 'Leave your details if you want to receive updates or help think about the (legal) validation of RegelRecht.',
+      pageTitle: 'Stay informed or help think along',
+      metaDescription: 'Leave your details to receive updates, or to help think about the legal validation of RegelRecht.',
       noscript:
         'This form needs JavaScript. Please send an email to regelrecht@minbzk.nl instead.',
-      legend: 'Want to contribute?',
-      radioYes: 'Yes, I want to contribute to the validation of RegelRecht',
-      radioNo: 'No, I do not want to contribute',
-      updates: 'Receive updates about the development of RegelRecht',
+      legend: 'Want to help think about the legal validation?',
+      radioYes: 'Yes, I want to help think along and receive updates',
+      radioNo: 'No, only receive updates',
       emailLabel: 'Email address',
       nameLabel: 'Full name',
       orgLabel: 'Organisation',
@@ -1029,9 +1026,9 @@ export const content: Record<'nl' | 'en', LandingContent> = {
       submit: 'Sign me up',
       submitting: 'Sending…',
       companyHoneypot: 'Company (do not fill in)',
-      errEmailEmpty: 'Enter your email address.',
-      errEmailInvalid: 'Enter a valid email address.',
-      errName: 'Enter your full name.',
+      errEmailEmpty: 'Enter your email address. We use this to send you updates and to get in touch.',
+      errEmailInvalid: 'Check your email address, an @ or a dot seems to be missing.',
+      errName: 'Enter your full name. So we know who is signing up.',
       successTitle: 'Thank you for signing up!',
       successBody:
         'We have sent your details. You will receive confirmation by email once your registration is processed. Something not right? Email us.',

--- a/docs/src/lib/landing-content.ts
+++ b/docs/src/lib/landing-content.ts
@@ -14,7 +14,7 @@ export interface NavLink {
 export interface LandingContent {
   meta: { title: string; description: string }
   nav: {
-    brandTagline: string
+    brandMinistry: string
     home: string
     what: string
     how: string
@@ -141,7 +141,7 @@ export const content: Record<'nl' | 'en', LandingContent> = {
         'Een verkenning van het Ministerie van BZK naar transparante, machine-uitvoerbare wetgeving.',
     },
     nav: {
-      brandTagline: 'Verkenning van Ministerie van BZK',
+      brandMinistry: 'Ministerie van Economische Zaken en Klimaat',
       home: 'Home',
       what: 'Wat',
       how: 'Hoe',
@@ -596,7 +596,7 @@ export const content: Record<'nl' | 'en', LandingContent> = {
         'An exploration by the Dutch Ministry of the Interior into transparent, machine-executable legislation.',
     },
     nav: {
-      brandTagline: 'Exploration by the Dutch Ministry of the Interior',
+      brandMinistry: 'Ministry of Economic Affairs and Climate Policy',
       home: 'Home',
       what: 'What',
       how: 'How',

--- a/docs/src/lib/landing-content.ts
+++ b/docs/src/lib/landing-content.ts
@@ -26,7 +26,6 @@ export interface LandingContent {
     docs: string
   }
   hero: { title: string; intro: string; cta: string }
-  partners: { label: string; items: NavLink[] }
   whatIsIt: { title: string; lede: string; cards: { h: string; p: string }[] }
   whyImportant: {
     title: string
@@ -156,17 +155,6 @@ export const content: Record<'nl' | 'en', LandingContent> = {
       intro:
         'RegelRecht verkent of wetgeving als uitvoerbare code geschreven kan worden, zodat verschillende organisaties dezelfde wet ook hetzelfde toepassen en burgers kunnen volgen hoe een besluit tot stand komt.',
       cta: 'Verken de mogelijkheden',
-    },
-    partners: {
-      label: 'Een initiatief van',
-      items: [
-        {
-          label: 'Ministerie van BZK',
-          href: 'https://www.rijksoverheid.nl/ministeries/ministerie-van-binnenlandse-zaken-en-koninkrijksrelaties',
-        },
-        { label: 'Bureau Architectuur', href: 'https://minbzk.github.io/BASE/' },
-        { label: 'Digilab', href: 'https://digilab.overheid.nl/' },
-      ],
     },
     whatIsIt: {
       title: 'Wetten uitvoeren zonder te programmeren',
@@ -537,12 +525,12 @@ export const content: Record<'nl' | 'en', LandingContent> = {
     },
     footer: {
       blurb:
-        'Een verkenning van Bureau Architectuur van het Ministerie van Binnenlandse Zaken naar de mogelijkheden van transparante, uitvoerbare wetgeving.',
+        'Een verkenning van Bureau Architectuur van het Ministerie van Economische Zaken en Klimaat naar de mogelijkheden van transparante, uitvoerbare wetgeving.',
       linksTitle: 'Links',
       contactTitle: 'Contact',
       partOfTitle: 'Onderdeel van',
       copyright:
-        '© 2026 Ministerie van Binnenlandse Zaken en Koninkrijksrelaties. Alle rechten voorbehouden.',
+        '© 2026 Ministerie van Economische Zaken en Klimaat. Alle rechten voorbehouden.',
       links: [
         { label: 'GitHub-repository', href: GITHUB },
         { label: 'Hoe het werkt', href: '/#how-it-works' },
@@ -551,7 +539,7 @@ export const content: Record<'nl' | 'en', LandingContent> = {
       ],
       partOf: [
         'Bureau Architectuur',
-        'Ministerie van Binnenlandse Zaken en Koninkrijksrelaties',
+        'Ministerie van Economische Zaken en Klimaat',
       ],
     },
     signup: {
@@ -610,17 +598,6 @@ export const content: Record<'nl' | 'en', LandingContent> = {
       intro:
         'RegelRecht explores whether legislation can be written as executable code, so that different organisations apply the same law the same way and citizens can follow how a decision is reached.',
       cta: 'Explore the possibilities',
-    },
-    partners: {
-      label: 'An initiative of',
-      items: [
-        {
-          label: 'Ministry of the Interior and Kingdom Relations',
-          href: 'https://www.rijksoverheid.nl/ministeries/ministerie-van-binnenlandse-zaken-en-koninkrijksrelaties',
-        },
-        { label: 'Bureau Architectuur', href: 'https://minbzk.github.io/BASE/' },
-        { label: 'Digilab', href: 'https://digilab.overheid.nl/' },
-      ],
     },
     whatIsIt: {
       title: 'Running laws without programming',
@@ -990,12 +967,12 @@ export const content: Record<'nl' | 'en', LandingContent> = {
     },
     footer: {
       blurb:
-        'An exploration by Bureau Architectuur of the Dutch Ministry of the Interior into the possibilities of transparent, executable legislation.',
+        'An exploration by Bureau Architectuur of the Dutch Ministry of Economic Affairs and Climate Policy into the possibilities of transparent, executable legislation.',
       linksTitle: 'Links',
       contactTitle: 'Contact',
       partOfTitle: 'Part of',
       copyright:
-        '© 2026 Ministry of the Interior and Kingdom Relations. All rights reserved.',
+        '© 2026 Ministry of Economic Affairs and Climate Policy. All rights reserved.',
       links: [
         { label: 'GitHub repository', href: GITHUB },
         { label: 'How it works', href: '/en/#how-it-works' },
@@ -1004,7 +981,7 @@ export const content: Record<'nl' | 'en', LandingContent> = {
       ],
       partOf: [
         'Bureau Architectuur',
-        'Ministry of the Interior and Kingdom Relations',
+        'Ministry of Economic Affairs and Climate Policy',
       ],
     },
     signup: {

--- a/docs/src/nldd-components.js
+++ b/docs/src/nldd-components.js
@@ -11,7 +11,6 @@ import '@nldd/design-system/button-group';
 import '@nldd/design-system/byline';
 import '@nldd/design-system/card';
 import '@nldd/design-system/cell';
-import '@nldd/design-system/checkbox-field';
 import '@nldd/design-system/code-editor';
 import '@nldd/design-system/code-viewer';
 import '@nldd/design-system/collection';

--- a/docs/src/pages/aanmelden.astro
+++ b/docs/src/pages/aanmelden.astro
@@ -5,7 +5,7 @@ import { content } from '~/lib/landing-content';
 
 const t = content.nl;
 const title = `${t.nav.signup} · RegelRecht`;
-const description = t.signup.lede;
+const description = t.signup.metaDescription;
 ---
 
 <Base

--- a/docs/src/pages/en/signup.astro
+++ b/docs/src/pages/en/signup.astro
@@ -5,7 +5,7 @@ import { content } from '~/lib/landing-content';
 
 const t = content.en;
 const title = `${t.nav.signup} · RegelRecht`;
-const description = t.signup.lede;
+const description = t.signup.metaDescription;
 ---
 
 <Base

--- a/frontend-lawmaking/package.json
+++ b/frontend-lawmaking/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@nldd/design-system": "^0.8.77",
+    "@nldd/design-system": "^0.8.78",
     "@regelrecht/frontend-shared": "*",
     "vue": "^3.5.38"
   },

--- a/frontend/e2e/action-crud.spec.js
+++ b/frontend/e2e/action-crud.spec.js
@@ -7,7 +7,8 @@ import {
   setYamlPane,
   openSheet,
   openActionEditor,
-  saveActionSheet,
+  saveActionSheet, pane,
+
 } from './helpers.js';
 
 test.describe('Action CRUD', () => {
@@ -20,7 +21,7 @@ test.describe('Action CRUD', () => {
     await selectArticle(page, '5');
 
     // Init machine_readable
-    await page.locator('[data-testid="init-mr-btn"]').click();
+    await pane(page, 'machine').locator('[data-testid="init-mr-btn"]').click();
     await page.waitForTimeout(300);
 
     // Click "Actie toevoegen" - a new action opens the sheet seeded with an
@@ -77,7 +78,7 @@ test.describe('Action CRUD', () => {
     // Init machine_readable, then author a literal-value action through the
     // YAML pane - the editor's manual escape hatch for shapes the structured
     // form does not build (a bare literal output value).
-    await page.locator('[data-testid="init-mr-btn"]').click();
+    await pane(page, 'machine').locator('[data-testid="init-mr-btn"]').click();
     await page.waitForTimeout(300);
 
     await setYamlPane(page, `definitions: {}
@@ -107,7 +108,7 @@ execution:
     await selectArticle(page, '2');
 
     // Init machine_readable
-    await page.locator('[data-testid="init-mr-btn"]').click();
+    await pane(page, 'machine').locator('[data-testid="init-mr-btn"]').click();
     await page.waitForTimeout(300);
 
     // Add an action and set only its output - the seeded EQUALS operation is

--- a/frontend/e2e/definitions.spec.js
+++ b/frontend/e2e/definitions.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { interceptLaw, gotoEditor, selectArticle, readYamlPane, waitForSheet, fillSheetTextField, fillSheetNumberField, saveSheet } from './helpers.js';
+import { interceptLaw, gotoEditor, selectArticle, readYamlPane, waitForSheet, fillSheetTextField, fillSheetNumberField, saveSheet, pane } from './helpers.js';
 
 test.describe('Definitions', () => {
   test.beforeEach(async ({ page }) => {
@@ -11,7 +11,7 @@ test.describe('Definitions', () => {
     await selectArticle(page, '1a');
 
     // Init machine_readable
-    await page.locator('[data-testid="init-mr-btn"]').click();
+    await pane(page, 'machine').locator('[data-testid="init-mr-btn"]').click();
     await page.waitForTimeout(300);
 
     // Click "Nieuwe definitie" button
@@ -42,7 +42,7 @@ test.describe('Definitions', () => {
     await selectArticle(page, '2');
 
     // Init machine_readable
-    await page.locator('[data-testid="init-mr-btn"]').click();
+    await pane(page, 'machine').locator('[data-testid="init-mr-btn"]').click();
     await page.waitForTimeout(300);
 
     // Add definition: drempelinkomen_alleenstaande = 3971900

--- a/frontend/e2e/full-roundtrip.spec.js
+++ b/frontend/e2e/full-roundtrip.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { interceptLaw, gotoEditor, selectArticle, readYamlPane, setYamlPane, openSheet, openActionEditor, loadFixture } from './helpers.js';
+import { interceptLaw, gotoEditor, selectArticle, readYamlPane, setYamlPane, openSheet, openActionEditor, loadFixture, pane } from './helpers.js';
 import * as yaml from 'js-yaml';
 
 /**
@@ -91,7 +91,7 @@ test.describe('Full round-trip', () => {
     await selectArticle(page, '2');
 
     // Init machine_readable
-    await page.locator('[data-testid="init-mr-btn"]').click();
+    await pane(page, 'machine').locator('[data-testid="init-mr-btn"]').click();
     await page.waitForTimeout(300);
 
     // Edit YAML directly to add complete machine_readable

--- a/frontend/e2e/helpers.js
+++ b/frontend/e2e/helpers.js
@@ -258,6 +258,23 @@ export async function readYamlPane(page) {
 }
 
 /**
+ * Get one of the editor's panes by its view id ('text', 'machine', 'scenario',
+ * 'yaml', 'notes').
+ *
+ * Without a stored preference the editor opens every pane at once, which is
+ * what a fresh CI browser gets. Components that appear in more than one pane -
+ * MachineEmptyState sits in both Machine and YAML - therefore put their
+ * test ids in the DOM twice. Scope through this helper rather than reaching for
+ * `.first()`: the ambiguity is real, and the test should say which pane it
+ * means.
+ * @param {import('@playwright/test').Page} page
+ * @param {string} view
+ */
+export function pane(page, view) {
+  return page.locator(`[data-testid="pane-${view}"]`);
+}
+
+/**
  * Get the machine_readable pane element.
  * @param {import('@playwright/test').Page} page
  */

--- a/frontend/e2e/init-machine-readable.spec.js
+++ b/frontend/e2e/init-machine-readable.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { interceptLaw, gotoEditor, selectArticle, readYamlPane } from './helpers.js';
+import { interceptLaw, gotoEditor, selectArticle, readYamlPane, pane } from './helpers.js';
 
 test.describe('Init machine_readable', () => {
   test.beforeEach(async ({ page }) => {
@@ -12,11 +12,11 @@ test.describe('Init machine_readable', () => {
     await selectArticle(page, '1a');
 
     // Should show the "no data" message with init button
-    const noMr = page.locator('[data-testid="no-machine-readable"]');
+    const noMr = pane(page, 'machine').locator('[data-testid="no-machine-readable"]');
     await expect(noMr).toBeVisible();
     await expect(noMr).toContainText('Geen machine-leesbare gegevens');
 
-    const initBtn = page.locator('[data-testid="init-mr-btn"]');
+    const initBtn = pane(page, 'machine').locator('[data-testid="init-mr-btn"]');
     await expect(initBtn).toBeVisible();
   });
 
@@ -24,7 +24,7 @@ test.describe('Init machine_readable', () => {
     await selectArticle(page, '1a');
 
     // Click init button
-    await page.locator('[data-testid="init-mr-btn"]').click();
+    await pane(page, 'machine').locator('[data-testid="init-mr-btn"]').click();
     await page.waitForTimeout(300);
 
     // The machine-readable section should now be visible

--- a/frontend/e2e/inputs.spec.js
+++ b/frontend/e2e/inputs.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { interceptLaw, gotoEditor, selectArticle, readYamlPane, waitForSheet, fillSheetTextField, selectSheetDropdown, setSheetComboBox, openSheet, saveSheet } from './helpers.js';
+import { interceptLaw, gotoEditor, selectArticle, readYamlPane, waitForSheet, fillSheetTextField, selectSheetDropdown, setSheetComboBox, openSheet, saveSheet, pane } from './helpers.js';
 
 test.describe('Inputs with sources', () => {
   test.beforeEach(async ({ page }) => {
@@ -11,7 +11,7 @@ test.describe('Inputs with sources', () => {
     await selectArticle(page, '2');
 
     // Init machine_readable
-    await page.locator('[data-testid="init-mr-btn"]').click();
+    await pane(page, 'machine').locator('[data-testid="init-mr-btn"]').click();
     await page.waitForTimeout(300);
 
     // Add input: leeftijd from wet_basisregistratie_personen

--- a/frontend/e2e/metadata-params-outputs.spec.js
+++ b/frontend/e2e/metadata-params-outputs.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { interceptLaw, gotoEditor, selectArticle, readYamlPane, waitForSheet, fillSheetTextField, selectSheetDropdown, saveSheet } from './helpers.js';
+import { interceptLaw, gotoEditor, selectArticle, readYamlPane, waitForSheet, fillSheetTextField, selectSheetDropdown, saveSheet, pane } from './helpers.js';
 
 test.describe('Parameters and Outputs', () => {
   test.beforeEach(async ({ page }) => {
@@ -11,7 +11,7 @@ test.describe('Parameters and Outputs', () => {
     await selectArticle(page, '2');
 
     // Init machine_readable
-    await page.locator('[data-testid="init-mr-btn"]').click();
+    await pane(page, 'machine').locator('[data-testid="init-mr-btn"]').click();
     await page.waitForTimeout(300);
 
     // --- Add parameter: bsn (string, required) ---

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@cucumber/gherkin": "^42.0.0",
     "@cucumber/messages": "^34.2.0",
-    "@nldd/design-system": "^0.8.77",
+    "@nldd/design-system": "^0.8.78",
     "@regelrecht/frontend-shared": "*",
     "@vue-flow/background": "^1.3.2",
     "@vue-flow/controls": "^1.1.3",

--- a/frontend/src/AppShell.vue
+++ b/frontend/src/AppShell.vue
@@ -5,10 +5,9 @@ import TrajectMenu from './components/TrajectMenu.vue';
 import MobileTrajectSheet from './components/MobileTrajectSheet.vue';
 import AboutSheet from './components/AboutSheet.vue';
 import SupportSheet from './components/SupportSheet.vue';
+import SettingsSheet from './components/SettingsSheet.vue';
 import { useAuth } from './composables/useAuth.js';
 import { useGithubAuth } from './composables/useGithubAuth.js';
-import { useFeatureFlags } from './composables/useFeatureFlags.js';
-import { useColorScheme } from './composables/useColorScheme.js';
 import { useTrajects } from './composables/useTrajects.js';
 import { useAddActions } from './composables/useAddActions.js';
 import {
@@ -29,15 +28,18 @@ import { SEARCH_PLACEHOLDER, SEARCH_ACCESSIBLE_LABEL } from './constants.js';
 // instance is reused, so the chrome never rebuilds (no refresh flash).
 
 const { authenticated, loading: authLoading, oidcConfigured, person, hasAnyRole, login, logout } = useAuth();
-// GitHub user-OAuth (spike): let a user link their own GitHub account so
-// traject writes go out under their credential. `status` is reactive and may
-// be null until loaded; the template guards on `githubStatus?.configured`.
-const {
-  status: githubStatus,
-  connect: connectGithub,
-  disconnect: disconnectGithub,
-} = useGithubAuth();
-const { isEnabled, toggle: toggleFlag } = useFeatureFlags();
+// Only for the identity line in the account-menu header — linking itself lives
+// in the settings sheet. The login is shown only when writes actually go out
+// under it, otherwise it would misstate who authors the commit. `required` is
+// the effective answer (env var OR feature flag), which is why the flag is not
+// read here directly.
+const { status: githubStatus } = useGithubAuth();
+const showGithubLine = computed(
+  () =>
+    !!githubStatus.value?.configured &&
+    !!githubStatus.value?.required &&
+    !!githubStatus.value?.connected,
+);
 
 // Roles that may reach the harvester-admin "Corpusinwinning" section. Any harvester-*
 // tier (reader/writer/admin) or the spanning regelrecht-admin sees the menu
@@ -59,7 +61,6 @@ function goToHarvesting() {
   rememberHarvesterOrigin(route.fullPath);
   router.push("/harvesting");
 }
-const { colorScheme, setColorScheme } = useColorScheme();
 const { activeTrajectRef } = useTrajects();
 // Universele "Toevoegen"-knop: vuurt intenties die LibraryView oppakt.
 const { triggerAddLaw, triggerNewWerkdoc, triggerUploadWerkdoc, triggerInviteMembers } = useAddActions();
@@ -78,35 +79,35 @@ function openSupport() {
   nextTick(() => supportSheet.value?.show?.());
 }
 
-const colorSchemeOptions = [
-  ['auto', 'Systeem', 'display'],
-  ['light', 'Licht', 'light-mode'],
-  ['dark', 'Donker', 'dark-mode'],
-];
+// Rejecting a proposal resolves the review task and throws the seeded edit
+// away, so it asks first. Owned here because the Verwerp button lives in the
+// changes bar; EditorView keeps the actual reject logic.
+const rejectConfirm = ref(null);
+function confirmReject() {
+  rejectConfirm.value?.hide();
+  editorActions.value?.reject?.();
+}
 
-// Editor panel feature flags, toggled from the settings menu of either
-// section (the menu lives in the shell now, so the full editor set is in one
-// place - the library previously listed only the first four). Toggling from
-// the library affects the editor the next time its panes render.
-const editorPanelFlags = [
-  ['panel.article_text', 'Tekst editor'],
-  ['panel.machine_readable', 'Machine editor'],
-  ['panel.scenario_form', 'Scenario editor'],
-  ['panel.yaml_editor', 'YAML editor'],
-  ['panel.notes', 'Notities'],
-];
+// In review mode the bar decides on a proposal, not on your own edits, so the
+// labels say so. Outside review "Opslaan" stays what it always was.
+const inReview = computed(() => !!editorChanges.value?.review);
+const saveLabel = computed(() => (inReview.value ? 'Sla voorstel op' : 'Opslaan'));
 
-// The "Functies" menu group: the panel flags, plus the GitHub-koppeling
-// toggle when this deployment has a GitHub OAuth App configured. The flag
-// (off by default, deployment-wide like all flags) is one switch with two
-// effects: it shows the Koppel/Ontkoppel items below AND makes the backend
-// require the acting user's own GitHub token for traject writes (a save
-// without a linked token then 428s, which apiAuthGuard.js turns into a
-// redirect through the connect flow).
-const functieFlags = computed(() => [
-  ...editorPanelFlags,
-  ...(githubStatus.value?.configured ? [['github.user_oauth', 'GitHub-koppeling']] : []),
-]);
+// Not dismissible: the notice explains what Verwerp and Opslaan below it refer
+// to, so hiding it would leave two decision buttons without their subject. It
+// disappears by deciding, not by clicking it away.
+//
+// Only while the editor has an article open that carries a proposal. Outside
+// the editor `editorChanges` is null, which is what keeps the notice off Home.
+const reviewNotice = computed(() => editorChanges.value?.reviewStatus ?? null);
+
+// "Instellingen" sheet, opened from the account menu. Owns Weergave, the panel
+// flags and the GitHub link — all of which used to hang off this menu directly.
+const settingsSheet = ref(null);
+function openSettings() {
+  // Let the account menu popover close first, then raise the sheet.
+  nextTick(() => settingsSheet.value?.show?.());
+}
 
 const route = useRoute();
 const router = useRouter();
@@ -190,43 +191,6 @@ function onEditorTab(e) {
     return;
   }
   if (isLibraryRoute.value) router.push(editorTabTarget.value);
-}
-
-// Enabling `github.user_oauth` is not a personal display preference like the
-// panel flags listed around it: the flag is deployment-wide AND doubles as the
-// backend's write-enforcement switch (`write_requires_user_token`), so turning
-// it on makes every editor-writer's next traject save require a linked
-// personal GitHub account (an unlinked user's save 428s into the connect
-// flow). Intercept the enable with an explicit confirmation popover - same
-// pattern as the login warning above. Disabling restores the pre-existing
-// service-token behaviour and stays a plain toggle.
-const enforcementConfirm = ref(null);
-function onFunctieFlagSelect(key, e) {
-  if (key === 'github.user_oauth' && !isEnabled(key)) {
-    if (enforcementConfirm.value) {
-      // Anchor to the settings button of whichever breakpoint menu fired the
-      // select: the menu itself closes on select, and a popover must never be
-      // anchored to a hidden element.
-      const anchorId = e.currentTarget.closest('nldd-menu')?.getAttribute('anchor');
-      enforcementConfirm.value.anchorElement =
-        (anchorId && document.getElementById(anchorId)) || e.currentTarget;
-      enforcementConfirm.value.show();
-    }
-    return;
-  }
-  toggleFlag(key);
-}
-function confirmUserOauthEnforcement() {
-  enforcementConfirm.value?.hide();
-  toggleFlag('github.user_oauth');
-}
-// Release the anchor when the popover closes (confirm, cancel, or light
-// dismiss). nldd-popover toggles itself on EVERY subsequent click on its
-// anchor element (popover.js `_handleDocumentClick`) - leaving the settings
-// button as anchor would hijack it: the next account-menu click opens this
-// popover and (auto-popover exclusivity) closes the menu.
-function onEnforcementConfirmClose() {
-  if (enforcementConfirm.value) enforcementConfirm.value.anchorElement = null;
 }
 
 // View-specific toolbar bits published by the active view.
@@ -389,45 +353,25 @@ function onTabDismiss(e) {
                 <nldd-menu slot="popup">
                   <nldd-menu-item v-if="!authLoading && oidcConfigured && !authenticated" text="Inloggen" icon="login" @click="login()"></nldd-menu-item>
                   <nldd-menu-item v-if="!authLoading && oidcConfigured && !authenticated" text="Account aanvragen" icon="new-account" @click="goToAccountRequest"></nldd-menu-item>
-                  <nldd-list v-if="!authLoading && authenticated" slot="header" variant="simple" no-dividers>
-                    <nldd-list-item>
-                      <nldd-spacer-cell size="10"></nldd-spacer-cell>
-                      <nldd-text-cell :text="person?.name || person?.email" :supporting-text="person?.name ? person?.email : ''"></nldd-text-cell>
-                      <nldd-spacer-cell size="10"></nldd-spacer-cell>
-                    </nldd-list-item>
-                  </nldd-list>
+                  <nldd-container v-if="!authLoading && authenticated" slot="header" padding-inline="16">
+                    <nldd-list variant="simple" no-dividers>
+                      <nldd-list-item>
+                        <nldd-text-cell :text="person?.name || person?.email">
+                        <span v-if="person?.name || showGithubLine" slot="supporting-text">
+                          <template v-if="person?.name">{{ person?.email }}</template>
+                          <br v-if="person?.name && showGithubLine">
+                          <template v-if="showGithubLine">GitHub: {{ githubStatus.github_login }}</template>
+                        </span>
+                      </nldd-text-cell>
+                      </nldd-list-item>
+                    </nldd-list>
+                  </nldd-container>
                   <nldd-menu-divider v-if="!authLoading && oidcConfigured && !authenticated"></nldd-menu-divider>
-                  <nldd-menu-item text="Weergave" icon="appearance">
-                    <nldd-menu>
-                      <nldd-menu-item
-                        v-for="[value, label, icon] in colorSchemeOptions"
-                        :key="`scheme-md-${value}`"
-                        type="radio"
-                        :selected="colorScheme === value || undefined"
-                        :text="label"
-                        :icon="icon"
-                        @select="setColorScheme(value)"
-                      ></nldd-menu-item>
-                    </nldd-menu>
-                  </nldd-menu-item>
+                  <nldd-menu-item text="Instellingen" icon="gear" @click="openSettings"></nldd-menu-item>
                   <nldd-menu-item v-if="canViewHarvesting" text="Harvester" icon="harvest" @click.stop="goToHarvesting"></nldd-menu-item>
-                  <nldd-menu-item v-if="!authLoading && authenticated" text="Feature flags" icon="flag">
-                    <nldd-menu>
-                      <nldd-menu-item
-                        v-for="[key, label] in functieFlags"
-                        :key="key"
-                        type="checkbox"
-                        :selected="isEnabled(key) || undefined"
-                        :text="label"
-                        @select="onFunctieFlagSelect(key, $event)"
-                      ></nldd-menu-item>
-                    </nldd-menu>
-                  </nldd-menu-item>
                   <nldd-menu-divider></nldd-menu-divider>
                   <nldd-menu-item text="Over RegelRecht" icon="info" @click="openAbout"></nldd-menu-item>
                   <nldd-menu-item text="Help" icon="help" @click="openSupport"></nldd-menu-item>
-                  <nldd-menu-item v-if="authenticated && githubStatus?.configured && isEnabled('github.user_oauth') && githubStatus?.connected" :text="'GitHub ontkoppelen (' + githubStatus.github_login + ')'" icon="dismiss" @click="disconnectGithub"></nldd-menu-item>
-                  <nldd-menu-item v-else-if="authenticated && githubStatus?.configured && isEnabled('github.user_oauth')" text="Koppel GitHub-account" icon="external-link" @click="connectGithub()"></nldd-menu-item>
                   <template v-if="!authLoading && authenticated">
                     <nldd-menu-divider></nldd-menu-divider>
                     <nldd-menu-item text="Log uit" icon="logout" @click="logout"></nldd-menu-item>
@@ -508,45 +452,25 @@ function onTabDismiss(e) {
                 <nldd-menu slot="popup">
                   <nldd-menu-item v-if="!authLoading && oidcConfigured && !authenticated" text="Inloggen" icon="login" @click="login()"></nldd-menu-item>
                   <nldd-menu-item v-if="!authLoading && oidcConfigured && !authenticated" text="Account aanvragen" icon="new-account" @click="goToAccountRequest"></nldd-menu-item>
-                  <nldd-list v-if="!authLoading && authenticated" slot="header" variant="simple" no-dividers>
-                    <nldd-list-item>
-                      <nldd-spacer-cell size="10"></nldd-spacer-cell>
-                      <nldd-text-cell :text="person?.name || person?.email" :supporting-text="person?.name ? person?.email : ''"></nldd-text-cell>
-                      <nldd-spacer-cell size="10"></nldd-spacer-cell>
-                    </nldd-list-item>
-                  </nldd-list>
+                  <nldd-container v-if="!authLoading && authenticated" slot="header" padding-inline="16">
+                    <nldd-list variant="simple" no-dividers>
+                      <nldd-list-item>
+                        <nldd-text-cell :text="person?.name || person?.email">
+                        <span v-if="person?.name || showGithubLine" slot="supporting-text">
+                          <template v-if="person?.name">{{ person?.email }}</template>
+                          <br v-if="person?.name && showGithubLine">
+                          <template v-if="showGithubLine">GitHub: {{ githubStatus.github_login }}</template>
+                        </span>
+                      </nldd-text-cell>
+                      </nldd-list-item>
+                    </nldd-list>
+                  </nldd-container>
                   <nldd-menu-divider v-if="!authLoading && oidcConfigured && !authenticated"></nldd-menu-divider>
-                  <nldd-menu-item text="Weergave" icon="appearance">
-                    <nldd-menu>
-                      <nldd-menu-item
-                        v-for="[value, label, icon] in colorSchemeOptions"
-                        :key="`scheme-lg-${value}`"
-                        type="radio"
-                        :selected="colorScheme === value || undefined"
-                        :text="label"
-                        :icon="icon"
-                        @select="setColorScheme(value)"
-                      ></nldd-menu-item>
-                    </nldd-menu>
-                  </nldd-menu-item>
+                  <nldd-menu-item text="Instellingen" icon="gear" @click="openSettings"></nldd-menu-item>
                   <nldd-menu-item v-if="canViewHarvesting" text="Harvester" icon="harvest" @click.stop="goToHarvesting"></nldd-menu-item>
-                  <nldd-menu-item v-if="!authLoading && authenticated" text="Feature flags" icon="flag">
-                    <nldd-menu>
-                      <nldd-menu-item
-                        v-for="[key, label] in functieFlags"
-                        :key="key"
-                        type="checkbox"
-                        :selected="isEnabled(key) || undefined"
-                        :text="label"
-                        @select="onFunctieFlagSelect(key, $event)"
-                      ></nldd-menu-item>
-                    </nldd-menu>
-                  </nldd-menu-item>
                   <nldd-menu-divider></nldd-menu-divider>
                   <nldd-menu-item text="Over RegelRecht" icon="info" @click="openAbout"></nldd-menu-item>
                   <nldd-menu-item text="Help" icon="help" @click="openSupport"></nldd-menu-item>
-                  <nldd-menu-item v-if="authenticated && githubStatus?.configured && isEnabled('github.user_oauth') && githubStatus?.connected" :text="'GitHub ontkoppelen (' + githubStatus.github_login + ')'" icon="dismiss" @click="disconnectGithub"></nldd-menu-item>
-                  <nldd-menu-item v-else-if="authenticated && githubStatus?.configured && isEnabled('github.user_oauth')" text="Koppel GitHub-account" icon="external-link" @click="connectGithub()"></nldd-menu-item>
                   <template v-if="!authLoading && authenticated">
                     <nldd-menu-divider></nldd-menu-divider>
                     <nldd-menu-item text="Log uit" icon="logout" @click="logout"></nldd-menu-item>
@@ -605,39 +529,39 @@ function onTabDismiss(e) {
         </nldd-container>
       </nldd-split-view-pane>
 
+      <!-- Review-melding (editor only): direct onder de document-tab-bar, dus
+           vóór `main` in de DOM. Eigen pane in de bar-split-view zodat hij niet
+           met de panes meescrollt. Op sm bestaat de tab-bar niet (above="md"),
+           daar landt hij dus vanzelf bovenaan. -->
+      <nldd-split-view-pane v-if="reviewNotice" slot="review-notice">
+        <nldd-container padding="8" padding-top="0">
+          <nldd-banner
+            size="sm"
+            :variant="editorChanges?.reviewVariant || 'accent'"
+            :text="reviewNotice"
+          ></nldd-banner>
+        </nldd-container>
+      </nldd-split-view-pane>
+
       <!-- Main content area - the active section's body. -->
       <nldd-split-view-pane slot="main">
         <router-view />
       </nldd-split-view-pane>
+
 
       <!-- Wijzigingenbalk (editor only): one article-level bar with Opslaan +
            Wijzigingen-ongedaan (+ text undo/redo), replacing the per-pane save
            footers. Published by EditorView via useAppChrome; shown only while
            the article has unsaved changes. Sits after `main` in the DOM, so on
            sm it lands above the two mobile bars and on md+ it's the bottom bar. -->
-      <nldd-split-view-pane v-if="editorChanges && editorChanges.dirty" slot="changes-bar">
+      <nldd-split-view-pane v-if="editorChanges && (editorChanges.dirty || editorChanges.review)" slot="changes-bar">
         <nldd-container padding="8" sm-padding-bottom="0">
           <nldd-toolbar size="md" label="Wijzigingen">
-            <!-- Discard zit bewust achter een 'meer'-menu zodat deze
-                 destructieve actie niet per ongeluk gekozen wordt. -->
-            <nldd-toolbar-item slot="start" label="Meer acties" :priority="1">
-              <nldd-icon-button icon="more" text="Meer acties" tooltip-timing="never">
-                <nldd-menu slot="popup">
-                  <nldd-menu-item
-                    text="Maak alle wijzigingen ongedaan"
-                    destructive
-                    @select="editorActions?.discard?.()"
-                  ></nldd-menu-item>
-                </nldd-menu>
-              </nldd-icon-button>
-              <nldd-menu-item
-                slot="overflow"
-                text="Maak alle wijzigingen ongedaan"
-                destructive
-                @select="editorActions?.discard?.()"
-              ></nldd-menu-item>
-            </nldd-toolbar-item>
-            <nldd-toolbar-item slot="start" label="Ongedaan maken / Opnieuw" :priority="1">
+            <!-- Undo en redo zijn losse knoppen: die gebruik je herhaald, en
+                 dan is elke klik door een menu er één te veel. De discard is
+                 destructief en houdt daarom z'n eigen chevron-knop, zodat hij
+                 niet per ongeluk geraakt wordt naast de twee ernaast. -->
+            <nldd-toolbar-item slot="start" label="Wijzigingen" :priority="1">
               <nldd-button-bar>
                 <nldd-icon-button
                   icon="undo"
@@ -652,6 +576,16 @@ function onTabDismiss(e) {
                   :disabled="!editorChanges.canRedo || undefined"
                   @click="editorActions?.redo?.()"
                 ></nldd-icon-button>
+                <nldd-button-bar-divider></nldd-button-bar-divider>
+                <nldd-icon-button icon="chevron-down" text="Meer acties" tooltip-timing="never">
+                  <nldd-menu slot="popup">
+                    <nldd-menu-item
+                      text="Maak alle wijzigingen ongedaan"
+                      destructive
+                      @select="editorActions?.discard?.()"
+                    ></nldd-menu-item>
+                  </nldd-menu>
+                </nldd-icon-button>
               </nldd-button-bar>
               <nldd-menu-item
                 slot="overflow"
@@ -667,20 +601,60 @@ function onTabDismiss(e) {
                 :disabled="!editorChanges.canRedo || undefined"
                 @select="editorActions?.redo?.()"
               ></nldd-menu-item>
+              <nldd-menu-item
+                slot="overflow"
+                text="Maak alle wijzigingen ongedaan"
+                destructive
+                @select="editorActions?.discard?.()"
+              ></nldd-menu-item>
             </nldd-toolbar-item>
-            <nldd-toolbar-item slot="end" label="Opslaan" width="320px" :priority="3">
+            <!-- Review-modus zet de beslissing hier. Twee losse toolbar-items,
+                 geen button-bar: die plakt een destructieve knop tegen een
+                 bevestigende aan, precies wat de ontwerprichtlijn ("geef ze
+                 visuele en fysieke afstand") wil voorkomen. Verwerp heeft de
+                 lagere prioriteit, dus die wijkt als eerste naar het
+                 overloopmenu. -->
+            <nldd-toolbar-item v-if="inReview" slot="end" label="Verwerp voorstel" :priority="2">
+              <nldd-button
+                variant="destructive"
+                size="md"
+                start-icon="dismiss-circle"
+                text="Verwerp voorstel"
+                :disabled="editorChanges.saving || undefined"
+                @click="rejectConfirm?.show()"
+              ></nldd-button>
+              <nldd-menu-item
+                slot="overflow"
+                icon="dismiss"
+                text="Verwerp voorstel"
+                destructive
+                :disabled="editorChanges.saving || undefined"
+                @select="rejectConfirm?.show()"
+              ></nldd-menu-item>
+            </nldd-toolbar-item>
+            <!-- Buiten review staat Opslaan er alleen, en dan houdt hij zijn
+                 eigen brede vlak: geen icoon nodig om zich van een buurknop te
+                 onderscheiden. In review staat Verwerp ernaast, en daar doen de
+                 iconen het onderscheidende werk op eigen breedte. -->
+            <nldd-toolbar-item
+              slot="end"
+              :label="saveLabel"
+              :width="inReview ? undefined : '320px'"
+              :priority="3"
+            >
               <nldd-button
                 variant="primary"
                 size="md"
-                width="full"
-                text="Opslaan"
+                :start-icon="inReview ? 'check-mark-circle' : undefined"
+                :width="inReview ? undefined : 'full'"
+                :text="saveLabel"
                 :loading="editorChanges.saving || undefined"
                 @click="editorActions?.save?.()"
               ></nldd-button>
               <nldd-menu-item
                 slot="overflow"
                 icon="save"
-                text="Opslaan"
+                :text="saveLabel"
                 :disabled="editorChanges.saving || undefined"
                 @select="editorActions?.save?.()"
               ></nldd-menu-item>
@@ -753,45 +727,25 @@ function onTabDismiss(e) {
                 <nldd-menu slot="popup">
                   <nldd-menu-item v-if="!authLoading && oidcConfigured && !authenticated" text="Inloggen" icon="login" @click="login()"></nldd-menu-item>
                   <nldd-menu-item v-if="!authLoading && oidcConfigured && !authenticated" text="Account aanvragen" icon="new-account" @click="goToAccountRequest"></nldd-menu-item>
-                  <nldd-list v-if="!authLoading && authenticated" slot="header" variant="simple" no-dividers>
-                    <nldd-list-item>
-                      <nldd-spacer-cell size="10"></nldd-spacer-cell>
-                      <nldd-text-cell :text="person?.name || person?.email" :supporting-text="person?.name ? person?.email : ''"></nldd-text-cell>
-                      <nldd-spacer-cell size="10"></nldd-spacer-cell>
-                    </nldd-list-item>
-                  </nldd-list>
+                  <nldd-container v-if="!authLoading && authenticated" slot="header" padding-inline="16">
+                    <nldd-list variant="simple" no-dividers>
+                      <nldd-list-item>
+                        <nldd-text-cell :text="person?.name || person?.email">
+                        <span v-if="person?.name || showGithubLine" slot="supporting-text">
+                          <template v-if="person?.name">{{ person?.email }}</template>
+                          <br v-if="person?.name && showGithubLine">
+                          <template v-if="showGithubLine">GitHub: {{ githubStatus.github_login }}</template>
+                        </span>
+                      </nldd-text-cell>
+                      </nldd-list-item>
+                    </nldd-list>
+                  </nldd-container>
                   <nldd-menu-divider v-if="!authLoading && oidcConfigured && !authenticated"></nldd-menu-divider>
-                  <nldd-menu-item text="Weergave" icon="appearance">
-                    <nldd-menu>
-                      <nldd-menu-item
-                        v-for="[value, label, icon] in colorSchemeOptions"
-                        :key="`scheme-sm-${value}`"
-                        type="radio"
-                        :selected="colorScheme === value || undefined"
-                        :text="label"
-                        :icon="icon"
-                        @select="setColorScheme(value)"
-                      ></nldd-menu-item>
-                    </nldd-menu>
-                  </nldd-menu-item>
+                  <nldd-menu-item text="Instellingen" icon="gear" @click="openSettings"></nldd-menu-item>
                   <nldd-menu-item v-if="canViewHarvesting" text="Harvester" icon="harvest" @click.stop="goToHarvesting"></nldd-menu-item>
-                  <nldd-menu-item v-if="!authLoading && authenticated" text="Feature flags" icon="flag">
-                    <nldd-menu>
-                      <nldd-menu-item
-                        v-for="[key, label] in functieFlags"
-                        :key="key"
-                        type="checkbox"
-                        :selected="isEnabled(key) || undefined"
-                        :text="label"
-                        @select="onFunctieFlagSelect(key, $event)"
-                      ></nldd-menu-item>
-                    </nldd-menu>
-                  </nldd-menu-item>
                   <nldd-menu-divider></nldd-menu-divider>
                   <nldd-menu-item text="Over RegelRecht" icon="info" @click="openAbout"></nldd-menu-item>
                   <nldd-menu-item text="Help" icon="help" @click="openSupport"></nldd-menu-item>
-                  <nldd-menu-item v-if="authenticated && githubStatus?.configured && isEnabled('github.user_oauth') && githubStatus?.connected" :text="'GitHub ontkoppelen (' + githubStatus.github_login + ')'" icon="dismiss" @click="disconnectGithub"></nldd-menu-item>
-                  <nldd-menu-item v-else-if="authenticated && githubStatus?.configured && isEnabled('github.user_oauth')" text="Koppel GitHub-account" icon="external-link" @click="connectGithub()"></nldd-menu-item>
                   <template v-if="!authLoading && authenticated">
                     <nldd-menu-divider></nldd-menu-divider>
                     <nldd-menu-item text="Log uit" icon="logout" @click="logout"></nldd-menu-item>
@@ -806,6 +760,7 @@ function onTabDismiss(e) {
 
     <AboutSheet ref="aboutSheet"></AboutSheet>
     <SupportSheet ref="supportSheet"></SupportSheet>
+    <SettingsSheet ref="settingsSheet"></SettingsSheet>
   </nldd-app-view>
 
   <!-- Editor requires login: a heads-up popover anchored to the clicked Editor
@@ -823,20 +778,24 @@ function onTabDismiss(e) {
     </nldd-container>
   </nldd-popover>
 
-  <!-- Enabling the GitHub-koppeling flag is a deployment-wide write-path
-       switch, not a personal preference like its neighbours in the Functies
-       list - confirm before every writer's saves start requiring a linked
-       GitHub account (see onFunctieFlagSelect). -->
-  <nldd-popover ref="enforcementConfirm" accessible-label="GitHub-koppeling inschakelen" width="360px" @close="onEnforcementConfirmClose">
-    <nldd-container padding="16">
-      <nldd-inline-dialog
-        icon="exclamation-triangle"
-        text="GitHub-koppeling voor iedereen inschakelen?"
-        supporting-text="Dit geldt voor de hele omgeving, niet alleen voor jou: opslaan in een traject vereist daarna voor elke gebruiker een gekoppeld GitHub-account. Wie nog niet gekoppeld heeft, wordt bij de eerstvolgende opslag naar de koppel-flow geleid."
-      >
-        <nldd-button slot="actions" variant="primary" text="Inschakelen" @click="confirmUserOauthEnforcement"></nldd-button>
-        <nldd-button slot="actions" text="Annuleren" @click="enforcementConfirm?.hide()"></nldd-button>
-      </nldd-inline-dialog>
-    </nldd-container>
-  </nldd-popover>
+  <nldd-modal-dialog
+    ref="rejectConfirm"
+    variant="alert"
+    icon="exclamation-triangle"
+    text="Voorstel verwerpen?"
+    supporting-text="De taak wordt afgesloten en het gegenereerde voorstel gaat verloren. Een nieuw voorstel vraag je opnieuw aan met Verrijk deze wet."
+  >
+    <nldd-button
+      slot="actions"
+      variant="primary"
+      text="Behoud voorstel"
+      @click="rejectConfirm?.hide()"
+    ></nldd-button>
+    <nldd-button
+      slot="actions"
+      variant="destructive"
+      text="Verwerp voorstel"
+      @click="confirmReject"
+    ></nldd-button>
+  </nldd-modal-dialog>
 </template>

--- a/frontend/src/EditorView.vue
+++ b/frontend/src/EditorView.vue
@@ -2401,10 +2401,14 @@ async function handleActionSave() {
                results into a different view. Re-keying on the view id
                forces an unmount + remount on identity change, at the
                (acceptable) cost of losing pane scroll position. -->
+          <!-- data-testid names the view, not the index: the empty states and
+               their buttons live in more than one pane, so an e2e locator has to
+               be able to say which pane it means. -->
           <nldd-split-view-pane
             v-for="(view, idx) in paneViews"
             :key="`${view}-${idx}`"
             :slot="`pane-${idx + 1}`"
+            :data-testid="`pane-${view}`"
           >
             <nldd-page
               sticky-header

--- a/frontend/src/EditorView.vue
+++ b/frontend/src/EditorView.vue
@@ -1588,12 +1588,14 @@ function applyProposedContent(proposedYaml) {
 // the parts the article-scoped editor can't show. A bar has no room for
 // paragraphs, so copy stays to a heading line + one short supporting line.
 const REVIEW_HIDDEN_CHANGES_NOTE = 'Zie ook het YAML-paneel voor wijzigingen buiten dit artikel.';
+// Accent, not neutral: a generated proposal is the one thing on screen that
+// asks for a decision, and a neutral bar reads as background chrome.
 const reviewBannerVariant = computed(() => {
   if (reviewLoadError.value) return 'critical';
-  if (reviewIsLawCreate.value) return 'neutral';
+  if (reviewIsLawCreate.value) return 'accent';
   if (reviewStale.value) return 'warning';
   if (reviewActive.value && !reviewSeeded.value) return 'warning';
-  return 'neutral';
+  return 'accent';
 });
 const reviewBannerText = computed(() =>
   reviewIsLawCreate.value ? 'Nieuwe wet uit documentconversie' : 'Voorstel uit verrijking',
@@ -1616,6 +1618,30 @@ const reviewBannerSupportingText = computed(() => {
     'Opslaan keurt het volledige voorstel goed (eigen aanpassingen gaan niet mee), Verwerpen wijst af.' +
     (reviewHasHiddenChanges.value ? ` ${REVIEW_HIDDEN_CHANGES_NOTE}` : '')
   );
+});
+
+// Which panes carry the proposal, for the review status bar. The proposal is
+// always a full law YAML, so the YAML pane always shows all of it; the
+// article-scoped panes only carry something when seeding succeeded. Scenario's
+// is deliberately absent: the worker does stage `features/*.feature` files, but
+// useTaskReview only ever picks the law YAML out of the result blobs, so no
+// scenario ever reaches these panes (see useTaskReview.js).
+const reviewChangedPanes = computed(() => {
+  const panes = [];
+  if (reviewSeeded.value) panes.push('Tekst', 'Machine');
+  panes.push('YAML');
+  return panes;
+});
+const reviewStatusText = computed(() => {
+  if (reviewLoadError.value) return reviewLoadError.value;
+  const what = reviewIsLawCreate.value
+    ? 'Dit is een nieuwe wet uit documentconversie'
+    : 'Dit is een gegenereerd voorstel';
+  const panes = reviewChangedPanes.value;
+  const list =
+    panes.length > 1 ? `${panes.slice(0, -1).join(', ')} en ${panes.at(-1)}` : panes[0];
+  const stale = reviewStale.value ? ' De wet is intussen gewijzigd, controleer extra goed.' : '';
+  return `${what}. Beoordeel ${list}.${stale}`;
 });
 
 // Fires once the law + its first article have finished loading (whether
@@ -1861,6 +1887,7 @@ registerEditorActions({
   discard: discardArticle,
   undo: undoText,
   redo: redoText,
+  reject: rejectReview,
 });
 watchEffect(() => {
   setEditorChanges({
@@ -1868,6 +1895,9 @@ watchEffect(() => {
     saving: lawSaving.value,
     canUndo: canUndoText.value,
     canRedo: canRedoText.value,
+    review: reviewActive.value,
+    reviewStatus: reviewActive.value || reviewLoadError.value ? reviewStatusText.value : null,
+    reviewVariant: reviewBannerVariant.value,
   });
 });
 
@@ -2260,43 +2290,12 @@ async function handleActionSave() {
              stay in the DOM so state is preserved when the viewport
              widens. -->
         <template v-else>
-          <!-- Review-modus (job_review-taak): a full-width, low bar above
-               the editor panes rather than a page-height dialog (PR #935 UX
-               feedback - the old nldd-page/nldd-simple-section wrapper made
-               it "too tall and too narrow", pushing real content down). A
-               bare nldd-container + nldd-banner sits directly in the flex
-               column here, outside the narrow-column nldd-simple-section
-               the pane/error states below use, the same way the
-               Wijzigingenbalk (AppShell.vue) is a bare nldd-container
-               outside its page-section too. nldd-banner natively supports
-               a variant colour + an actions slot (nldd-button, wrapped in
-               nldd-button-group), so it carries "Verwerpen"/"Voorstel
-               opslaan en goedkeuren" without any custom CSS. -->
-          <nldd-container v-if="reviewActive || reviewLoadError" padding="8">
-            <nldd-banner :variant="reviewBannerVariant" :text="reviewBannerText" :supporting-text="reviewBannerSupportingText">
-              <!-- Wijzigingenbalk only appears when a pane is dirty, which
-                   `!reviewSeeded` never is (nothing was seeded into the
-                   panes) - give the banner its own primary action so
-                   approving a proposal that touches nothing visible here
-                   is still reachable. -->
-              <nldd-button
-                v-if="reviewActive && !reviewSeeded"
-                slot="actions"
-                variant="primary"
-                text="Voorstel opslaan en goedkeuren"
-                :loading="lawSaving || undefined"
-                :disabled="lawSaving || undefined"
-                @click="handleLawSave"
-              ></nldd-button>
-              <nldd-button
-                v-if="reviewActive"
-                slot="actions"
-                variant="secondary"
-                text="Verwerpen"
-                @click="rejectReview"
-              ></nldd-button>
-            </nldd-banner>
-          </nldd-container>
+          <!-- Review-modus (job_review-taak) heeft geen eigen blok meer in de
+               content. De melding gaat als `slot="review-notice"` naar de
+               bar-split-view in AppShell (onder de document-tab-bar, boven
+               `main`) en de beslissing staat in de Wijzigingenbalk eronder.
+               Allebei via useAppChrome, net als de rest van de shell-chrome,
+               zodat geen van beide met de panes meescrollt. -->
 
           <!-- Feedback from "Verrijk deze wet" (see the pane toolbar below):
                same page-wide banner-in-container pattern as the review notice

--- a/frontend/src/EditorView.vue
+++ b/frontend/src/EditorView.vue
@@ -8,7 +8,8 @@ import { useEngine } from './composables/useEngine.js';
 import { useAuth } from './composables/useAuth.js';
 import { useTrajects } from './composables/useTrajects.js';
 import { useFeatureFlags } from './composables/useFeatureFlags.js';
-import { useTaskActions } from './composables/useTasks.js';
+import { useTaskActions, usePollWhile } from './composables/useTasks.js';
+import { reviewTarget } from './lib/taskReview.js';
 import { useTaskReview } from './composables/useTaskReview.js';
 import { useNotes, useResolvedDraftNotes } from './composables/useNotes.js';
 import { useDraftNotes } from './composables/useDraftNotes.js';
@@ -41,6 +42,7 @@ import ActionSheet from './components/ActionSheet.vue';
 import EditSheet from './components/EditSheet.vue';
 import SearchPopover from './components/SearchPopover.vue';
 import MachineReadable from './components/MachineReadable.vue';
+import MachineEmptyState from './components/MachineEmptyState.vue';
 import ScenarioBuilder from './components/ScenarioBuilder.vue';
 import ExecutionTraceView from './components/ExecutionTraceView.vue';
 import LawGraphView from './components/LawGraphView.vue';
@@ -1620,15 +1622,15 @@ const reviewBannerSupportingText = computed(() => {
   );
 });
 
-// Which panes carry the proposal, for the review status bar. The proposal is
-// always a full law YAML, so the YAML pane always shows all of it; the
-// article-scoped panes only carry something when seeding succeeded. Scenario's
-// is deliberately absent: the worker does stage `features/*.feature` files, but
-// useTaskReview only ever picks the law YAML out of the result blobs, so no
-// scenario ever reaches these panes (see useTaskReview.js).
+// Which panes carry the proposal, for de review-melding. De verrijking schrijft
+// machine_readable en scenario's, niet de wettekst, dus Tekst hoort hier niet
+// in. YAML toont altijd de volledige proposal; Machine alleen als het seeden
+// lukte. Scenario's staat er bewust niet bij: de worker staged wel
+// `features/*.feature`, maar useTaskReview pakt alleen de wet-YAML uit de
+// resultaat-blobs, dus daar komt nooit een scenario aan.
 const reviewChangedPanes = computed(() => {
   const panes = [];
-  if (reviewSeeded.value) panes.push('Tekst', 'Machine');
+  if (reviewSeeded.value) panes.push('Machine');
   panes.push('YAML');
   return panes;
 });
@@ -1712,14 +1714,46 @@ async function rejectReview() {
   clearReviewQuery();
 }
 
-// --- "Verrijk deze wet" (request a job_review task) ---------------------
+// --- Verrijken aanvragen (levert een job_review-taak op) -----------------
 // Fire-and-forget request; the resulting job_review task shows up in the
 // taken-lijst in Home on its next poll (TasksSidebarItem/TasksListPane poll
 // via useTasks() every 30s). Use the non-polling useTaskActions() here -
 // EditorView doesn't need the shared task list/badge count, and joining
 // useTasks() unconditionally in setup() would start that poll for every
 // editor visitor, including anonymous ones.
-const { requestEnrich } = useTaskActions();
+const { requestEnrich, running: runningJobs, tasks: openTasks } = useTaskActions();
+// Staat er al een beoordeelbaar voorstel klaar voor deze wet? Dan meldt de lege
+// pane dat, in plaats van opnieuw te laten genereren.
+const pendingReviewTask = computed(() =>
+  openTasks.value.find(
+    (t) => t.task_type === 'job_review' && t.payload?.law_id === lawId.value,
+  ) ?? null,
+);
+// Niet melden terwijl je die taak al aan het beoordelen bent.
+const reviewReady = computed(() => !!pendingReviewTask.value && !reviewActive.value);
+function openReviewForLaw() {
+  const target = reviewTarget(pendingReviewTask.value);
+  if (target) router.push(target);
+}
+// Loopt er al een verrijking voor deze wet? Dan meldt de lege pane dat in
+// plaats van opnieuw de knoppen aan te bieden.
+// Naar de takenlijst, gefilterd op deze wet: daar staat de lopende aanvraag.
+function openTasksForLaw() {
+  if (!activeTrajectRef.value || !lawId.value) return;
+  router.push({
+    name: 'taken-traject',
+    params: {
+      trajectRef: activeTrajectRef.value,
+      categorie: 'wet',
+      contextLawId: lawId.value,
+    },
+  });
+}
+// Alleen pollen zolang je naar de bezig-staat kijkt; zie usePollWhile.
+const isEnriching = computed(() =>
+  runningJobs.value.some((job) => job.job_type === 'enrich' && job.law_id === lawId.value),
+);
+usePollWhile(isEnriching);
 const enrichFeedback = ref(null); // { variant, text } | null
 // An actual traject open (write access implies a traject, see `canEdit`
 // above) and a law loaded - mirrors the gates other write actions in this
@@ -1727,6 +1761,13 @@ const enrichFeedback = ref(null); // { variant, text } | null
 const canEnrichLaw = computed(
   () => canEdit.value && !!activeTrajectRef.value && !!lawId.value,
 );
+
+// De verrijking schrijft machine_readable en scenario's, niet de wettekst. De
+// knop hoort dus bij de panes waar dat resultaat landt, niet in de toolbar van
+// de tekstverwerker (waar hij stond omdat die toevallig pane 0 is). In elke
+// Machine- en YAML-pane, niet één keer: die twee staan niet altijd allebei
+// open, en de pane die je wél ziet moet je verder kunnen helpen.
+const isEnrichPane = (view) => view === 'machine' || view === 'yaml';
 
 async function enrichLaw() {
   if (!activeTrajectRef.value || !lawId.value) return;
@@ -2297,7 +2338,7 @@ async function handleActionSave() {
                Allebei via useAppChrome, net als de rest van de shell-chrome,
                zodat geen van beide met de panes meescrollt. -->
 
-          <!-- Feedback from "Verrijk deze wet" (see the pane toolbar below):
+          <!-- Feedback op een aangevraagde verrijking (zie de Machine/YAML-pane):
                same page-wide banner-in-container pattern as the review notice
                above, so feedback never pushes the editor into a tall narrow
                column. -->
@@ -2601,30 +2642,20 @@ async function handleActionSave() {
                       disabled
                     ></nldd-menu-item>
                   </nldd-toolbar-item>
-                  <!-- Wet-acties: only on the first pane - the action applies to
-                       the whole law, not this one pane, so showing it in every
-                       pane's own toolbar would just duplicate it. -->
-                  <nldd-toolbar-item
-                    v-if="idx === 0 && canEnrichLaw"
-                    slot="end"
-                    label="Wet acties"
-                    :priority="1"
-                  >
-                    <nldd-icon-button
-                      icon="ai"
-                      text="Wet acties"
-                      variant="secondary"
-                      size="md"
-                      expandable
-                    >
-                      <nldd-menu slot="popup">
-                        <nldd-menu-item icon="ai" text="Verrijk deze wet" @select="enrichLaw"></nldd-menu-item>
-                      </nldd-menu>
-                    </nldd-icon-button>
-                    <nldd-menu-group slot="overflow" text="Wet acties">
-                      <nldd-menu-item icon="ai" text="Verrijk deze wet" @select="enrichLaw"></nldd-menu-item>
-                    </nldd-menu-group>
-                  </nldd-toolbar-item>
+                  <!-- Verrijken hoort bij de panes die het resultaat tonen, maar
+                       het is geen actie die je vaak aanraakt en de pane-toolbar
+                       is smal. Als directe child van nldd-toolbar met
+                       slot="overflow" is dit een pinned overflow item: hij staat
+                       altijd achter de ...-knop en vecht dus nooit met de
+                       pane-switcher om breedte. Is de pane leeg, dan staat de
+                       ingang in de lege staat zelf. -->
+                  <nldd-menu-item
+                    v-if="canEnrichLaw && isEnrichPane(view) && hasMachineReadable"
+                    slot="overflow"
+                    icon="ai"
+                    text="Genereer nieuw voorstel"
+                    @select="enrichLaw"
+                  ></nldd-menu-item>
                 </nldd-toolbar>
               </nldd-container>
 
@@ -2783,12 +2814,18 @@ async function handleActionSave() {
                 <MachineReadable
                   :article="editedArticle"
                   :editable="canEdit"
+                  :can-enrich="canEnrichLaw"
+                  :enriching="isEnriching"
+                  :review-ready="reviewReady"
                   :dirty="isMachineReadableDirty"
                   :saving="lawSaving"
                   :traject-ref="activeTrajectRef"
                   @open-action="handleOpenAction"
                   @open-edit="activeEditItem = $event"
                   @init-mr="handleInitMr"
+                  @enrich="enrichLaw"
+                  @view-tasks="openTasksForLaw"
+                  @review="openReviewForLaw"
                   @add-action="handleAddAction"
                   @save="handleMachineReadableSave"
                   @patch="handleSave"
@@ -2820,20 +2857,17 @@ async function handleActionSave() {
 
               <!-- YAML -->
               <nldd-simple-section v-else-if="view === 'yaml'" width="full">
-                <nldd-inline-dialog
+                <MachineEmptyState
                   v-if="!hasMachineReadable"
-                  text="Geen machine-leesbare gegevens voor dit artikel"
-                >
-                  <nldd-button
-                    v-if="canEdit"
-                    slot="actions"
-                    variant="secondary"
-                    size="md"
-                    data-testid="init-mr-btn-yaml"
-                    text="Maak machine versie aan"
-                    @click="handleInitMr"
-                  ></nldd-button>
-                </nldd-inline-dialog>
+                  :review-ready="reviewReady"
+                  :enriching="isEnriching"
+                  :can-enrich="canEnrichLaw"
+                  :can-write-here="canEdit"
+                  @enrich="enrichLaw"
+                  @write="handleInitMr"
+                  @view-tasks="openTasksForLaw"
+                  @review="openReviewForLaw"
+                ></MachineEmptyState>
                 <template v-else>
                   <nldd-code-editor
                     resize="auto"

--- a/frontend/src/EditorView.vue
+++ b/frontend/src/EditorView.vue
@@ -1497,11 +1497,10 @@ const lastSaveTouchedMachine = ref(false);
 // the same pane-local "current" refs a manual edit would touch), so the
 // existing dirty-tracking and Wijzigingenbalk (Opslaan/Wijzigingen-
 // ongedaan) drive the review UI the same way they drive a manual edit.
-// The SEEDING is single-article-scoped like `currentLawYaml` below (a
-// proposal touching several articles only seeds the first one that
-// differs into the panes), but the SAVE is not: `handleLawSave` sends the
-// full `reviewProposedContent` when a review is active, so approving
-// always commits the entire proposal - never just the seeded article.
+// Seeding en opslaan zijn allebei artikel-scoped: de taak wijst het artikel
+// aan (`payload.article`), de editor seedt dat en Opslaan bewaart de splice.
+// Alleen een taak zónder artikelnummer valt terug op de hele wet, zie
+// `reviewSavesWholeLaw`.
 const {
   reviewTask,
   proposedContent: reviewProposedContent,
@@ -1518,6 +1517,22 @@ const reviewActive = computed(() => !!reviewTask.value);
 const reviewIsLawCreate = computed(
   () => reviewTask.value?.payload?.kind === 'law_create',
 );
+// Het artikel waar deze taak over gaat. De worker maakt sinds de opsplitsing
+// één review-taak per gewijzigd artikel en zet het nummer in de payload, zodat
+// een beoordelaar zich uitspreekt over wat er werkelijk veranderd is.
+//
+// Zonder nummer gaat de taak over de hele wet. Dat blijft bestaan voor een
+// `law_create` (de wet ís het voorstel), voor een voorstel dat de worker niet
+// kon opsplitsen, en voor taken van vóór deze wijziging.
+const reviewArticleNumber = computed(() => {
+  const number = reviewTask.value?.payload?.article;
+  return number == null ? null : String(number);
+});
+// Een taak die één artikel aanwijst, slaat op als elke andere artikel-save: de
+// splice van de zichtbare pane, inclusief wat de beoordelaar er zelf nog aan
+// veranderde. Alleen een taak zonder artikelnummer committeert het voorstel in
+// zijn geheel, want daar is geen kleinere eenheid om over te beslissen.
+const reviewSavesWholeLaw = computed(() => reviewActive.value && !reviewArticleNumber.value);
 const reviewTaskIdParam = computed(() =>
   typeof route.query.task === 'string' ? route.query.task : null,
 );
@@ -1565,7 +1580,11 @@ function applyProposedContent(proposedYaml) {
   // which has no way to splice in an article the saved law doesn't have),
   // and can't show a removed article either - proposalDivergence folds both
   // into `hiddenChanges` so the banner points at the YAML panel for them.
-  const { target, hiddenChanges } = proposalDivergence(articles.value, proposedArticles);
+  const { target, hiddenChanges } = proposalDivergence(
+    articles.value,
+    proposedArticles,
+    reviewArticleNumber.value,
+  );
   reviewHasHiddenChanges.value = hiddenChanges;
   if (!target) return; // nothing seedable differs - nothing to seed
   reviewSeeded.value = true;
@@ -1608,13 +1627,21 @@ const reviewBannerSupportingText = computed(() => {
     return 'Controleer de wet; Opslaan voegt de wet toe aan het traject, Verwerpen wijst af.';
   }
   if (!reviewSeeded.value) {
-    return 'Voorstel raakt alleen inhoud die hier niet zichtbaar is - bekijk het YAML-paneel.';
+    return reviewArticleNumber.value
+      ? `Artikel ${reviewArticleNumber.value} wijkt niet af van het voorstel; er valt niets te wijzigen.`
+      : 'Voorstel raakt alleen inhoud die hier niet zichtbaar is - bekijk het YAML-paneel.';
   }
   if (reviewStale.value) {
     return (
       'Let op: de wet is intussen gewijzigd; controleer extra goed.' +
       (reviewHasHiddenChanges.value ? ` ${REVIEW_HIDDEN_CHANGES_NOTE}` : '')
     );
+  }
+  // Artikel-scoped: Opslaan is de gewone artikel-save, dus eigen aanpassingen
+  // gaan wél mee. Bij een voorstel voor de hele wet niet, en dat moet er dan
+  // ook staan - het is precies wat een beoordelaar niet verwacht.
+  if (!reviewSavesWholeLaw.value) {
+    return `Opslaan bewaart artikel ${reviewArticleNumber.value} zoals het hier staat, Verwerpen wijst het voorstel af.`;
   }
   return (
     'Opslaan keurt het volledige voorstel goed (eigen aanpassingen gaan niet mee), Verwerpen wijst af.' +
@@ -1724,13 +1751,25 @@ async function rejectReview() {
 const { requestEnrich, running: runningJobs, tasks: openTasks } = useTaskActions();
 // Staat er al een beoordeelbaar voorstel klaar voor deze wet? Dan meldt de lege
 // pane dat, in plaats van opnieuw te laten genereren.
-const pendingReviewTask = computed(() =>
-  openTasks.value.find(
+// Eén verrijking levert een taak per gewijzigd artikel, dus meestal staan er
+// meerdere open voor deze wet. Je kijkt naar één artikel, dus de taak van dát
+// artikel gaat voor; is die er niet, dan de eerste van de wet - beter naar een
+// naburig voorstel wijzen dan naar niets.
+const pendingReviewTask = computed(() => {
+  const forLaw = openTasks.value.filter(
     (t) => t.task_type === 'job_review' && t.payload?.law_id === lawId.value,
-  ) ?? null,
-);
+  );
+  if (!forLaw.length) return null;
+  const here = String(selectedArticleNumber.value ?? '');
+  return forLaw.find((t) => String(t.payload?.article ?? '') === here) ?? forLaw[0];
+});
 // Niet melden terwijl je die taak al aan het beoordelen bent.
 const reviewReady = computed(() => !!pendingReviewTask.value && !reviewActive.value);
+const reviewArticleForPane = computed(() =>
+  pendingReviewTask.value?.payload?.article == null
+    ? ''
+    : String(pendingReviewTask.value.payload.article),
+);
 function openReviewForLaw() {
   const target = reviewTarget(pendingReviewTask.value);
   if (target) router.push(target);
@@ -1795,15 +1834,19 @@ function dismissEnrichFeedback() {
 // the whole law YAML, so one click persists every in-memory edit for the
 // selected article regardless of which pane surfaced the button.
 //
-// Review-modus: Opslaan approves the task, and approval must commit the
-// FULL proposal (spec §5.3/§6), not just the splice `currentLawYaml` makes
-// into the single selected article - a proposal touching several articles
-// would otherwise lose every article besides the one shown in the editor.
-// `saveLaw` already accepts arbitrary full-law YAML text (see its PUT body
-// in useLaw.js), so reusing it with `reviewProposedContent` instead of
-// `currentLawYaml` is the whole fix; no second save path is introduced.
+// Review-modus: Opslaan approves the task. Een taak die één artikel aanwijst
+// loopt langs het gewone pad - `currentLawYaml` splicet dat artikel in de
+// opgeslagen wet, en dat is precies de eenheid waarover de taak gaat. Wat de
+// verrijking elders voorstelde, blijft aan de eigen taak van dát artikel
+// hangen en gaat hier niet ongezien mee.
+//
+// Een taak zonder artikelnummer (law_create, of een voorstel dat de worker
+// niet kon opsplitsen) heeft die kleinere eenheid niet, en committeert het
+// voorstel integraal. `saveLaw` accepteert willekeurige volledige-wet-YAML
+// (zie de PUT-body in useLaw.js), dus dat is dezelfde aanroep met andere
+// inhoud; er komt geen tweede save-pad bij.
 async function handleLawSave() {
-  const lawYaml = reviewActive.value ? reviewProposedContent.value : currentLawYaml.value;
+  const lawYaml = reviewSavesWholeLaw.value ? reviewProposedContent.value : currentLawYaml.value;
   if (!lawYaml) return;
   // Snapshot the law id before the await. saveLaw itself guards its own
   // reactive writes with the same check, but the post-save cleanup below
@@ -1815,8 +1858,8 @@ async function handleLawSave() {
   // the visible pane's edits - always treat it as touching text (notes
   // re-anchor safely; skipping would risk leaving a note's positions stale
   // against text the proposal actually changed elsewhere in the law).
-  lastSaveTouchedText.value = reviewActive.value ? true : isArticleTextDirty.value;
-  lastSaveTouchedMachine.value = reviewActive.value ? true : isMachineReadableDirty.value;
+  lastSaveTouchedText.value = reviewSavesWholeLaw.value ? true : isArticleTextDirty.value;
+  lastSaveTouchedMachine.value = reviewSavesWholeLaw.value ? true : isMachineReadableDirty.value;
   try {
     // law_create: de wet bestaat nog niet in het traject, dus het voorstel
     // gaat door het create-pad (POST, pad server-side afgeleid) - daarna
@@ -2817,6 +2860,7 @@ async function handleActionSave() {
                   :can-enrich="canEnrichLaw"
                   :enriching="isEnriching"
                   :review-ready="reviewReady"
+                  :review-article="reviewArticleForPane"
                   :dirty="isMachineReadableDirty"
                   :saving="lawSaving"
                   :traject-ref="activeTrajectRef"
@@ -2860,6 +2904,7 @@ async function handleActionSave() {
                 <MachineEmptyState
                   v-if="!hasMachineReadable"
                   :review-ready="reviewReady"
+                  :review-article="reviewArticleForPane"
                   :enriching="isEnriching"
                   :can-enrich="canEnrichLaw"
                   :can-write-here="canEdit"

--- a/frontend/src/LibraryView.recentLaws.test.js
+++ b/frontend/src/LibraryView.recentLaws.test.js
@@ -1,0 +1,191 @@
+// "Recent bekeken" is stored per traject: two trajects hold different laws, so
+// a law opened in the one must not turn up under the other, where that id may
+// not even resolve. Mounts LibraryView `shallow` with the same composable stubs
+// LibraryView.docReview.test.js uses - deliberately narrow, this file only
+// exercises the recent-laws surface.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+
+const routeState = {
+  name: 'library-traject',
+  params: { trajectRef: 'traject-aaaa1111', docPath: '' },
+  query: {},
+  fullPath: '/traject/traject-aaaa1111/bibliotheek',
+  hash: '',
+};
+vi.mock('vue-router', () => ({
+  useRoute: () => routeState,
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn(), resolve: () => ({ href: '#' }) }),
+  onBeforeRouteUpdate: vi.fn(),
+  onBeforeRouteLeave: vi.fn(),
+}));
+
+vi.mock('./composables/useAuth.js', () => ({
+  useAuth: () => ({ authenticated: ref(true), login: vi.fn() }),
+}));
+
+// The ref the view watches: switching traject keeps the view mounted, so the
+// test drives the switch by writing to this exact ref.
+const activeTrajectRef = ref('traject-aaaa1111');
+vi.mock('./composables/useTrajects.js', () => ({
+  useTrajects: () => ({
+    activeTrajectRef,
+    activeTraject: ref({ name: 'Traject A' }),
+  }),
+  refreshTrajects: vi.fn(),
+}));
+
+vi.mock('./lib/apiFetch.js', () => ({
+  apiFetch: vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => [] }),
+  apiFetchJson: vi.fn().mockResolvedValue([]),
+  ApiError: class ApiError extends Error {},
+}));
+
+vi.mock('./composables/useFeatureFlags.js', () => ({
+  useFeatureFlags: () => ({ isEnabled: () => true }),
+}));
+
+vi.mock('./composables/useDocumentsManager.js', () => ({
+  useDocumentsManager: () => ({
+    documents: ref([]),
+    listLoading: ref(false),
+    listError: ref(null),
+    currentPath: ref(null),
+    currentBody: ref(''),
+    hasChanges: ref(false),
+    docLoading: ref(false),
+    docError: ref(null),
+    saving: ref(false),
+    open: vi.fn(),
+    startNew: vi.fn(),
+    close: vi.fn(),
+    uploadDocument: vi.fn(),
+    displayTitle: (p) => p,
+    dropDraft: vi.fn(),
+  }),
+}));
+
+vi.mock('./composables/useTrajectDocumentJobs.js', () => ({
+  useTrajectDocumentJobs: () => ({
+    jobs: ref([]),
+    refresh: vi.fn(),
+    startPolling: vi.fn(),
+    stopPolling: vi.fn(),
+  }),
+}));
+
+vi.mock('./composables/useDocumentUpload.js', () => ({
+  useDocumentUpload: () => ({
+    fileInput: ref(null),
+    uploadError: ref(null),
+    uploadRetryable: ref(false),
+    onUpload: vi.fn(),
+    onFileChange: vi.fn(),
+  }),
+}));
+
+vi.mock('./composables/useDocumentTaskReview.js', () => ({
+  useDocumentTaskReview: () => ({
+    reviewTask: ref(null),
+    proposedContent: ref(null),
+    loadError: ref(null),
+    loadReview: vi.fn(),
+    approveAfterSave: vi.fn(),
+    reject: vi.fn(),
+  }),
+}));
+
+import LibraryView from './LibraryView.vue';
+
+const KEY = 'regelrecht-recent-laws';
+const mountLibrary = () => shallowMount(LibraryView, { global: { stubs: { teleport: true } } });
+const stored = (trajectRef) => JSON.parse(localStorage.getItem(`${KEY}:${trajectRef}`) || '[]');
+
+beforeEach(() => {
+  localStorage.clear();
+  activeTrajectRef.value = 'traject-aaaa1111';
+  routeState.params = { trajectRef: 'traject-aaaa1111', docPath: '' };
+});
+
+describe('LibraryView recent bekeken', () => {
+  it('bewaart een bekeken wet onder de sleutel van het actieve traject', async () => {
+    const wrapper = mountLibrary();
+    wrapper.vm.recordRecentLaw('wet_a', 'Wet A');
+    await wrapper.vm.$nextTick();
+    expect(stored('traject-aaaa1111').map(r => r.law_id)).toEqual(['wet_a']);
+    expect(localStorage.getItem(KEY)).toBeNull();
+  });
+
+  it('toont de lijst van het andere traject na een wissel, niet die van het eerste', async () => {
+    localStorage.setItem(`${KEY}:traject-bbbb2222`, JSON.stringify([{ law_id: 'wet_b', name: 'Wet B' }]));
+    const wrapper = mountLibrary();
+    wrapper.vm.recordRecentLaw('wet_a', 'Wet A');
+    await wrapper.vm.$nextTick();
+
+    activeTrajectRef.value = 'traject-bbbb2222';
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.recentLaws.map(r => r.law_id)).toEqual(['wet_b']);
+    // En het eerste traject houdt zijn eigen lijst.
+    expect(stored('traject-aaaa1111').map(r => r.law_id)).toEqual(['wet_a']);
+  });
+
+  it('houdt de globale corpus apart van een traject', async () => {
+    const wrapper = mountLibrary();
+    wrapper.vm.recordRecentLaw('wet_a', 'Wet A');
+    await wrapper.vm.$nextTick();
+
+    activeTrajectRef.value = null;
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.recentLaws).toEqual([]);
+
+    wrapper.vm.recordRecentLaw('wet_c', 'Wet C');
+    await wrapper.vm.$nextTick();
+    expect(stored('corpus').map(r => r.law_id)).toEqual(['wet_c']);
+    expect(stored('traject-aaaa1111').map(r => r.law_id)).toEqual(['wet_a']);
+  });
+
+  it('wist bij "wis recent" alleen het actieve traject', async () => {
+    localStorage.setItem(`${KEY}:traject-bbbb2222`, JSON.stringify([{ law_id: 'wet_b', name: 'Wet B' }]));
+    const wrapper = mountLibrary();
+    wrapper.vm.recordRecentLaw('wet_a', 'Wet A');
+    await wrapper.vm.$nextTick();
+
+    wrapper.vm.clearRecent();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.recentLaws).toEqual([]);
+    expect(localStorage.getItem(`${KEY}:traject-aaaa1111`)).toBeNull();
+    expect(stored('traject-bbbb2222').map(r => r.law_id)).toEqual(['wet_b']);
+  });
+
+  // De wet blijft bij een wissel gewoon openstaan, en de naam wordt opnieuw
+  // opgelost, dus de watch die de lijst bijhoudt vuurt nog een keer. Dat is een
+  // wissel en geen bezoek.
+  it('schrijft de openstaande wet niet in de lijst van het traject waar je heen wisselt', async () => {
+    const wrapper = mountLibrary();
+    wrapper.vm.laws = [{ law_id: 'wet_a', name: 'Wet A in traject' }];
+    wrapper.vm.selectedLawId = 'wet_a';
+    await wrapper.vm.$nextTick();
+    expect(stored('traject-aaaa1111').map(r => r.law_id)).toEqual(['wet_a']);
+
+    // Wat de wissel in het echt doet: de corpus laadt opnieuw, dus de naam van
+    // de nog openstaande wet lost opnieuw op en de watch vuurt.
+    activeTrajectRef.value = null;
+    wrapper.vm.laws = [{ law_id: 'wet_a', name: 'Wet A in de corpus' }];
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+
+    expect(stored('corpus')).toEqual([]);
+    expect(wrapper.vm.recentLaws).toEqual([]);
+  });
+
+  it('gooit de oude ongescopete lijst weg', async () => {
+    localStorage.setItem(KEY, JSON.stringify([{ law_id: 'wet_oud', name: 'Oud' }]));
+    const wrapper = mountLibrary();
+    await wrapper.vm.$nextTick();
+    expect(localStorage.getItem(KEY)).toBeNull();
+    expect(wrapper.vm.recentLaws).toEqual([]);
+  });
+});

--- a/frontend/src/LibraryView.vue
+++ b/frontend/src/LibraryView.vue
@@ -112,13 +112,23 @@ const isEnriching = computed(() =>
 );
 // Alleen pollen zolang je naar de bezig-staat kijkt; zie usePollWhile.
 
-// Staat er al een beoordeelbaar voorstel klaar voor deze wet?
-const pendingReviewTask = computed(() =>
-  openTasks.value.find(
+// Staat er al een beoordeelbaar voorstel klaar voor deze wet? Een verrijking
+// levert een taak per gewijzigd artikel, dus die van het geopende artikel gaat
+// voor; anders de eerste van de wet.
+const pendingReviewTask = computed(() => {
+  const forLaw = openTasks.value.filter(
     (t) => t.task_type === 'job_review' && t.payload?.law_id === selectedLawId.value,
-  ) ?? null,
-);
+  );
+  if (!forLaw.length) return null;
+  const here = String(selectedArticleNumber.value ?? '');
+  return forLaw.find((t) => String(t.payload?.article ?? '') === here) ?? forLaw[0];
+});
 const reviewReady = computed(() => !!pendingReviewTask.value);
+const reviewArticleForPane = computed(() =>
+  pendingReviewTask.value?.payload?.article == null
+    ? ''
+    : String(pendingReviewTask.value.payload.article),
+);
 function openReviewForLaw() {
   const target = reviewTarget(pendingReviewTask.value);
   if (target) router.push(target);
@@ -2540,8 +2550,8 @@ watch(activeTrajectRef, () => {
                   <nldd-spacer size="24"></nldd-spacer>
                   <KeepAlive>
                     <ArticleText v-if="detailView === 'tekst'" :article="selectedArticle" centered />
-                    <MachineReadable v-else-if="detailView === 'machine'" :article="selectedArticle" :can-create="!!selectedLawId" :can-enrich="canEnrich" :enriching="isEnriching" :review-ready="reviewReady" :enrich-error="enrichError" :create-href="authenticated ? editLawHref : undefined" @create-mr="openEditor" @enrich="enrichSelectedLaw" @view-tasks="openTasksForLaw" @review="openReviewForLaw" @open-action="activeAction = $event" />
-                    <YamlView v-else-if="detailView === 'yaml'" :article="selectedArticle" :can-create="!!selectedLawId" :can-enrich="canEnrich" :enriching="isEnriching" :review-ready="reviewReady" :enrich-error="enrichError" :create-href="authenticated ? editLawHref : undefined" @create-mr="openEditor" @enrich="enrichSelectedLaw" @view-tasks="openTasksForLaw" @review="openReviewForLaw" />
+                    <MachineReadable v-else-if="detailView === 'machine'" :article="selectedArticle" :can-create="!!selectedLawId" :can-enrich="canEnrich" :enriching="isEnriching" :review-ready="reviewReady" :review-article="reviewArticleForPane" :enrich-error="enrichError" :create-href="authenticated ? editLawHref : undefined" @create-mr="openEditor" @enrich="enrichSelectedLaw" @view-tasks="openTasksForLaw" @review="openReviewForLaw" @open-action="activeAction = $event" />
+                    <YamlView v-else-if="detailView === 'yaml'" :article="selectedArticle" :can-create="!!selectedLawId" :can-enrich="canEnrich" :enriching="isEnriching" :review-ready="reviewReady" :review-article="reviewArticleForPane" :enrich-error="enrichError" :create-href="authenticated ? editLawHref : undefined" @create-mr="openEditor" @enrich="enrichSelectedLaw" @view-tasks="openTasksForLaw" @review="openReviewForLaw" />
                   </KeepAlive>
                 </nldd-simple-section>
               </template>

--- a/frontend/src/LibraryView.vue
+++ b/frontend/src/LibraryView.vue
@@ -910,23 +910,39 @@ const selectedArticleNumber = ref(null);
 // Recently-viewed laws (most-recent-first), persisted across sessions. Stored
 // as { law_id, name } so a law that fails to load in the active traject - and
 // therefore never enters the corpus index - still stays reachable + labelled.
+//
+// One list per traject, plus one for the global corpus. Two trajects hold
+// different laws, so a law you opened in the one has no business turning up
+// under "Recent bekeken" in the other - it would point at something that
+// corpus may not even have.
 const RECENT_LAWS_KEY = 'regelrecht-recent-laws';
 const MAX_RECENT_LAWS = 12;
-function loadRecentLaws() {
+function recentLawsKey(trajectRef) {
+  return `${RECENT_LAWS_KEY}:${trajectRef || 'corpus'}`;
+}
+function loadRecentLaws(trajectRef) {
   try {
-    const raw = JSON.parse(localStorage.getItem(RECENT_LAWS_KEY) || '[]');
+    const raw = JSON.parse(localStorage.getItem(recentLawsKey(trajectRef)) || '[]');
     return Array.isArray(raw) ? raw.filter(r => r && r.law_id) : [];
   } catch {
     return [];
   }
 }
-const recentLaws = ref(loadRecentLaws());
+// The list from before this was scoped mixed every traject together, so there
+// is nothing to migrate it into. Drop it instead of leaving it behind forever.
+try { localStorage.removeItem(RECENT_LAWS_KEY); } catch { /* ignore */ }
+const recentLaws = ref(loadRecentLaws(activeTrajectRef.value));
+// Switching traject keeps this view mounted (same route, other param), so the
+// list has to follow the switch itself; there is no remount to reload it.
+watch(activeTrajectRef, (trajectRef) => {
+  recentLaws.value = loadRecentLaws(trajectRef);
+});
 function recordRecentLaw(lawId, name) {
   if (!lawId) return;
   const entry = { law_id: lawId, name: name || humanizeLawId(lawId) };
   recentLaws.value = [entry, ...recentLaws.value.filter(r => r.law_id !== lawId)].slice(0, MAX_RECENT_LAWS);
   try {
-    localStorage.setItem(RECENT_LAWS_KEY, JSON.stringify(recentLaws.value));
+    localStorage.setItem(recentLawsKey(activeTrajectRef.value), JSON.stringify(recentLaws.value));
   } catch { /* storage unavailable - keep the in-memory list */ }
 }
 // Detail view (tekst/machine/yaml) is reflected in the URL hash so the
@@ -1120,10 +1136,20 @@ const lawTitle = computed(() =>
 // so the sidebar reflects what the user is looking at even when nothing is
 // curated yet. Re-runs as the name resolves to upgrade the label from the
 // humanized id to the real name.
+//
+// Switching traject keeps the open law on screen and re-resolves its name, so
+// this watch fires again. That is a switch and not a visit: without the guard
+// below, every switch prepends the law you were already looking at to the list
+// of the corpus you just moved into, and the two lists converge again.
+let lastRecorded = { trajectRef: null, lawId: null };
 watch([selectedLawId, lawName, indexedLawName], () => {
-  if (selectedLawId.value) {
-    recordRecentLaw(selectedLawId.value, lawName.value || indexedLawName.value);
-  }
+  const lawId = selectedLawId.value;
+  if (!lawId) return;
+  const trajectRef = activeTrajectRef.value ?? null;
+  const switchedContext = lawId === lastRecorded.lawId && trajectRef !== lastRecorded.trajectRef;
+  lastRecorded = { trajectRef, lawId };
+  if (switchedContext) return;
+  recordRecentLaw(lawId, lawName.value || indexedLawName.value);
 }, { immediate: true });
 
 const selectedArticle = computed(() => {
@@ -1755,7 +1781,7 @@ function clearRecent() {
               (changedLawIds.value && changedLawIds.value.has(sel)));
   const deselect = !!sel && recentLaws.value.some(r => r.law_id === sel) && !stillShown;
   recentLaws.value = [];
-  try { localStorage.removeItem(RECENT_LAWS_KEY); } catch { /* ignore */ }
+  try { localStorage.removeItem(recentLawsKey(activeTrajectRef.value)); } catch { /* ignore */ }
   if (deselect) {
     // Clear the open law up front so the article sidebar + main reflow to the
     // empty state now. `selectedLawId` is a manual ref, not route-derived; a

--- a/frontend/src/LibraryView.vue
+++ b/frontend/src/LibraryView.vue
@@ -273,6 +273,10 @@ const {
   onFileChange: onDocFileChange,
 } = useDocumentUpload(docsMgr.uploadDocument, (result) => {
   docJobs.refresh();
+  // De conversie is ook een wacht-taak. Zonder deze refresh wacht de takenlijst
+  // op zijn eigen 30s-poll en staat de taak die je zojuist in gang zette er nog
+  // niet in als je er meteen naartoe navigeert.
+  refreshTasks();
   if (!result?.targetPath) return;
   // Vanuit de takenlijst ("Probeer opnieuw") staan we niet in werkdoc-modus, en
   // `showUploadedJob` zet alleen state die dáár rendert - de gebruiker zou dan
@@ -354,6 +358,7 @@ const {
   onFileChange: onLawFileChange,
 } = useDocumentUpload(uploadLawDocument, () => {
   lawUploadStarted.value = true;
+  refreshTasks();
 });
 // Zelfde modal-behandeling als de werkdocument-upload, met een eigen modal
 // zodat de retry-actie de juiste picker heropent.

--- a/frontend/src/LibraryView.vue
+++ b/frontend/src/LibraryView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, shallowRef, nextTick, watch, watchEffect, onBeforeUnmount, inject } from 'vue';
+import { ref, computed, shallowRef, nextTick, watch, watchEffect, onMounted, onBeforeUnmount, inject } from 'vue';
 import { useRoute, useRouter, onBeforeRouteUpdate, onBeforeRouteLeave } from 'vue-router';
 import * as yaml from 'js-yaml';
 import ArticleText from './components/ArticleText.vue';
@@ -21,7 +21,8 @@ import { useCorpusLaws } from './composables/useCorpusLaws.js';
 // useTaskActions, niet useTasks: LibraryView heeft alleen de refresh nodig na
 // een geannuleerde job en mag daarvoor niet de 30s-poll aanzetten (die hoort
 // bij de taken-componenten, en anonieme bezoekers pollen nooit).
-import { useTaskActions } from './composables/useTasks.js';
+import { useTaskActions, usePollWhile } from './composables/useTasks.js';
+import { reviewTarget } from './lib/taskReview.js';
 import { lawFetchInit } from './composables/useLaw.js';
 import { useTrajects, refreshTrajects } from './composables/useTrajects.js';
 import { lawsListUrl, lawUrl, lawUploadUrl, changedLawsUrl } from './composables/corpusUrls.js';
@@ -100,7 +101,81 @@ function goToAccountRequest() {
 // so it can reserve converting target names against create/rename collisions.
 const docJobs = useTrajectDocumentJobs(activeTrajectRef);
 const { jobs: conversionJobs, cancelJob: cancelConversionJob } = docJobs;
-const { refresh: refreshTasks } = useTaskActions();
+const { refresh: refreshTasks, requestEnrich, running: runningJobs, tasks: openTasks } = useTaskActions();
+
+// Loopt er al een verrijking voor deze wet? Dan toont de lege pane dat in
+// plaats van de knoppen; een tweede aanvraag zou toch op een 409 stuiten.
+const isEnriching = computed(() =>
+  runningJobs.value.some(
+    (job) => job.job_type === 'enrich' && job.law_id === selectedLawId.value,
+  ),
+);
+// Alleen pollen zolang je naar de bezig-staat kijkt; zie usePollWhile.
+usePollWhile(isEnriching);
+
+// Staat er al een beoordeelbaar voorstel klaar voor deze wet?
+const pendingReviewTask = computed(() =>
+  openTasks.value.find(
+    (t) => t.task_type === 'job_review' && t.payload?.law_id === selectedLawId.value,
+  ) ?? null,
+);
+const reviewReady = computed(() => !!pendingReviewTask.value);
+function openReviewForLaw() {
+  const target = reviewTarget(pendingReviewTask.value);
+  if (target) router.push(target);
+}
+
+// Verrijken kan ook vanuit de corpusweergave, met dezelfde twee knoppen als in
+// een traject. De knop staat er dus altijd zodra er een wet is; ontbreekt de
+// login of het traject, dan routeert hij net als "Bewerken" ernaast in plaats
+// van te verdwijnen. Zonder traject is er namelijk niets om het voorstel ín te
+// landen: het endpoint hangt onder /api/trajects/{ref}/.
+const canEnrich = computed(() => !!selectedLawId.value);
+
+const enrichError = ref('');
+
+// `running` wordt alleen door een refresh gevuld; deze view pollt niet. Eén keer
+// bij mount is genoeg om na een herlaad te weten of er al iets loopt.
+onMounted(() => {
+  if (authenticated.value) refreshTasks();
+});
+// Naar de takenlijst, gefilterd op deze wet: dezelfde context waar de lopende
+// aanvraag als rij met activity-indicator staat.
+function openTasksForLaw() {
+  if (!activeTrajectRef.value || !selectedLawId.value) return;
+  router.push({
+    name: 'taken-traject',
+    params: {
+      trajectRef: activeTrajectRef.value,
+      categorie: 'wet',
+      contextLawId: selectedLawId.value,
+    },
+  });
+}
+
+async function enrichSelectedLaw(anchorEl) {
+  if (!selectedLawId.value) return;
+  if (!authenticated.value || !activeTrajectRef.value) {
+    // openEditor regelt beide: login-popover op deze knop, of de editor-route
+    // die de trajectkiezer toont.
+    openEditor(anchorEl);
+    return;
+  }
+  enrichError.value = '';
+  try {
+    const { alreadyRunning, tooMany } = await requestEnrich(
+      activeTrajectRef.value,
+      selectedLawId.value,
+    );
+    if (tooMany) enrichError.value = 'Je hebt te veel verrijkingen tegelijk lopen.';
+    // alreadyRunning heeft geen melding nodig: de refresh hieronder zet de pane
+    // in de bezig-staat, en dat is precies wat er aan de hand is.
+    else if (!alreadyRunning) enrichError.value = '';
+    await refreshTasks();
+  } catch {
+    enrichError.value = 'Verrijking aanvragen mislukt.';
+  }
+}
 
 const docsMgr = useDocumentsManager(
   activeTrajectRef,
@@ -1728,14 +1803,34 @@ onBeforeRouteLeave(async (to) => {
 // (traject-home / corpus home) via the back button or a tab switch - a
 // different route record - leaves the ref set and the article list lingers
 // until refresh. Sync it reactively so the view reflows on any such navigation.
+// Symmetrisch: een wet die uit de route verdwijnt ruimt op, een wet die erin
+// verschijnt wordt geopend. Dat tweede stond alleen in de initiële load
+// hieronder, en die draait niet opnieuw wanneer je vanuit de takenlijst hierheen
+// navigeert: `taken-traject` en `library-traject` worden door dezelfde
+// LibraryView gerenderd, dus Vue hergebruikt de instantie. Zonder deze tak bleef
+// de view op "Geen selectie" staan terwijl de URL de wet wél noemde.
+//
+// Niet via selectLaw(): die doet een router.push naar de route waar we al zijn.
 watch(() => route.params.lawId, (lawId) => {
-  if (!lawId && selectedLawId.value) {
-    selectedLawId.value = null;
-    selectedLaw.value = null;
-    selectedArticleNumber.value = null;
-    activeAction.value = null;
-    lawError.value = null;
+  if (!lawId) {
+    if (selectedLawId.value) {
+      selectedLawId.value = null;
+      selectedLaw.value = null;
+      selectedArticleNumber.value = null;
+      activeAction.value = null;
+      lawError.value = null;
+    }
+    return;
   }
+  if (lawId === selectedLawId.value && !lawError.value) return;
+  selectedSection.value = null;
+  selectedLawId.value = lawId;
+  selectedArticleNumber.value = route.params.articleNumber
+    ? String(route.params.articleNumber)
+    : null;
+  activeAction.value = null;
+  lawError.value = null;
+  loadLaw(lawId);
 });
 
 // When a harvested law becomes available, reload the corpus and select it.
@@ -2435,8 +2530,8 @@ watch(activeTrajectRef, () => {
                   <nldd-spacer size="24"></nldd-spacer>
                   <KeepAlive>
                     <ArticleText v-if="detailView === 'tekst'" :article="selectedArticle" centered />
-                    <MachineReadable v-else-if="detailView === 'machine'" :article="selectedArticle" :can-create="!!selectedLawId" :create-href="authenticated ? editLawHref : undefined" @create-mr="openEditor" @open-action="activeAction = $event" />
-                    <YamlView v-else-if="detailView === 'yaml'" :article="selectedArticle" :can-create="!!selectedLawId" :create-href="authenticated ? editLawHref : undefined" @create-mr="openEditor" />
+                    <MachineReadable v-else-if="detailView === 'machine'" :article="selectedArticle" :can-create="!!selectedLawId" :can-enrich="canEnrich" :enriching="isEnriching" :review-ready="reviewReady" :enrich-error="enrichError" :create-href="authenticated ? editLawHref : undefined" @create-mr="openEditor" @enrich="enrichSelectedLaw" @view-tasks="openTasksForLaw" @review="openReviewForLaw" @open-action="activeAction = $event" />
+                    <YamlView v-else-if="detailView === 'yaml'" :article="selectedArticle" :can-create="!!selectedLawId" :can-enrich="canEnrich" :enriching="isEnriching" :review-ready="reviewReady" :enrich-error="enrichError" :create-href="authenticated ? editLawHref : undefined" @create-mr="openEditor" @enrich="enrichSelectedLaw" @view-tasks="openTasksForLaw" @review="openReviewForLaw" />
                   </KeepAlive>
                 </nldd-simple-section>
               </template>

--- a/frontend/src/LibraryView.vue
+++ b/frontend/src/LibraryView.vue
@@ -111,7 +111,6 @@ const isEnriching = computed(() =>
   ),
 );
 // Alleen pollen zolang je naar de bezig-staat kijkt; zie usePollWhile.
-usePollWhile(isEnriching);
 
 // Staat er al een beoordeelbaar voorstel klaar voor deze wet?
 const pendingReviewTask = computed(() =>
@@ -885,6 +884,12 @@ const selectedSection = ref(null);
 const selectedLaw = shallowRef(null);
 const selectedLawLoading = ref(false);
 const lawError = ref(null);
+
+// Hier en niet bij isEnriching hierboven: watch() leest zijn bron meteen om de
+// dependency te leggen, en die computed gebruikt selectedLawId - dat staat een
+// paar regels hierboven pas. Eerder aanroepen gooit een ReferenceError in setup
+// en dan rendert de hele view niets.
+usePollWhile(isEnriching);
 const selectedArticleNumber = ref(null);
 
 // Recently-viewed laws (most-recent-first), persisted across sessions. Stored

--- a/frontend/src/components/MachineEmptyState.vue
+++ b/frontend/src/components/MachineEmptyState.vue
@@ -16,6 +16,10 @@ import { inject } from 'vue';
 const props = defineProps({
   /** Er staat een openstaande review-taak klaar voor deze wet. */
   reviewReady: { type: Boolean, default: false },
+  /** Het artikel waar die taak over gaat. Leeg bij een voorstel voor de hele
+   *  wet. Staat in de tekst omdat de knop naar dat artikel navigeert, en dat
+   *  hoeft niet het artikel te zijn dat je nu open hebt. */
+  reviewArticle: { type: String, default: '' },
   /** Er loopt een verrijking voor deze wet (pending of processing). */
   enriching: { type: Boolean, default: false },
   /** Verrijken is hier aan te vragen (of routeert naar login/traject). */
@@ -51,7 +55,9 @@ const onLoginTriggerPointerdown = inject('onLoginTriggerPointerdown', () => {});
     data-testid="review-ready"
     icon="ai"
     text="Er ligt een voorstel klaar"
-    supporting-text="Beoordeel de wijzigingen en sla ze op, of verwerp ze."
+    :supporting-text="reviewArticle
+      ? `Beoordeel het voorstel voor artikel ${reviewArticle} en sla het op, of verwerp het.`
+      : 'Beoordeel de wijzigingen en sla ze op, of verwerp ze.'"
   >
     <nldd-button
       slot="actions"

--- a/frontend/src/components/MachineEmptyState.vue
+++ b/frontend/src/components/MachineEmptyState.vue
@@ -1,0 +1,124 @@
+<script setup>
+import { inject } from 'vue';
+
+// De lege staat van de Machine- en YAML-panes, op één plek.
+//
+// Die twee panes tonen dezelfde gegevens (machine_readable, de een als
+// formulier en de ander als YAML) en stonden daarom met dezelfde tekst en
+// knoppen op drie plekken: MachineReadable, YamlView en de inline YAML-pane in
+// EditorView. Ze liepen uit elkaar zodra er iets bijkwam. Eén component houdt
+// ze gelijk.
+//
+// Drie toestanden, in volgorde van "wat vraagt nu je aandacht":
+//   1. reviewReady - er ligt een voorstel klaar om te beoordelen
+//   2. enriching   - er loopt een verrijking
+//   3. leeg        - niets, dus bied de twee manieren aan om te beginnen
+const props = defineProps({
+  /** Er staat een openstaande review-taak klaar voor deze wet. */
+  reviewReady: { type: Boolean, default: false },
+  /** Er loopt een verrijking voor deze wet (pending of processing). */
+  enriching: { type: Boolean, default: false },
+  /** Verrijken is hier aan te vragen (of routeert naar login/traject). */
+  canEnrich: { type: Boolean, default: false },
+  /** De machine-versie kan hier ter plekke worden aangemaakt (editor). */
+  canWriteHere: { type: Boolean, default: false },
+  /** Read-only context: bied een route naar de editor aan. */
+  canCreate: { type: Boolean, default: false },
+  /** Doel van die route; leeg laten zolang de gebruiker niet is ingelogd, dan
+   *  gaat de klik door de login-popover in plaats van door de href. */
+  createHref: { type: String, default: undefined },
+  /** Melding van de laatste mislukte verrijk-aanvraag. */
+  enrichError: { type: String, default: '' },
+});
+
+const emit = defineEmits([
+  'enrich',
+  /** Machine-versie hier ter plekke aanmaken. */
+  'write',
+  /** Naar de editor om hem daar aan te maken. Payload is het knopelement, zodat
+   *  de ouder de login-popover eraan kan ankeren. */
+  'create',
+  'view-tasks',
+  'review',
+]);
+
+const onLoginTriggerPointerdown = inject('onLoginTriggerPointerdown', () => {});
+</script>
+
+<template>
+  <nldd-inline-dialog
+    v-if="reviewReady"
+    data-testid="review-ready"
+    icon="ai"
+    text="Er ligt een voorstel klaar"
+    supporting-text="Beoordeel de wijzigingen en sla ze op, of verwerp ze."
+  >
+    <nldd-button
+      slot="actions"
+      variant="secondary"
+      size="md"
+      data-testid="review-btn"
+      text="Beoordeel voorstel"
+      @click="emit('review')"
+    ></nldd-button>
+  </nldd-inline-dialog>
+
+  <nldd-inline-dialog
+    v-else-if="enriching"
+    data-testid="enriching"
+    icon="ai"
+    text="We genereren een voorstel"
+    supporting-text="Er staat een wacht-taak klaar. Zodra het voorstel er is, kun je het beoordelen."
+  >
+    <nldd-button
+      slot="actions"
+      variant="secondary"
+      size="md"
+      data-testid="view-tasks-btn"
+      text="Bekijk taken"
+      @click="emit('view-tasks')"
+    ></nldd-button>
+  </nldd-inline-dialog>
+
+  <nldd-inline-dialog
+    v-else
+    data-testid="no-machine-readable"
+    text="Geen machine-leesbare gegevens voor dit artikel"
+    :variant="enrichError ? 'alert' : undefined"
+    :supporting-text="enrichError || (canEnrich ? 'Genereren verrijkt de hele wet en levert een voorstel per artikel op.' : undefined)"
+  >
+    <nldd-button
+      v-if="canEnrich"
+      slot="actions"
+      variant="secondary"
+      size="md"
+      start-icon="ai"
+      data-testid="enrich-btn"
+      text="Genereer een voorstel"
+      @click="emit('enrich', $event.currentTarget)"
+      @pointerdown.capture="onLoginTriggerPointerdown"
+    ></nldd-button>
+    <nldd-button
+      v-if="canWriteHere"
+      slot="actions"
+      variant="secondary"
+      size="md"
+      start-icon="write"
+      data-testid="init-mr-btn"
+      text="Stel handmatig op"
+      @click="emit('write')"
+    ></nldd-button>
+    <nldd-button
+      v-else-if="canCreate"
+      slot="actions"
+      variant="secondary"
+      size="md"
+      start-icon="write"
+      data-testid="create-mr-btn"
+      text="Stel handmatig op"
+      :href="createHref"
+      @click.prevent="emit('create', $event.currentTarget)"
+      @pointerdown.capture="onLoginTriggerPointerdown"
+    ></nldd-button>
+  </nldd-inline-dialog>
+</template>

--- a/frontend/src/components/MachineReadable.vue
+++ b/frontend/src/components/MachineReadable.vue
@@ -32,6 +32,7 @@ const props = defineProps({
   enrichError: { type: String, default: '' },
   /** Er staat een openstaande review-taak klaar voor deze wet. */
   reviewReady: { type: Boolean, default: false },
+  reviewArticle: { type: String, default: '' },
   /** Anchor target for that button. Leave unset when the user isn't logged
    *  in, so the click gates on the login popover instead of the href. */
   createHref: { type: String, default: undefined },
@@ -293,6 +294,7 @@ function addOutput() {
   <MachineEmptyState
     v-if="!mr"
     :review-ready="reviewReady"
+    :review-article="reviewArticle"
     :enriching="enriching"
     :can-enrich="canEnrich"
     :can-write-here="editable"

--- a/frontend/src/components/MachineReadable.vue
+++ b/frontend/src/components/MachineReadable.vue
@@ -4,6 +4,7 @@ import { humanize } from '../utils/outputFormat.js';
 import { useCorpusLaws } from '../composables/useCorpusLaws.js';
 import BreakableName from './BreakableName.vue';
 import RowActionsMenu from './RowActionsMenu.vue';
+import MachineEmptyState from './MachineEmptyState.vue';
 
 const props = defineProps({
   article: { type: Object, default: null },
@@ -20,6 +21,17 @@ const props = defineProps({
    *  machine-readable version can be created there. Ignored when `editable`,
    *  which seeds it in place instead. */
   canCreate: { type: Boolean, default: false },
+  /** Whether an enrichment can be requested here. The run covers the whole
+   *  law, not just this article, so the empty state says so. */
+  canEnrich: { type: Boolean, default: false },
+  /** An enrichment for this law is already pending or processing. The empty
+   *  state then reports that instead of offering the buttons again. */
+  enriching: { type: Boolean, default: false },
+  /** Message from the most recent failed enrich request, shown in place of
+   *  the supporting text. */
+  enrichError: { type: String, default: '' },
+  /** Er staat een openstaande review-taak klaar voor deze wet. */
+  reviewReady: { type: Boolean, default: false },
   /** Anchor target for that button. Leave unset when the user isn't logged
    *  in, so the click gates on the login popover instead of the href. */
   createHref: { type: String, default: undefined },
@@ -34,6 +46,12 @@ const emit = defineEmits([
   'open-action',
   'open-edit',
   'init-mr',
+  /** Ask for a generated proposal instead of writing one by hand. */
+  'enrich',
+  /** Open the task list filtered to this law, while a run is pending. */
+  'view-tasks',
+  /** Open review-modus voor de klaarstaande taak. */
+  'review',
   /**
    * Read-only empty state: the user wants the machine-readable version
    * created, which only the editor can do. Payload is the button element, so
@@ -269,20 +287,24 @@ function addOutput() {
 </script>
 
 <template>
-  <nldd-inline-dialog v-if="!mr" data-testid="no-machine-readable" text="Geen machine-leesbare gegevens voor dit artikel">
-    <nldd-button v-if="editable" slot="actions" variant="secondary" size="md" data-testid="init-mr-btn" @click="emit('init-mr')" text="Maak machine versie aan"></nldd-button>
-    <nldd-button
-      v-else-if="canCreate"
-      slot="actions"
-      variant="secondary"
-      size="md"
-      data-testid="create-mr-btn"
-      text="Machine versie aanmaken"
-      :href="createHref"
-      @click.prevent="emit('create-mr', $event.currentTarget)"
-      @pointerdown.capture="onLoginTriggerPointerdown"
-    ></nldd-button>
-  </nldd-inline-dialog>
+  <!-- De verrijking schrijft machine_readable en scenario's, dus dit is de
+       plek waar je erom vraagt. De supporting-text benoemt de scope: de run
+       gaat over de hele wet, terwijl deze pane één artikel toont. -->
+  <MachineEmptyState
+    v-if="!mr"
+    :review-ready="reviewReady"
+    :enriching="enriching"
+    :can-enrich="canEnrich"
+    :can-write-here="editable"
+    :can-create="canCreate"
+    :create-href="createHref"
+    :enrich-error="enrichError"
+    @enrich="emit('enrich', $event)"
+    @write="emit('init-mr')"
+    @create="emit('create-mr', $event)"
+    @view-tasks="emit('view-tasks')"
+    @review="emit('review')"
+  ></MachineEmptyState>
 
   <div v-else data-testid="machine-readable">
     <!-- Metadata: produces -->

--- a/frontend/src/components/SettingsSheet.vue
+++ b/frontend/src/components/SettingsSheet.vue
@@ -1,0 +1,280 @@
+<script setup>
+// "Instellingen" — the account settings sheet, opened from the account menu.
+//
+// Collects what used to be submenus of that menu (Weergave, Functies) plus the
+// GitHub link. The link is a connection, not an action: it belongs with the
+// other account state rather than between Help and Log uit, where its label
+// also changed identity depending on whether you were connected.
+//
+// Settings are not a form — nothing is submitted, every control applies at
+// once — so these are list rows under section titles, not fields in a
+// fieldset.
+//
+// The composables backing this are singletons, so the sheet reads them
+// directly instead of taking the whole set as props.
+import { computed, ref } from 'vue';
+import { useAuth } from '../composables/useAuth.js';
+import { useColorScheme } from '../composables/useColorScheme.js';
+import { useFeatureFlags } from '../composables/useFeatureFlags.js';
+import { useGithubAuth } from '../composables/useGithubAuth.js';
+
+const sheetEl = ref(null);
+
+function show() {
+  sheetEl.value?.show?.();
+}
+function hide() {
+  sheetEl.value?.hide?.();
+}
+
+defineExpose({ show, hide });
+
+const { authenticated, loading: authLoading, hasRole } = useAuth();
+const { colorScheme, setColorScheme } = useColorScheme();
+const { isEnabled, toggle: toggleFlag } = useFeatureFlags();
+const {
+  status: githubStatus,
+  connect: connectGithub,
+  disconnect: disconnectGithub,
+} = useGithubAuth();
+
+const colorSchemeOptions = [
+  ['auto', 'Systeem', 'display'],
+  ['light', 'Licht', 'light-mode'],
+  ['dark', 'Donker', 'dark-mode'],
+];
+
+const editorPanelFlags = [
+  ['panel.article_text', 'Tekst editor'],
+  ['panel.machine_readable', 'Machine editor'],
+  ['panel.scenario_form', 'Scenario editor'],
+  ['panel.yaml_editor', 'YAML editor'],
+  ['panel.notes', 'Notities'],
+];
+
+const signedIn = computed(() => !authLoading.value && authenticated.value);
+// Feature flags are deployment-wide and the PUT is behind `editor-admin`
+// (main.rs, "Admin routes"). Showing the switches to anyone else would give
+// them controls that silently revert on the 403.
+const isAdmin = computed(() => signedIn.value && hasRole('editor-admin'));
+// `configured: false` means this deployment has no GitHub OAuth App wired up,
+// so the whole section stays hidden.
+const githubConfigured = computed(() => signedIn.value && !!githubStatus.value?.configured);
+// Two different questions, deliberately not the same computed:
+//   `required` — does the write path actually demand a personal token? The
+//     backend folds the GITHUB_USER_TOKEN_REQUIRED env var AND the feature flag
+//     into this one field, and the env var wins. Use it wherever the UI
+//     describes behaviour.
+//   `enforced` — is the feature flag on? That is the only half an admin can
+//     change here, so the switch binds to this.
+// They differ when the deployment forces it through config; then the switch
+// would be a control that changes nothing, so it makes way for a plain line.
+const githubRequired = computed(() => !!githubStatus.value?.required);
+const githubEnforced = computed(() => isEnabled('github.user_oauth'));
+const githubForcedByConfig = computed(() => githubRequired.value && !githubEnforced.value);
+const githubConnected = computed(() => !!githubStatus.value?.connected);
+
+function onPanelFlagChange(key, event) {
+  // Follow the store rather than the switch's own DOM state.
+  if (event.detail.checked !== isEnabled(key)) toggleFlag(key);
+}
+
+// Enabling `github.user_oauth` is not a personal display preference like the
+// panel flags: the flag is deployment-wide AND doubles as the backend's
+// write-enforcement switch (`write_requires_user_token`), so turning it on
+// makes every editor-writer's next traject save require a linked personal
+// GitHub account (an unlinked user's save 428s into the connect flow).
+// Intercept the enable with an explicit confirmation. Disabling restores the
+// pre-existing service-token behaviour and stays a plain toggle.
+const enforcementConfirm = ref(null);
+const enforcementSwitch = ref(null);
+
+function onEnforcementChange(event) {
+  if (!isEnabled('github.user_oauth')) {
+    // Revert the switch: it flipped itself, and the flag only actually turns
+    // on once the confirmation is accepted.
+    event.target.checked = false;
+    if (enforcementConfirm.value) {
+      enforcementConfirm.value.anchorElement = enforcementSwitch.value || event.target;
+      enforcementConfirm.value.show();
+    }
+    return;
+  }
+  toggleFlag('github.user_oauth');
+}
+
+function confirmUserOauthEnforcement() {
+  enforcementConfirm.value?.hide();
+  toggleFlag('github.user_oauth');
+}
+
+// Release the anchor when the popover closes (confirm, cancel, or light
+// dismiss): nldd-popover toggles itself on every subsequent click on its
+// anchor element, so a stale anchor makes the switch reopen it.
+function onEnforcementConfirmClose() {
+  if (enforcementConfirm.value) enforcementConfirm.value.anchorElement = null;
+}
+
+// Disconnecting revokes the token at GitHub and, with the flag on, makes the
+// next traject save fail with a 428 — so it asks first instead of firing on
+// the click.
+const disconnectConfirm = ref(null);
+
+function confirmDisconnect() {
+  disconnectConfirm.value?.hide();
+  disconnectGithub();
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <nldd-sheet ref="sheetEl" placement="right" width="480px" full-height @close="hide">
+      <nldd-page sticky-header>
+        <nldd-top-title-bar
+          slot="header"
+          text="Instellingen"
+          dismiss-text="Sluit"
+          @dismiss="hide"
+        ></nldd-top-title-bar>
+
+        <nldd-simple-section width="full">
+          <nldd-title size="5">
+            <h2>Weergave</h2>
+          </nldd-title>
+          <nldd-spacer size="8"></nldd-spacer>
+          <nldd-segmented-control
+            variant="icon-and-text"
+            width="full"
+            accessible-label="Kleurschema"
+            :value="colorScheme"
+            @change="setColorScheme($event.detail.value)"
+          >
+            <nldd-segmented-control-item
+              v-for="[value, label, icon] in colorSchemeOptions"
+              :key="value"
+              :value="value"
+              :text="label"
+              :icon="icon"
+            ></nldd-segmented-control-item>
+          </nldd-segmented-control>
+
+          <template v-if="githubConfigured && githubRequired">
+            <nldd-spacer size="24"></nldd-spacer>
+            <nldd-title size="5">
+              <h2>Koppelingen</h2>
+            </nldd-title>
+            <nldd-spacer size="8"></nldd-spacer>
+            <nldd-list variant="box">
+              <nldd-list-item>
+                <nldd-text-cell
+                  text="GitHub"
+                  :supporting-text="githubConnected ? githubStatus.github_login : 'Niet gekoppeld'"
+                ></nldd-text-cell>
+                <nldd-cell>
+                  <nldd-button
+                    v-if="githubConnected"
+                    variant="destructive"
+                    text="Ontkoppelen"
+                    @click="disconnectConfirm?.show()"
+                  ></nldd-button>
+                  <nldd-button
+                    v-else
+                    variant="primary"
+                    text="Koppelen"
+                    end-icon="external-link"
+                    @click="connectGithub()"
+                  ></nldd-button>
+                </nldd-cell>
+              </nldd-list-item>
+            </nldd-list>
+          </template>
+
+          <template v-if="isAdmin">
+            <nldd-spacer size="24"></nldd-spacer>
+            <nldd-title size="5">
+              <h2>Beheer</h2>
+              <span slot="subtitle">Geldt voor alle gebruikers en trajecten in deze installatie.</span>
+            </nldd-title>
+            <nldd-spacer size="8"></nldd-spacer>
+            <nldd-list variant="box">
+              <nldd-list-item v-for="[key, label] in editorPanelFlags" :key="key">
+                <nldd-text-cell :text="label"></nldd-text-cell>
+                <nldd-cell>
+                  <nldd-switch
+                    :accessible-label="label"
+                    :checked="isEnabled(key) || undefined"
+                    @change="onPanelFlagChange(key, $event)"
+                  ></nldd-switch>
+                </nldd-cell>
+              </nldd-list-item>
+              <nldd-list-item v-if="githubConfigured">
+                <nldd-text-cell
+                  text="Met eigen GitHub-account schrijven"
+                  :supporting-text="githubForcedByConfig
+                    ? 'Aan, vastgezet in de configuratie van deze omgeving.'
+                    : 'Uit: RegelRecht schrijft met één gedeeld account.'"
+                ></nldd-text-cell>
+                <nldd-cell v-if="!githubForcedByConfig">
+                  <nldd-switch
+                    ref="enforcementSwitch"
+                    accessible-label="Met eigen GitHub-account schrijven"
+                    :checked="githubEnforced || undefined"
+                    @change="onEnforcementChange"
+                  ></nldd-switch>
+                </nldd-cell>
+              </nldd-list-item>
+            </nldd-list>
+          </template>
+        </nldd-simple-section>
+      </nldd-page>
+    </nldd-sheet>
+
+    <nldd-popover
+      ref="enforcementConfirm"
+      accessible-label="GitHub-koppeling inschakelen"
+      width="360px"
+      @close="onEnforcementConfirmClose"
+    >
+      <nldd-container padding="16">
+        <nldd-inline-dialog
+          icon="exclamation-triangle"
+          text="GitHub-koppeling voor iedereen inschakelen?"
+          supporting-text="Dit geldt voor de hele omgeving, niet alleen voor jou: opslaan in een traject vereist daarna voor elke gebruiker een gekoppeld GitHub-account. Wie nog niet gekoppeld heeft, wordt bij de eerstvolgende opslag naar de koppel-flow geleid."
+        >
+          <nldd-button
+            slot="actions"
+            variant="primary"
+            text="Inschakelen"
+            @click="confirmUserOauthEnforcement"
+          ></nldd-button>
+          <nldd-button
+            slot="actions"
+            text="Annuleren"
+            @click="enforcementConfirm?.hide()"
+          ></nldd-button>
+        </nldd-inline-dialog>
+      </nldd-container>
+    </nldd-popover>
+
+    <nldd-modal-dialog
+      ref="disconnectConfirm"
+      variant="alert"
+      icon="exclamation-triangle"
+      text="GitHub-account ontkoppelen?"
+      supporting-text="Het token wordt ingetrokken bij GitHub. Zolang schrijven met een eigen account vereist is, mislukt je eerstvolgende opslag in een traject tot je opnieuw koppelt."
+    >
+      <nldd-button
+        slot="actions"
+        variant="primary"
+        text="Behoud koppeling"
+        @click="disconnectConfirm?.hide()"
+      ></nldd-button>
+      <nldd-button
+        slot="actions"
+        variant="destructive"
+        text="Ontkoppel"
+        @click="confirmDisconnect"
+      ></nldd-button>
+    </nldd-modal-dialog>
+  </Teleport>
+</template>

--- a/frontend/src/components/TasksListPane.vue
+++ b/frontend/src/components/TasksListPane.vue
@@ -21,7 +21,7 @@
  * Mounten start via `useTasks()` de gedeelde 30s-poll; de route erachter vereist
  * login, dus anonieme bezoekers pollen nooit.
  */
-import { computed, nextTick, ref, toRef, watch } from 'vue';
+import { computed, nextTick, onMounted, ref, toRef, watch } from 'vue';
 import { useRouter } from 'vue-router';
 import { useTasks } from '../composables/useTasks.js';
 import { useCorpusLaws } from '../composables/useCorpusLaws.js';
@@ -54,6 +54,11 @@ const emit = defineEmits(['upload', 'cancel-job', 'view-job']);
 const router = useRouter();
 const { tasks, running, resolveTask, requestEnrich, refresh } = useTasks();
 const { displayName } = useCorpusLaws(toRef(props, 'trajectRef'));
+
+// De gedeelde lijst loopt al op zijn 30s-poll, maar die is elders gestart en zit
+// midden in een interval zodra jij hier binnenkomt. Wie een lijst opent, wil hem
+// actueel zien: het openen zelf is het moment om te verversen.
+onMounted(refresh);
 
 // Mislukt bovenaan, de rest op de servervolgorde (nieuwste eerst). Voorlopig:
 // een mislukte taak is de enige die echt vastzit, dus die hoort niet onder een

--- a/frontend/src/components/YamlView.vue
+++ b/frontend/src/components/YamlView.vue
@@ -19,6 +19,7 @@ const props = defineProps({
   enrichError: { type: String, default: '' },
   /** Er staat een openstaande review-taak klaar voor deze wet. */
   reviewReady: { type: Boolean, default: false },
+  reviewArticle: { type: String, default: '' },
   /** Anchor target for that button. Leave unset when the user isn't logged
    *  in, so the click gates on the login popover instead of the href. */
   createHref: { type: String, default: undefined },
@@ -53,6 +54,7 @@ const yamlText = computed(() => {
   <MachineEmptyState
     v-if="!yamlText"
     :review-ready="reviewReady"
+    :review-article="reviewArticle"
     :enriching="enriching"
     :can-enrich="canEnrich"
     :can-create="canCreate"

--- a/frontend/src/components/YamlView.vue
+++ b/frontend/src/components/YamlView.vue
@@ -1,12 +1,24 @@
 <script setup>
 import { computed, inject } from 'vue';
 import * as yaml from 'js-yaml';
+import MachineEmptyState from './MachineEmptyState.vue';
 
 const props = defineProps({
   article: { type: Object, default: null },
   /** Read-only context: offer a button that opens the editor so the missing
    *  machine-readable version can be created there. */
   canCreate: { type: Boolean, default: false },
+  /** Whether an enrichment can be requested here. The run covers the whole
+   *  law, not just this article, so the empty state says so. */
+  canEnrich: { type: Boolean, default: false },
+  /** An enrichment for this law is already pending or processing. The empty
+   *  state then reports that instead of offering the buttons again. */
+  enriching: { type: Boolean, default: false },
+  /** Message from the most recent failed enrich request, shown in place of
+   *  the supporting text. */
+  enrichError: { type: String, default: '' },
+  /** Er staat een openstaande review-taak klaar voor deze wet. */
+  reviewReady: { type: Boolean, default: false },
   /** Anchor target for that button. Leave unset when the user isn't logged
    *  in, so the click gates on the login popover instead of the href. */
   createHref: { type: String, default: undefined },
@@ -16,6 +28,12 @@ const emit = defineEmits([
   /** Create-button click. Payload is the button element, so the parent can
    *  anchor the login popover to it. */
   'create-mr',
+  /** Ask for a generated proposal instead of writing one by hand. */
+  'enrich',
+  /** Open the task list filtered to this law, while a run is pending. */
+  'view-tasks',
+  /** Open review-modus voor de klaarstaande taak. */
+  'review',
 ]);
 
 // Provided by AppShell; see LibraryView's "Bewerken" button.
@@ -29,18 +47,21 @@ const yamlText = computed(() => {
 </script>
 
 <template>
-  <nldd-inline-dialog v-if="!yamlText" text="Geen machine-leesbare gegevens voor dit artikel">
-    <nldd-button
-      v-if="canCreate"
-      slot="actions"
-      variant="secondary"
-      size="md"
-      data-testid="create-mr-btn"
-      text="Machine versie aanmaken"
-      :href="createHref"
-      @click.prevent="emit('create-mr', $event.currentTarget)"
-      @pointerdown.capture="onLoginTriggerPointerdown"
-    ></nldd-button>
-  </nldd-inline-dialog>
+  <!-- Zelfde ingang als in de Machine-pane: die twee staan niet altijd allebei
+       open. De supporting-text benoemt de scope, want de knop staat in een
+       weergave die over één artikel gaat. -->
+  <MachineEmptyState
+    v-if="!yamlText"
+    :review-ready="reviewReady"
+    :enriching="enriching"
+    :can-enrich="canEnrich"
+    :can-create="canCreate"
+    :create-href="createHref"
+    :enrich-error="enrichError"
+    @enrich="emit('enrich', $event)"
+    @create="emit('create-mr', $event)"
+    @view-tasks="emit('view-tasks')"
+    @review="emit('review')"
+  ></MachineEmptyState>
   <nldd-code-viewer v-else language="yaml">{{ yamlText }}</nldd-code-viewer>
 </template>

--- a/frontend/src/composables/useAppChrome.js
+++ b/frontend/src/composables/useAppChrome.js
@@ -67,8 +67,15 @@ const documentTabsTrajectRef = shallowRef(null);
 // Article-level pending-changes bar (Wijzigingenbalk). The editor publishes
 // the dirty/saving/undo state reactively and registers the action callbacks;
 // the shell renders the bar while there are unsaved changes.
-const editorChanges = shallowRef(null); // { dirty, saving, canUndo, canRedo } | null
-const editorActions = shallowRef(null); // { save, discard, undo, redo } | null
+// `review` puts the bar in proposal-review mode: it then shows even when the
+// panes are not dirty (a proposal that seeded nothing visible is still a
+// decision waiting to be made) and it carries a Verwerp action next to Opslaan.
+// `reviewStatus`/`reviewVariant` feed the status bar the shell renders above
+// `main`: it belongs to the bar-split-view, not to the editor's own content
+// flow, so it lines up with the tab bar and the changes bar instead of
+// scrolling with the panes.
+const editorChanges = shallowRef(null); // { dirty, saving, canUndo, canRedo, review, reviewStatus, reviewVariant } | null
+const editorActions = shallowRef(null); // { save, discard, undo, redo, reject } | null
 
 // --- Library-only chrome ---
 // Whether the library has nothing curated yet (no favorites, no traject edits,

--- a/frontend/src/composables/useTasks.js
+++ b/frontend/src/composables/useTasks.js
@@ -131,13 +131,14 @@ export function usePollWhile(active, intervalMs = 10000) {
     if (pollTimer) clearInterval(pollTimer);
     pollTimer = null;
   };
-  watch(
-    active,
-    (on) => {
-      stop();
-      if (on) pollTimer = setInterval(refresh, intervalMs);
-    },
-    { immediate: true },
-  );
+  // Bewust NIET immediate: dat evalueert `active` tijdens setup, en een
+  // caller die zijn computed bovenaan definieert leest dan state die verderop
+  // in het bestand pas gedeclareerd wordt (temporal dead zone). Setup gooit
+  // dan en de hele view rendert niets. Kost ook niets: `running` is bij setup
+  // nog leeg, dus er valt op dat moment nooit iets te starten.
+  watch(active, (on) => {
+    stop();
+    if (on) pollTimer = setInterval(refresh, intervalMs);
+  });
   if (getCurrentInstance()) onUnmounted(stop);
 }

--- a/frontend/src/composables/useTasks.js
+++ b/frontend/src/composables/useTasks.js
@@ -7,7 +7,7 @@
  * zijn laagfrequent; na eigen acties (enrich-aanvraag, resolve) wordt direct
  * ge-refreshed.
  */
-import { ref, computed, onUnmounted, getCurrentInstance } from 'vue';
+import { ref, computed, watch, onUnmounted, getCurrentInstance } from 'vue';
 import { apiFetch } from '@regelrecht/frontend-shared';
 
 const POLL_INTERVAL_MS = 30_000;
@@ -109,5 +109,35 @@ export function useTasks() {
 // that DO want the shared, polled task list (the taken-lijst in Home:
 // TasksSidebarItem/TasksListPane) keep using useTasks().
 export function useTaskActions() {
-  return { fetchTask, resolveTask, requestEnrich, refresh };
+  // `running` is een module-level ref, gedeeld met useTasks(). Meegeven kost
+  // niets en start geen poll: een view die alleen wil weten of er iets loopt,
+  // leest hem en ververst zelf na een actie of bij mount.
+  return { fetchTask, resolveTask, requestEnrich, refresh, running, tasks };
+}
+
+/**
+ * Ververs de takenlijst zolang `active` waar is, en stop zodra hij omslaat of
+ * de component verdwijnt.
+ *
+ * Voor de bezig-staat van een verrijking: die kan minuten duren, dus een
+ * permanente poll is verspilling, maar wie er op dat moment naar kijkt wil het
+ * zien omslaan zonder zelf te verversen. De kosten hangen zo aan kijktijd in
+ * plaats van aan looptijd. Bewust korter dan de 30s van useTasks: dit is een
+ * gerichte poll die je zelf in gang hebt gezet.
+ */
+export function usePollWhile(active, intervalMs = 10000) {
+  let pollTimer = null;
+  const stop = () => {
+    if (pollTimer) clearInterval(pollTimer);
+    pollTimer = null;
+  };
+  watch(
+    active,
+    (on) => {
+      stop();
+      if (on) pollTimer = setInterval(refresh, intervalMs);
+    },
+    { immediate: true },
+  );
+  if (getCurrentInstance()) onUnmounted(stop);
 }

--- a/frontend/src/lib/taskReview.js
+++ b/frontend/src/lib/taskReview.js
@@ -32,9 +32,13 @@ export function reviewTarget(task) {
   }
   const lawId = task?.payload?.law_id;
   if (!lawId) return null;
+  // Wijst de taak een artikel aan, neem het dan meteen in de route op. De
+  // editor zou er zelf ook naartoe springen zodra het voorstel is geladen,
+  // maar dan zie je eerst het verkeerde artikel voorbijkomen.
+  const article = task?.payload?.article;
   return {
     name: 'editor-traject',
-    params: { trajectRef, lawId },
+    params: article == null ? { trajectRef, lawId } : { trajectRef, lawId, articleNumber: String(article) },
     query: { task: task.id },
   };
 }
@@ -63,10 +67,27 @@ function articleDiffers(current, proposedArticle) {
  *    verwijdering) - Opslaan committeert die verwijdering net zo goed als
  *    de rest van het voorstel, dus de banner moet ernaar verwijzen ook al
  *    is er geen "proposed article" om te seeden of te tonen.
+ *
+ * @param {string|null} [articleNumber] Wijst de taak één artikel aan
+ *   (`payload.article`), dan gaat het hier alléén daarover: dat artikel wordt
+ *   het target en `hiddenChanges` blijft onwaar. Wat de verrijking elders in
+ *   de wet voorstelt, hangt aan de taak van dát artikel en is hier geen
+ *   verborgen wijziging maar simpelweg andermans werk.
  */
-export function proposalDivergence(currentArticles, proposedArticles) {
+export function proposalDivergence(currentArticles, proposedArticles, articleNumber = null) {
   const current = Array.isArray(currentArticles) ? currentArticles : [];
   const proposed = Array.isArray(proposedArticles) ? proposedArticles : [];
+
+  if (articleNumber != null) {
+    const wanted = String(articleNumber);
+    const pa = proposed.find((a) => String(a.number) === wanted);
+    const match = current.find((a) => String(a.number) === wanted);
+    // Zonder tegenhanger in de opgeslagen wet valt er niets te seeden: de
+    // editor kan een artikel dat de wet niet heeft niet als losse wijziging
+    // tonen. Dan geen target, en de banner meldt dat.
+    const target = pa && match && articleDiffers(match, pa) ? pa : null;
+    return { target, hiddenChanges: false };
+  }
 
   let target = null;
   let hiddenChanges = false;

--- a/frontend/src/lib/taskReview.test.js
+++ b/frontend/src/lib/taskReview.test.js
@@ -20,6 +20,23 @@ describe('reviewTarget', () => {
     );
   });
 
+  it('neemt het artikel uit de payload op in de editor-route', () => {
+    const task = {
+      id: 't1a',
+      task_type: 'job_review',
+      payload: {
+        traject_ref: 'mijn-traject-1a2b3c4d',
+        law_id: 'wet_op_de_zorgtoeslag',
+        article: '2',
+      },
+    };
+    const resolved = router.resolve(reviewTarget(task));
+    expect(resolved.params.articleNumber).toBe('2');
+    expect(resolved.fullPath).toBe(
+      '/trajecten/mijn-traject-1a2b3c4d/editor/wet_op_de_zorgtoeslag/2?task=t1a',
+    );
+  });
+
   it('geeft null voor een taak zonder traject_ref in de payload', () => {
     expect(reviewTarget({ id: 't2', payload: { law_id: 'wet_op_de_zorgtoeslag' } })).toBeNull();
   });
@@ -148,5 +165,49 @@ describe('proposalDivergence', () => {
       hiddenChanges: false,
     });
     expect(proposalDivergence([], [])).toEqual({ target: null, hiddenChanges: false });
+  });
+
+  it('pakt het aangewezen artikel, ook als een eerder artikel ook afwijkt', () => {
+    const current = [
+      { number: '1', text: 'oud-1' },
+      { number: '2', text: 'oud-2' },
+    ];
+    const proposed = [
+      { number: '1', text: 'nieuw-1' },
+      { number: '2', text: 'nieuw-2' },
+    ];
+    const result = proposalDivergence(current, proposed, '2');
+    expect(result.target).toEqual(proposed[1]);
+    // Artikel 1 hangt aan zijn eigen taak, dus het is hier geen verborgen
+    // wijziging waar de banner naar hoeft te verwijzen.
+    expect(result.hiddenChanges).toBe(false);
+  });
+
+  it('geeft geen target als het aangewezen artikel niet afwijkt', () => {
+    const current = [{ number: '1', text: 'zelfde' }];
+    const proposed = [{ number: '1', text: 'zelfde' }];
+    expect(proposalDivergence(current, proposed, '1')).toEqual({
+      target: null,
+      hiddenChanges: false,
+    });
+  });
+
+  it('geeft geen target als het aangewezen artikel in de wet of het voorstel ontbreekt', () => {
+    const current = [{ number: '1', text: 'oud' }];
+    const proposed = [{ number: '1', text: 'nieuw' }];
+    expect(proposalDivergence(current, proposed, '9')).toEqual({
+      target: null,
+      hiddenChanges: false,
+    });
+    expect(proposalDivergence([], proposed, '1')).toEqual({
+      target: null,
+      hiddenChanges: false,
+    });
+  });
+
+  it('vergelijkt het nummer als tekst, zodat een numeriek payload-artikel raak is', () => {
+    const current = [{ number: '2', text: 'oud' }];
+    const proposed = [{ number: 2, text: 'nieuw' }];
+    expect(proposalDivergence(current, proposed, 2).target).toEqual(proposed[0]);
   });
 });

--- a/frontend/src/lib/taskTitle.js
+++ b/frontend/src/lib/taskTitle.js
@@ -34,7 +34,15 @@ export function taskTitle(task, lawName = (id) => id) {
 
   if (context === WET) {
     const naam = lawName(task.payload.law_id);
-    return failed ? `Verrijking van ${naam} is mislukt` : `Beoordeel verrijking van ${naam}`;
+    // Een mislukking geldt de hele verrijking, dus die noemt nooit een artikel.
+    if (failed) return `Verrijking van ${naam} is mislukt`;
+    // De worker maakt één taak per gewijzigd artikel en zet het nummer in de
+    // payload. Zonder nummer gaat de taak over de hele wet: een nieuwe wet uit
+    // documentconversie, of een voorstel dat de worker niet kon opsplitsen.
+    const artikel = task.payload.article;
+    return artikel
+      ? `Beoordeel artikel ${artikel} van ${naam}`
+      : `Beoordeel verrijking van ${naam}`;
   }
   if (context === WERKDOCUMENTEN) {
     const naam = fileName(task.payload.target_path);

--- a/frontend/src/lib/taskTitle.test.js
+++ b/frontend/src/lib/taskTitle.test.js
@@ -14,6 +14,23 @@ describe('taskTitle', () => {
     expect(taskTitle(task, lawName)).toBe('Beoordeel verrijking van Wet op de zorgtoeslag');
   });
 
+  it('noemt het artikel als de taak er een aanwijst', () => {
+    const task = {
+      task_type: 'job_review',
+      title: 'Verrijking beoordelen: wet_op_de_zorgtoeslag artikel 2',
+      payload: { law_id: 'wet_op_de_zorgtoeslag', traject_ref: 't-1', article: '2' },
+    };
+    expect(taskTitle(task, lawName)).toBe('Beoordeel artikel 2 van Wet op de zorgtoeslag');
+  });
+
+  it('noemt geen artikel bij een mislukte verrijking - die geldt de hele wet', () => {
+    const task = {
+      task_type: 'job_failed',
+      payload: { law_id: 'wet_op_de_zorgtoeslag', traject_ref: 't-1', article: '2' },
+    };
+    expect(taskTitle(task, lawName)).toBe('Verrijking van Wet op de zorgtoeslag is mislukt');
+  });
+
   it('schrijft een document-review in de gebiedende wijs', () => {
     const task = {
       task_type: 'job_review',

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       "dependencies": {
         "@cucumber/gherkin": "^42.0.0",
         "@cucumber/messages": "^34.2.0",
-        "@nldd/design-system": "^0.8.77",
+        "@nldd/design-system": "^0.8.78",
         "@regelrecht/frontend-shared": "*",
         "@vue-flow/background": "^1.3.2",
         "@vue-flow/controls": "^1.1.3",
@@ -47,7 +47,7 @@
       "name": "regelrecht-frontend-lawmaking",
       "version": "1.0.0",
       "dependencies": {
-        "@nldd/design-system": "^0.8.77",
+        "@nldd/design-system": "^0.8.78",
         "@regelrecht/frontend-shared": "*",
         "vue": "^3.5.38"
       },
@@ -947,9 +947,9 @@
       }
     },
     "node_modules/@nldd/design-system": {
-      "version": "0.8.77",
-      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.77.tgz",
-      "integrity": "sha512-s8g6BVzIpeK3wBgA5/rjQ6tZ6U4u9d/8STXBlXabUd4si6oddc9WFIAJLvGegnZrjQN7QQ8qJJhmDqV3K0WZJA==",
+      "version": "0.8.78",
+      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.78.tgz",
+      "integrity": "sha512-qRR2/SUbqM2NIYLVWOlDRiRMf8YDAw0Dl7lLiSfZK9au2TBQkOsUhX+JxNev0XkYTx/9jro9M9cGVgWAbB7d3w==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.3",

--- a/packages/editor-api/src/tasks_api.rs
+++ b/packages/editor-api/src/tasks_api.rs
@@ -141,9 +141,14 @@ pub async fn resolve(
         .map_err(db_error)?
         .ok_or(StatusCode::NOT_FOUND)?;
     if let Some(job_id) = task.job_id {
+        // Alleen als deze taak de laatste open taak van de job was: een
+        // verrijking levert er één per gewijzigd artikel, allemaal op dezelfde
+        // resultaat-blobs, en die moeten blijven staan zolang iemand nog een
+        // voorstel te beoordelen heeft.
+        //
         // Best-effort: een cleanup-fout mag de afhandeling niet terugdraaien;
         // de 7-dagen-GC vangt het restje.
-        if let Err(e) = tasks::delete_blobs_for_job(pool, job_id).await {
+        if let Err(e) = tasks::delete_blobs_for_finished_job(pool, job_id).await {
             tracing::warn!(error = %e, task_id = %task.id, "blob-cleanup na resolve mislukt");
         }
     }

--- a/packages/pipeline/src/tasks.rs
+++ b/packages/pipeline/src/tasks.rs
@@ -411,6 +411,38 @@ where
     Ok(())
 }
 
+/// Ruim de blobs van een job op, maar alleen als er geen open taak meer aan
+/// hangt. Levert het aantal verwijderde rijen.
+///
+/// Een verrijking levert één review-taak per gewijzigd artikel, allemaal op
+/// dezelfde job en dus op dezelfde resultaat-blobs. Wie de eerste taak
+/// afhandelt is daarmee nog niet klaar met de job: onvoorwaardelijk wissen
+/// zou de andere beoordelaars hun voorstel onder de voeten weghalen.
+///
+/// De check zit in het statement zelf, niet in een aparte telling ervoor:
+/// twee gebruikers die tegelijk hun laatste taak afronden zouden anders
+/// allebei kunnen concluderen dat de ander nog openstaat, en dan blijven de
+/// blobs tot de GC liggen.
+pub async fn delete_blobs_for_finished_job<'e, E>(executor: E, job_id: Uuid) -> Result<u64>
+where
+    E: sqlx::PgExecutor<'e>,
+{
+    let result = sqlx::query(
+        r#"
+        DELETE FROM job_blobs jb
+        WHERE jb.job_id = $1
+          AND NOT EXISTS (
+              SELECT 1 FROM tasks t
+              WHERE t.job_id = jb.job_id AND t.status = 'open'
+          )
+        "#,
+    )
+    .bind(job_id)
+    .execute(executor)
+    .await?;
+    Ok(result.rows_affected())
+}
+
 /// GC: verwijder blobs ouder dan 7 dagen waarvan de job geen open taak meer
 /// heeft (patroon `cleanup_orphaned_uploads`). De grace is ruim: een open
 /// taak houdt zijn blobs onbeperkt vast — dit vangt alleen wezen af van

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -1853,6 +1853,38 @@ pub async fn materialize_task_workdir(
     Ok(dir)
 }
 
+/// Reden waarmee een geslaagde run die niets beoordeelbaars opleverde alsnog
+/// als mislukking bij de aanvrager landt. Zonder deze stap zou de review-taak
+/// gewoon worden aangemaakt en zou de gebruiker een taak openen die per
+/// definitie niet af te maken is.
+pub(crate) const NO_REVIEWABLE_LAW: &str =
+    "de verrijking leverde geen wet-YAML op om te beoordelen";
+
+/// Whether an enrich run wrote something the review UI can actually open.
+///
+/// Mirrors how `useTaskReview` picks the law out of the result blobs: the
+/// exact `yaml_path` from the payload, else a file whose basename is neither
+/// dot-prefixed nor a sidecar. The worker stages `features/*.feature` files
+/// alongside the law, and those are not a proposal on their own — a run that
+/// produced only those has nothing to review.
+///
+/// Pure so the contract can be pinned without a live database or workdir.
+pub(crate) fn produced_reviewable_law(
+    workdir: &Path,
+    written_files: &[std::path::PathBuf],
+    yaml_path: &str,
+) -> bool {
+    written_files.iter().any(|abs| {
+        let rel = abs.strip_prefix(workdir).unwrap_or(abs);
+        if rel.to_string_lossy() == yaml_path {
+            return true;
+        }
+        rel.file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| !name.starts_with('.') && name.ends_with(".yaml"))
+    })
+}
+
 /// Taak-flow succes: schrijf de door de enrichment aangeraakte bestanden als
 /// result-blobs, verwijder de input-blobs, complete de job en maak de
 /// review-taak aan — alles in één transactie.
@@ -2146,6 +2178,21 @@ async fn process_enrich_task_job(
             }
         }
         Ok(Ok((result, written_files))) => {
+            // De run meldde succes, maar zonder wet-YAML valt er niets te
+            // beoordelen. Een review-taak aanmaken zou de aanvrager een
+            // onmogelijke taak geven; met retry-semantiek krijgt hij in plaats
+            // daarvan een nieuwe poging, en pas na de laatste een
+            // `job_failed`-taak met deze reden erin.
+            if !produced_reviewable_law(workdir.path(), &written_files, &payload.yaml_path) {
+                tracing::warn!(
+                    job_id = %job.id,
+                    law_id = %job.law_id,
+                    files = written_files.len(),
+                    "enrich-run zonder beoordeelbare wet-YAML"
+                );
+                fail_enrich_task_job_with_retry(pool, job, NO_REVIEWABLE_LAW).await?;
+                return Ok(JobOutcome::Processed);
+            }
             let result_json = match serde_json::to_value(&result) {
                 Ok(v) => Some(v),
                 Err(e) => {
@@ -3049,6 +3096,7 @@ async fn handle_enrich_exhausted_or_retry(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
 
     #[test]
     fn hourly_cap_day_vs_night() {
@@ -3128,6 +3176,62 @@ mod tests {
         assert!(!is_resource_exhaustion(
             "YAML error: did not find expected key at line 5 column 3"
         ));
+    }
+
+    #[test]
+    fn accepts_a_run_that_wrote_the_law_yaml() {
+        let workdir = Path::new("/tmp/wd");
+        let files = vec![
+            PathBuf::from("/tmp/wd/features/zorgtoeslag.feature"),
+            PathBuf::from("/tmp/wd/laws/wet_op_de_zorgtoeslag/law.yaml"),
+        ];
+        assert!(produced_reviewable_law(
+            workdir,
+            &files,
+            "laws/wet_op_de_zorgtoeslag/law.yaml"
+        ));
+    }
+
+    #[test]
+    fn rejects_a_run_that_only_wrote_feature_files() {
+        // De worker staged features naast de wet. Alleen features betekent dat
+        // er niets te beoordelen is, ook al meldde de run succes.
+        let workdir = Path::new("/tmp/wd");
+        let files = vec![
+            PathBuf::from("/tmp/wd/features/zorgtoeslag.feature"),
+            PathBuf::from("/tmp/wd/features/premie.feature"),
+        ];
+        assert!(!produced_reviewable_law(
+            workdir,
+            &files,
+            "laws/wet_op_de_zorgtoeslag/law.yaml"
+        ));
+    }
+
+    #[test]
+    fn rejects_a_run_that_only_wrote_sidecars() {
+        let workdir = Path::new("/tmp/wd");
+        let files = vec![PathBuf::from("/tmp/wd/laws/x/.enrichment.yaml")];
+        assert!(!produced_reviewable_law(workdir, &files, "laws/x/law.yaml"));
+    }
+
+    #[test]
+    fn rejects_a_run_that_wrote_nothing() {
+        assert!(!produced_reviewable_law(
+            Path::new("/tmp/wd"),
+            &[],
+            "laws/x/law.yaml"
+        ));
+    }
+
+    #[test]
+    fn accepts_a_law_yaml_on_a_path_other_than_the_payload_one() {
+        // Fallback, gelijk aan die van useTaskReview: schrijft het model de wet
+        // ergens anders neer, dan is er nog steeds iets te beoordelen. Alleen
+        // een run zonder énige wet-YAML faalt.
+        let workdir = Path::new("/tmp/wd");
+        let files = vec![PathBuf::from("/tmp/wd/regulation/nl/wet/anders.yaml")];
+        assert!(produced_reviewable_law(workdir, &files, "laws/x/law.yaml"));
     }
 
     #[test]

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -1885,6 +1885,51 @@ pub(crate) fn produced_reviewable_law(
     })
 }
 
+/// Article numbers whose content differs between the source snapshot and the
+/// proposal, in the proposal's own order.
+///
+/// The enrichment writes `machine_readable` per article, so a run typically
+/// touches a handful of them while leaving the rest byte-identical. Splitting
+/// the review per article means a reviewer decides on what actually changed
+/// instead of on the whole law at once.
+///
+/// Compared as untyped YAML rather than through the law model on purpose: the
+/// only question here is "did this article change", and an untyped compare
+/// keeps answering that when the schema grows a field this crate does not know
+/// about yet. An article the source does not have at all counts as changed.
+///
+/// A parse failure yields None, and the caller then falls back to one task for
+/// the whole law — a proposal we cannot read is still reviewable by hand.
+pub(crate) fn changed_articles(source_yaml: &str, proposal_yaml: &str) -> Option<Vec<String>> {
+    fn articles(yaml: &str) -> Option<Vec<(String, serde_yaml_ng::Value)>> {
+        let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(yaml).ok()?;
+        let list = doc.get("articles")?.as_sequence()?;
+        Some(
+            list.iter()
+                .filter_map(|a| {
+                    let number = a.get("number")?.as_str()?.to_string();
+                    Some((number, a.clone()))
+                })
+                .collect(),
+        )
+    }
+
+    let source = articles(source_yaml)?;
+    let proposal = articles(proposal_yaml)?;
+    Some(
+        proposal
+            .into_iter()
+            .filter(|(number, article)| {
+                source
+                    .iter()
+                    .find(|(n, _)| n == number)
+                    .is_none_or(|(_, before)| before != article)
+            })
+            .map(|(number, _)| number)
+            .collect(),
+    )
+}
+
 /// Taak-flow succes: schrijf de door de enrichment aangeraakte bestanden als
 /// result-blobs, verwijder de input-blobs, complete de job en maak de
 /// review-taak aan — alles in één transactie.
@@ -1898,8 +1943,17 @@ pub async fn finish_enrich_task_job(
     let payload: EnrichPayload = serde_json::from_value(job.payload.clone().unwrap_or_default())
         .map_err(|e| PipelineError::Enrich(format!("invalid enrich payload: {e}")))?;
 
+    // Vóór de transactie, want delete_blobs_for_job hieronder gooit de
+    // input-blobs weg: dit is de bronsnapshot waartegen we de proposal diffen.
+    let source_yaml = crate::tasks::load_blobs(pool, job.id, crate::tasks::BlobKind::Input)
+        .await?
+        .into_iter()
+        .find(|b| b.path == payload.yaml_path)
+        .map(|b| b.content);
+
     let mut tx = pool.begin().await?;
     crate::tasks::delete_blobs_for_job(&mut *tx, job.id).await?;
+    let mut proposal_yaml: Option<String> = None;
     for abs in written_files {
         let rel = abs
             .strip_prefix(workdir)
@@ -1912,6 +1966,9 @@ pub async fn finish_enrich_task_job(
             .to_string_lossy()
             .to_string();
         let content = tokio::fs::read_to_string(abs).await?;
+        if rel == payload.yaml_path {
+            proposal_yaml = Some(content.clone());
+        }
         crate::tasks::insert_blob(
             &mut *tx,
             job.id,
@@ -1936,23 +1993,81 @@ pub async fn finish_enrich_task_job(
     if new_law {
         task_payload["kind"] = serde_json::json!("law_create");
     }
-    let title = if new_law {
-        format!("Nieuwe wet beoordelen: {}", payload.law_id)
+
+    // Eén taak per gewijzigd artikel. Een verrijking raakt doorgaans een
+    // handvol artikelen en laat de rest ongemoeid; per artikel beslissen laat de
+    // beoordelaar zich uitspreken over wat er werkelijk veranderd is.
+    //
+    // Terug naar één taak voor de hele wet wanneer we niet kunnen diffen: bij
+    // een nieuwe wet is er geen bron om tegen af te zetten, en bij een
+    // onleesbare YAML weten we het simpelweg niet. Beide zijn met de hand nog
+    // prima te beoordelen, dus dat is een terugval en geen fout.
+    let per_article = if new_law {
+        None
     } else {
-        format!("Verrijking beoordelen: {}", payload.law_id)
+        match (source_yaml.as_deref(), proposal_yaml.as_deref()) {
+            (Some(before), Some(after)) => changed_articles(before, after),
+            _ => None,
+        }
     };
-    crate::tasks::create_task(
-        &mut *tx,
-        crate::tasks::NewTask {
-            task_type: crate::tasks::TaskType::JobReview,
-            assignee_account_id: payload.requested_by,
-            traject_id: payload.traject_id,
-            job_id: Some(job.id),
-            title,
-            payload: Some(task_payload),
-        },
-    )
-    .await?;
+
+    match per_article {
+        Some(articles) if !articles.is_empty() => {
+            tracing::info!(
+                job_id = %job.id,
+                law_id = %payload.law_id,
+                articles = articles.len(),
+                "review-taken per artikel aangemaakt"
+            );
+            for number in articles {
+                let mut article_payload = task_payload.clone();
+                article_payload["article"] = serde_json::json!(number);
+                crate::tasks::create_task(
+                    &mut *tx,
+                    crate::tasks::NewTask {
+                        task_type: crate::tasks::TaskType::JobReview,
+                        assignee_account_id: payload.requested_by,
+                        traject_id: payload.traject_id,
+                        job_id: Some(job.id),
+                        title: format!(
+                            "Verrijking beoordelen: {} artikel {}",
+                            payload.law_id, number
+                        ),
+                        payload: Some(article_payload),
+                    },
+                )
+                .await?;
+            }
+        }
+        // Leeg betekent: de proposal verschilt nergens van de bron. Dan valt er
+        // niets te beoordelen en hoort er geen taak te komen; de job is klaar.
+        Some(_) => {
+            tracing::info!(
+                job_id = %job.id,
+                law_id = %payload.law_id,
+                "verrijking leverde geen wijziging op, geen review-taak"
+            );
+        }
+        None => {
+            let title = if new_law {
+                format!("Nieuwe wet beoordelen: {}", payload.law_id)
+            } else {
+                format!("Verrijking beoordelen: {}", payload.law_id)
+            };
+            crate::tasks::create_task(
+                &mut *tx,
+                crate::tasks::NewTask {
+                    task_type: crate::tasks::TaskType::JobReview,
+                    assignee_account_id: payload.requested_by,
+                    traject_id: payload.traject_id,
+                    job_id: Some(job.id),
+                    title,
+                    payload: Some(task_payload),
+                },
+            )
+            .await?;
+        }
+    }
     tx.commit().await?;
     Ok(())
 }
@@ -3176,6 +3291,75 @@ mod tests {
         assert!(!is_resource_exhaustion(
             "YAML error: did not find expected key at line 5 column 3"
         ));
+    }
+
+    const SOURCE: &str = r#"
+$id: wet_x
+articles:
+  - number: "1"
+    text: Eerste artikel
+  - number: "2"
+    text: Tweede artikel
+    machine_readable:
+      execution:
+        output: []
+"#;
+
+    #[test]
+    fn reports_only_the_articles_that_differ() {
+        let proposal = r#"
+$id: wet_x
+articles:
+  - number: "1"
+    text: Eerste artikel
+  - number: "2"
+    text: Tweede artikel
+    machine_readable:
+      execution:
+        output:
+          - name: bedrag
+"#;
+        assert_eq!(
+            changed_articles(SOURCE, proposal),
+            Some(vec!["2".to_string()])
+        );
+    }
+
+    #[test]
+    fn reports_nothing_when_the_proposal_matches_the_source() {
+        assert_eq!(changed_articles(SOURCE, SOURCE), Some(Vec::new()));
+    }
+
+    #[test]
+    fn counts_an_article_the_source_does_not_have_as_changed() {
+        let proposal = r#"
+$id: wet_x
+articles:
+  - number: "1"
+    text: Eerste artikel
+  - number: "2"
+    text: Tweede artikel
+    machine_readable:
+      execution:
+        output: []
+  - number: "3"
+    text: Nieuw artikel
+"#;
+        assert_eq!(
+            changed_articles(SOURCE, proposal),
+            Some(vec!["3".to_string()])
+        );
+    }
+
+    #[test]
+    fn yields_none_on_unreadable_yaml_so_the_caller_falls_back() {
+        // Geen paniek en geen lege lijst: "ik weet het niet" is iets anders dan
+        // "er is niets veranderd", en de caller maakt er één taak van.
+        assert_eq!(
+            changed_articles(SOURCE, "dit is: [geen: geldige yaml"),
+            None
+        );
+        assert_eq!(changed_articles("zonder articles-sleutel: 1", SOURCE), None);
     }
 
     #[test]

--- a/packages/pipeline/tests/tasks_tests.rs
+++ b/packages/pipeline/tests/tasks_tests.rs
@@ -184,6 +184,73 @@ async fn test_blob_roundtrip_and_delete() {
 }
 
 #[tokio::test]
+async fn test_blobs_survive_until_the_last_per_article_task_is_resolved() {
+    let db = TestDb::new().await;
+    let (account_id, traject_id) = seed_account_and_traject(&db).await;
+    let job = job_queue::create_job(&db.pool, CreateJobRequest::new(JobType::Enrich, "wet_a"))
+        .await
+        .unwrap();
+    tasks::insert_blob(
+        &db.pool,
+        job.id,
+        BlobKind::Result,
+        "laws/wet_a.yaml",
+        "a: 2",
+    )
+    .await
+    .unwrap();
+    // Eén verrijking, twee gewijzigde artikelen, dus twee taken op dezelfde
+    // resultaat-blob.
+    let mut task_ids = Vec::new();
+    for article in ["1", "2"] {
+        let task = tasks::create_task(
+            &db.pool,
+            NewTask {
+                task_type: TaskType::JobReview,
+                assignee_account_id: Some(account_id),
+                traject_id: Some(traject_id),
+                job_id: Some(job.id),
+                title: format!("artikel {article}"),
+                payload: None,
+            },
+        )
+        .await
+        .unwrap();
+        task_ids.push(task.id);
+    }
+
+    tasks::resolve_task(&db.pool, task_ids[0], account_id, TaskStatus::Approved)
+        .await
+        .unwrap();
+    let removed = tasks::delete_blobs_for_finished_job(&db.pool, job.id)
+        .await
+        .unwrap();
+    assert_eq!(
+        removed, 0,
+        "de tweede taak moet zijn voorstel nog kunnen laden"
+    );
+    assert_eq!(
+        tasks::load_blobs(&db.pool, job.id, BlobKind::Result)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+
+    tasks::resolve_task(&db.pool, task_ids[1], account_id, TaskStatus::Rejected)
+        .await
+        .unwrap();
+    let removed = tasks::delete_blobs_for_finished_job(&db.pool, job.id)
+        .await
+        .unwrap();
+    assert_eq!(removed, 1);
+    assert!(tasks::load_blobs(&db.pool, job.id, BlobKind::Result)
+        .await
+        .unwrap()
+        .is_empty());
+}
+
+#[tokio::test]
 async fn test_cleanup_orphaned_blobs_keeps_open_task_blobs() {
     let db = TestDb::new().await;
     let (account_id, traject_id) = seed_account_and_traject(&db).await;
@@ -292,6 +359,74 @@ async fn test_finish_enrich_task_job_creates_task_and_result_blobs() {
     assert_eq!(open.len(), 1);
     assert_eq!(open[0].task_type, "job_review");
     assert_eq!(open[0].job_id, Some(job.id));
+    // Zonder bronsnapshot valt de worker terug op één taak voor de hele wet,
+    // en die draagt dan ook geen artikelnummer.
+    assert!(open[0].payload.as_ref().unwrap().get("article").is_none());
+}
+
+#[tokio::test]
+async fn test_finish_enrich_task_job_creates_one_task_per_changed_article() {
+    let db = TestDb::new().await;
+    let (account_id, traject_id) = seed_account_and_traject(&db).await;
+    let _created = job_queue::create_job(
+        &db.pool,
+        CreateJobRequest::new(JobType::Enrich, "test_wet").with_payload(json!({
+            "law_id": "test_wet",
+            "yaml_path": "laws/test_wet/law.yaml",
+            "provider": "claude",
+            "requested_by": account_id,
+            "deliver": "task",
+            "traject_id": traject_id,
+            "traject_ref": "testtraject-abcd1234",
+            "source_etag": "\"etag-1\""
+        })),
+    )
+    .await
+    .unwrap();
+    let job = job_queue::claim_job(&db.pool, Some(JobType::Enrich))
+        .await
+        .unwrap()
+        .unwrap();
+
+    // De bronsnapshot zoals de worker die bij het starten wegschrijft.
+    let source = "articles:\n  - number: '1'\n    text: een\n  - number: '2'\n    text: twee\n";
+    tasks::insert_blob(
+        &db.pool,
+        job.id,
+        BlobKind::Input,
+        "laws/test_wet/law.yaml",
+        source,
+    )
+    .await
+    .unwrap();
+
+    // Het voorstel raakt alleen artikel 2.
+    let proposal =
+        "articles:\n  - number: '1'\n    text: een\n  - number: '2'\n    text: twee bis\n";
+    let dir = tempfile::tempdir().unwrap();
+    let law_abs = dir.path().join("laws/test_wet/law.yaml");
+    tokio::fs::create_dir_all(law_abs.parent().unwrap())
+        .await
+        .unwrap();
+    tokio::fs::write(&law_abs, proposal).await.unwrap();
+
+    finish_enrich_task_job(&db.pool, &job, dir.path(), &[law_abs.clone()], None)
+        .await
+        .unwrap();
+
+    let open = tasks::list_open_tasks_for_account(&db.pool, account_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        open.len(),
+        1,
+        "alleen het gewijzigde artikel krijgt een taak"
+    );
+    assert_eq!(
+        open[0].payload.as_ref().unwrap().get("article").unwrap(),
+        "2"
+    );
+    assert_eq!(open[0].title, "Verrijking beoordelen: test_wet artikel 2");
 }
 
 #[tokio::test]

--- a/script/dev-lib.sh
+++ b/script/dev-lib.sh
@@ -124,10 +124,21 @@ dev_ensure_wasm() {
 # per-service env vars and `cd` without leaking them into the recipe shell.
 # `setsid` makes the process its own session/group leader (PID == PGID), so
 # dev_stop can kill the whole subtree — npm → node, cargo → child — in one shot.
+# macOS ships no setsid(1), and without it dev_start silently started nothing:
+# the log held "setsid: command not found" and the port stayed dead. perl's
+# POSIX::setsid is the same syscall, and perl is on every mac by default.
+dev_setsid() {
+    if command -v setsid > /dev/null 2>&1; then
+        setsid "$@"
+    else
+        perl -e 'use POSIX qw(setsid); setsid() or die "setsid: $!\n"; exec @ARGV or die "exec: $!\n"' "$@"
+    fi
+}
+
 dev_start() {
     local label="$1" logfile="$2" cmd="$3"
     printf "${bold}=> Starting %s…${reset}\n" "$label"
-    setsid bash -c "$cmd" > "$logfile" 2>&1 &
+    dev_setsid bash -c "$cmd" > "$logfile" 2>&1 &
     echo "$!" >> "$PIDFILE"
 }
 


### PR DESCRIPTION
## Wat zit erin

**Instellingen-sheet en review-balk in de editor.** Het voorstel krijgt een balk eromheen waarmee je het beoordeelt, en de instellingen verhuizen naar een sheet in plaats van los in de pagina. Verrijken kan nu ook vanuit Machine en YAML, met één gedeelde lege staat, zodat je niet eerst terug hoeft naar Tekst.

**Beoordelen per artikel.** Een verrijking beoordeel je per artikel in plaats van in één keer voor de hele wet. Een verrijking zonder wet-YAML levert daarbij geen review-taak meer op, want daar valt niets te beoordelen.

**Recent bekeken per traject.** De lijst stond op één localStorage-sleutel, dus een wet die je in een traject opende verscheen ook onder corpus juris en andersom. Twee trajecten bevatten andere wetten, dus zo'n verwijzing kon naar iets wijzen dat er niet is. Nu een sleutel per traject en één voor het corpus, met zes tests eromheen.

**Docs-site.** Het ministerie staat in het logo met RegelRecht als websitetitel, één hero-titel op size 1, een kortere aanmeldpagina en EZK in de footer.

**Twee losse fixes.** Een net gestarte taak verschijnt zonder herladen, en `usePollWhile` sloopt de setup niet meer.

**Dev en dependencies.** macOS levert geen `setsid(1)`, waardoor `dev_start` in stilte niets startte: in het log stond "setsid: command not found" en de poort bleef dood. Nu een perl-fallback op dezelfde syscall. En het design system gaat naar 0.8.78, in alle drie de workspaces die het gebruiken.

## Testen

- 6 nieuwe tests voor recent bekeken per traject (`frontend/src/LibraryView.recentLaws.test.js`)
- uitgebreide tests in `packages/pipeline/tests/tasks_tests.rs` voor de review-taken

🤖 Generated with [Claude Code](https://claude.com/claude-code)
