### PR TITLE
fix(pipeline): law-source herschrijft een wet niet meer weg

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -133,10 +133,13 @@ harvester-test:
     cd packages/harvester && {{ci_flags}} cargo test
 
 # Run pipeline unit tests. Five of these are container-backed and carry
-# #[ignore]; add `-- --ignored` to run those instead.
+# #[ignore]; add `-- --ignored` to run those instead. The two CLI test
+# suites run the built binaries against temp directories and need no
+# Docker either, so they belong in this recipe, not only in the db-leg.
 [doc("Run pipeline unit tests (the container-backed ones are #[ignore]d)")]
 pipeline-test:
     cd packages/pipeline && {{ci_flags}} cargo test --lib
+    cd packages/pipeline && {{ci_flags}} cargo test --test law_source_cli --test enrich_once_cli
 
 # Run pipeline integration tests (requires Docker for testcontainers)
 pipeline-integration-test:

--- a/packages/pipeline/src/bin/law_source.rs
+++ b/packages/pipeline/src/bin/law_source.rs
@@ -16,13 +16,15 @@
 //! sidecar beside the file. Existing `machine_readable` is carried over by
 //! article number: discarding it would throw away work, and the checks that
 //! run afterwards are what decide whether the translation still holds
-//! against the corrected text.
+//! against the corrected text. A rewrite that would empty the file or
+//! remove most of it is refused: that shape means the source is wrong, not
+//! the law.
 
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use regelrecht_pipeline::enrich_v2::source_gate::{
-    parse_toestand, rewrite, toestand_url, verify, Verdict, CONTEXT_SIDECAR,
+    parse_toestand, rewrite, toestand_url, verify, write_atomic, Verdict, CONTEXT_SIDECAR,
 };
 
 #[tokio::main]
@@ -170,16 +172,29 @@ async fn check_one(
     }
 
     if do_rewrite {
-        let (fixed, sidecar) = rewrite(&doc, &official, &report);
-        let yaml = serde_yaml_ng::to_string(&fixed).map_err(|e| e.to_string())?;
-        std::fs::write(path, yaml).map_err(|e| e.to_string())?;
+        // The rewrite refuses an empty or drastically shrunken official
+        // set instead of writing it out; acting on one has erased a
+        // complete law before. A refusal fails the gate and leaves the
+        // file exactly as it was.
+        let (fixed, sidecar) = match rewrite(&doc, &official, &report) {
+            Ok(pair) => pair,
+            Err(reason) => {
+                println!("  rewrite refused: {reason}");
+                return Ok(false);
+            }
+        };
 
+        // Serialize both documents before writing either, and write each
+        // through a temp file plus rename, so an interruption cannot leave
+        // a truncated law file behind.
+        let yaml = serde_yaml_ng::to_string(&fixed).map_err(|e| e.to_string())?;
         let sidecar_path = path
             .parent()
             .ok_or("law file has no parent directory")?
             .join(CONTEXT_SIDECAR);
         let sidecar_yaml = serde_yaml_ng::to_string(&sidecar).map_err(|e| e.to_string())?;
-        std::fs::write(&sidecar_path, sidecar_yaml).map_err(|e| e.to_string())?;
+        write_atomic(path, &yaml)?;
+        write_atomic(&sidecar_path, &sidecar_yaml)?;
 
         println!(
             "  rewritten: {} article(s) now carry the official text; structure in {}",

--- a/packages/pipeline/src/bin/law_source.rs
+++ b/packages/pipeline/src/bin/law_source.rs
@@ -24,7 +24,7 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use regelrecht_pipeline::enrich_v2::source_gate::{
-    parse_toestand, rewrite, toestand_url, verify, write_atomic, Verdict, CONTEXT_SIDECAR,
+    parse_toestand, rewrite, toestand_url, verify, write_atomic_pair, Verdict, CONTEXT_SIDECAR,
 };
 
 #[tokio::main]
@@ -184,17 +184,17 @@ async fn check_one(
             }
         };
 
-        // Serialize both documents before writing either, and write each
-        // through a temp file plus rename, so an interruption cannot leave
-        // a truncated law file behind.
+        // Serialize both documents before writing either. The pair write
+        // stages both files and renames the law file last, so neither an
+        // interruption nor a failing sidecar write can leave a truncated
+        // or half-replaced law file behind.
         let yaml = serde_yaml_ng::to_string(&fixed).map_err(|e| e.to_string())?;
         let sidecar_path = path
             .parent()
             .ok_or("law file has no parent directory")?
             .join(CONTEXT_SIDECAR);
         let sidecar_yaml = serde_yaml_ng::to_string(&sidecar).map_err(|e| e.to_string())?;
-        write_atomic(path, &yaml)?;
-        write_atomic(&sidecar_path, &sidecar_yaml)?;
+        write_atomic_pair((path, &yaml), (&sidecar_path, &sidecar_yaml))?;
 
         println!(
             "  rewritten: {} article(s) now carry the official text; structure in {}",

--- a/packages/pipeline/src/enrich_v2/source_gate.rs
+++ b/packages/pipeline/src/enrich_v2/source_gate.rs
@@ -523,13 +523,48 @@ pub const CONTEXT_SIDECAR: &str = ".source-context.yaml";
 /// run afterwards are what decide whether the translation still holds
 /// against the corrected text.
 ///
-/// Returns the rewritten document and the sidecar.
+/// The rewrite refuses two situations instead of writing them out. An
+/// empty official set never means the law lost its articles; it means the
+/// fetch or the parse went wrong (a network error, a changed response, a
+/// wrong BWB id), and acting on it would erase the whole file. And a
+/// rewrite that keeps less than half of the file's entries is treated the
+/// same way: a rewrite corrects text and moves a handful of articles in or
+/// out, it does not legitimately remove the majority of a law. When it
+/// would, either the source set does not describe this law, or the corpus
+/// is fragmented per lid and this whole-article rewrite would flatten it,
+/// losing the leden, references and links. Both need a human, not a write.
+///
+/// Returns the rewritten document and the sidecar, or the reason the
+/// rewrite is refused.
 pub fn rewrite(
     corpus: &serde_yaml_ng::Value,
     official: &[SourceArticle],
     report: &GateReport,
-) -> (serde_yaml_ng::Value, ContextSidecar) {
+) -> Result<(serde_yaml_ng::Value, ContextSidecar), String> {
     use serde_yaml_ng::{Mapping, Value};
+
+    let existing = corpus
+        .get("articles")
+        .and_then(Value::as_sequence)
+        .map_or(0, Vec::len);
+    if official.is_empty() {
+        return Err(format!(
+            "the official toestand parsed to 0 articles while the file carries \
+             {existing} entr{}; an empty source set means the fetch or the parse \
+             failed (network error, changed response, wrong BWB id), not that the \
+             law has no articles — the file is left as it is",
+            if existing == 1 { "y" } else { "ies" }
+        ));
+    }
+    if official.len() * 2 < existing {
+        return Err(format!(
+            "the rewrite would shrink the file from {existing} entries to {} \
+             article(s); removing the majority of a law points at the wrong \
+             source or at a per-lid fragmented corpus this whole-article \
+             rewrite would flatten — the file is left as it is",
+            official.len()
+        ));
+    }
 
     let mut existing_mr: BTreeMap<String, Value> = BTreeMap::new();
     let mut existing_url: BTreeMap<String, Value> = BTreeMap::new();
@@ -607,7 +642,41 @@ pub fn rewrite(
     if let Value::Mapping(map) = &mut doc {
         map.insert(Value::from("articles"), Value::Sequence(articles));
     }
-    (doc, sidecar)
+    Ok((doc, sidecar))
+}
+
+/// Write `content` to `path` through a temp file in the same directory and
+/// an atomic rename, so an interruption never leaves a truncated file
+/// behind. The harvester writes its YAML the same way (`yaml/writer.rs`),
+/// for the same reason.
+pub fn write_atomic(path: &std::path::Path, content: &str) -> Result<(), String> {
+    use std::io::Write;
+
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("{} has no parent directory", path.display()))?;
+    let file_name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| format!("{} has no file name", path.display()))?;
+    let tmp = parent.join(format!(".{file_name}.tmp"));
+
+    let attempt = (|| -> std::io::Result<()> {
+        let mut file = std::fs::File::create(&tmp)?;
+        file.write_all(content.as_bytes())?;
+        file.sync_all()?;
+        // On Windows, rename refuses when the destination exists.
+        #[cfg(target_os = "windows")]
+        if path.exists() {
+            std::fs::remove_file(path)?;
+        }
+        std::fs::rename(&tmp, path)
+    })();
+
+    attempt.map_err(|e| {
+        let _ = std::fs::remove_file(&tmp);
+        format!("writing {}: {e}", path.display())
+    })
 }
 
 /// Split a corpus article number into the source article it belongs to and
@@ -780,7 +849,7 @@ articles:
         )
         .unwrap();
         let report = verify(&corpus, &official);
-        let (doc, sidecar) = rewrite(&corpus, &official, &report);
+        let (doc, sidecar) = rewrite(&corpus, &official, &report).unwrap();
 
         let arts = doc.get("articles").unwrap().as_sequence().unwrap();
         let numbers: Vec<&str> = arts
@@ -808,6 +877,97 @@ articles:
             "Hoofdstuk 3 Besluiten > Afdeling 3.3 Advisering"
         );
         assert_eq!(sidecar.articles["1"].verdict, "text replaced (had drifted)");
+    }
+
+    #[test]
+    fn rewrite_refuses_an_empty_official_set() {
+        // A toestand that parses but holds no articles: what a changed
+        // response format or a wrong BWB id produces. Yesterday this shape
+        // erased a complete law from the corpus.
+        let official =
+            parse_toestand(r#"<toestand bwb-id="BWBR0000001"><wettekst/></toestand>"#).unwrap();
+        assert!(official.is_empty());
+        let corpus: serde_yaml_ng::Value = serde_yaml_ng::from_str(
+            "articles:\n  - number: '1'\n    text: Eerste artikel.\n    machine_readable: {a: 1}\n  - number: '2'\n    text: Tweede artikel.\n",
+        )
+        .unwrap();
+        let report = verify(&corpus, &official);
+        let err = rewrite(&corpus, &official, &report).unwrap_err();
+        assert!(err.contains("0 articles"), "{err}");
+        assert!(err.contains("2 entries"), "{err}");
+        // The message must point at the real causes, not at the law.
+        assert!(err.contains("wrong BWB id"), "{err}");
+    }
+
+    #[test]
+    fn rewrite_refuses_to_remove_the_majority_of_a_law() {
+        // A per-lid fragmented corpus: six entries that all belong to the
+        // single official article. Writing the whole-article form would
+        // flatten the leden and drop every extra field, which is what
+        // happened to the Awir (329 entries became 87 bare articles).
+        let official = parse_toestand(
+            r#"<toestand bwb-id="BWBR0000001"><wettekst>
+              <artikel><kop><label>Artikel</label><nr>1</nr></kop>
+                <lid><lidnr>1</lidnr><al>Eerste lid.</al></lid>
+                <lid><lidnr>2</lidnr><al>Tweede lid.</al></lid>
+              </artikel>
+            </wettekst></toestand>"#,
+        )
+        .unwrap();
+        let corpus: serde_yaml_ng::Value = serde_yaml_ng::from_str(
+            r#"
+articles:
+  - {number: '1.1', text: Eerste lid.}
+  - {number: '1.2', text: Tweede lid.}
+  - {number: '1.2.a', text: onderdeel a}
+  - {number: '1.2.b', text: onderdeel b}
+  - {number: '1.2.c', text: onderdeel c}
+  - {number: '1.2.d', text: onderdeel d}
+"#,
+        )
+        .unwrap();
+        let report = verify(&corpus, &official);
+        let err = rewrite(&corpus, &official, &report).unwrap_err();
+        assert!(err.contains("6 entries"), "{err}");
+        assert!(err.contains("1 article(s)"), "{err}");
+    }
+
+    #[test]
+    fn rewrite_still_accepts_keeping_exactly_half() {
+        // Two fabricated entries next to two real articles: dropping the
+        // fabrications keeps half of the file, and that is a correction,
+        // not a demolition.
+        let official = parse_toestand(XML).unwrap();
+        let corpus: serde_yaml_ng::Value = serde_yaml_ng::from_str(
+            r#"
+articles:
+  - {number: '1', text: 1. Eerste lid. 2. Tweede lid.}
+  - {number: '3:9', text: iets}
+  - {number: 1a, text: verzonnen}
+  - {number: 1b, text: ook verzonnen}
+  - {number: 1c, text: nog een}
+  - {number: 1d, text: en nog een}
+"#,
+        )
+        .unwrap();
+        let report = verify(&corpus, &official);
+        // XML carries three official articles; 6 entries -> 3 is exactly
+        // half and passes the threshold.
+        assert!(rewrite(&corpus, &official, &report).is_ok());
+    }
+
+    #[test]
+    fn write_atomic_replaces_the_file_and_leaves_no_temp() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("law.yaml");
+        std::fs::write(&path, "oud").unwrap();
+        // A stale temp file from an earlier interrupted run is harmless.
+        std::fs::write(dir.path().join(".law.yaml.tmp"), "afgekapt").unwrap();
+
+        write_atomic(&path, "nieuw").unwrap();
+
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "nieuw");
+        assert!(!dir.path().join(".law.yaml.tmp").exists());
     }
 
     const FRAGMENTED_XML: &str = r#"<toestand bwb-id="BWBR0000002">

--- a/packages/pipeline/src/enrich_v2/source_gate.rs
+++ b/packages/pipeline/src/enrich_v2/source_gate.rs
@@ -523,16 +523,19 @@ pub const CONTEXT_SIDECAR: &str = ".source-context.yaml";
 /// run afterwards are what decide whether the translation still holds
 /// against the corrected text.
 ///
-/// The rewrite refuses two situations instead of writing them out. An
+/// The rewrite refuses four situations instead of writing them out, all
+/// shapes in which the write would destroy more than it corrects. An
 /// empty official set never means the law lost its articles; it means the
-/// fetch or the parse went wrong (a network error, a changed response, a
-/// wrong BWB id), and acting on it would erase the whole file. And a
-/// rewrite that keeps less than half of the file's entries is treated the
-/// same way: a rewrite corrects text and moves a handful of articles in or
-/// out, it does not legitimately remove the majority of a law. When it
-/// would, either the source set does not describe this law, or the corpus
-/// is fragmented per lid and this whole-article rewrite would flatten it,
-/// losing the leden, references and links. Both need a human, not a write.
+/// fetch or the parse went wrong. A source set that shares not a single
+/// article with the file (no verdict `Verified` or `Drift`) is a
+/// different law, whatever the counts say — the shape a wrong BWB id of
+/// similar size produces. A rewrite that keeps less than half of the
+/// file's entries removes the majority of a law, which a rewrite never
+/// legitimately does. And an entry that addresses a lid or onderdeel
+/// while carrying `machine_readable` or `references` would be flattened
+/// into its whole article, silently dropping that work, because the
+/// carry-over goes by exact article number. All four need a human, not a
+/// write; each refusal says what to do next.
 ///
 /// Returns the rewritten document and the sidecar, or the reason the
 /// rewrite is refused.
@@ -543,27 +546,85 @@ pub fn rewrite(
 ) -> Result<(serde_yaml_ng::Value, ContextSidecar), String> {
     use serde_yaml_ng::{Mapping, Value};
 
-    let existing = corpus
+    let empty_seq = Vec::new();
+    let corpus_articles = corpus
         .get("articles")
         .and_then(Value::as_sequence)
-        .map_or(0, Vec::len);
+        .unwrap_or(&empty_seq);
+    let existing = corpus_articles.len();
+
     if official.is_empty() {
         return Err(format!(
             "the official toestand parsed to 0 articles while the file carries \
              {existing} entr{}; an empty source set means the fetch or the parse \
              failed (network error, changed response, wrong BWB id), not that the \
-             law has no articles — the file is left as it is",
+             law has no articles. The file is left as it is; check the bwb_id and \
+             valid_from in the file and retry when the toestand is sound",
             if existing == 1 { "y" } else { "ies" }
         ));
     }
+
+    // A source set that shares nothing with the file is a different law,
+    // whatever the counts say. This is the wrong-BWB-id-of-similar-size
+    // case: every entry fabricated, every official article missing, and a
+    // size threshold alone would wave the substitution through.
+    let overlap = report
+        .verdicts
+        .values()
+        .any(|v| matches!(v, Verdict::Verified | Verdict::Drift { .. }));
+    if existing > 0 && !overlap {
+        return Err(format!(
+            "not one of the file's {existing} entries matches an official \
+             article (0 verified, 0 drifted); a source that shares nothing \
+             with the file is a different law, so this points at a wrong \
+             bwb_id or valid_from. The file is left as it is; run without \
+             --rewrite to see the per-article verdicts",
+        ));
+    }
+
     if official.len() * 2 < existing {
         return Err(format!(
             "the rewrite would shrink the file from {existing} entries to {} \
              article(s); removing the majority of a law points at the wrong \
              source or at a per-lid fragmented corpus this whole-article \
-             rewrite would flatten — the file is left as it is",
+             rewrite would flatten. The file is left as it is; run without \
+             --rewrite to see the verdicts, and prune the file by hand if \
+             the law really shrank this much",
             official.len()
         ));
+    }
+
+    // The carry-over below goes by exact article number, so an entry that
+    // addresses a lid or onderdeel (`2.2`) is flattened into its whole
+    // article (`2`) and anything it carries is dropped. Refuse when that
+    // would discard work, whatever the entry counts are.
+    let official_by_number: BTreeMap<&str, &SourceArticle> =
+        official.iter().map(|a| (a.number.as_str(), a)).collect();
+    for article in corpus_articles {
+        let Some(number) = article.get("number").and_then(Value::as_str) else {
+            continue;
+        };
+        let Some((source, path)) = resolve(&official_by_number, number) else {
+            continue;
+        };
+        if path.is_empty() {
+            continue;
+        }
+        let carried: Vec<&str> = ["machine_readable", "references"]
+            .into_iter()
+            .filter(|k| article.get(*k).is_some())
+            .collect();
+        if !carried.is_empty() {
+            return Err(format!(
+                "entry {number} addresses a lid or onderdeel of article {} and \
+                 carries {}; the whole-article rewrite would flatten the entry \
+                 and silently drop that work. The file is left as it is; move \
+                 the work to the whole article first, or make the correction \
+                 by hand",
+                source.number,
+                carried.join(" and ")
+            ));
+        }
     }
 
     let mut existing_mr: BTreeMap<String, Value> = BTreeMap::new();
@@ -645,38 +706,88 @@ pub fn rewrite(
     Ok((doc, sidecar))
 }
 
+/// A file staged next to its destination: the content is on disk and
+/// synced, only the rename remains. Every failure path removes the temp
+/// file again.
+struct StagedWrite {
+    tmp: std::path::PathBuf,
+    dest: std::path::PathBuf,
+}
+
+impl StagedWrite {
+    fn new(path: &std::path::Path, content: &str) -> Result<Self, String> {
+        use std::io::Write;
+
+        let parent = path
+            .parent()
+            .ok_or_else(|| format!("{} has no parent directory", path.display()))?;
+        let file_name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .ok_or_else(|| format!("{} has no file name", path.display()))?;
+        let tmp = parent.join(format!(".{file_name}.tmp"));
+
+        (|| -> std::io::Result<()> {
+            let mut file = std::fs::File::create(&tmp)?;
+            file.write_all(content.as_bytes())?;
+            file.sync_all()
+        })()
+        .map_err(|e| {
+            let _ = std::fs::remove_file(&tmp);
+            format!("writing {}: {e}", path.display())
+        })?;
+
+        Ok(Self {
+            tmp,
+            dest: path.to_path_buf(),
+        })
+    }
+
+    fn commit(self) -> Result<(), String> {
+        // On Windows, rename refuses when the destination exists.
+        #[cfg(target_os = "windows")]
+        if self.dest.exists() {
+            std::fs::remove_file(&self.dest)
+                .map_err(|e| format!("writing {}: {e}", self.dest.display()))?;
+        }
+        std::fs::rename(&self.tmp, &self.dest).map_err(|e| {
+            let _ = std::fs::remove_file(&self.tmp);
+            format!("writing {}: {e}", self.dest.display())
+        })
+    }
+}
+
 /// Write `content` to `path` through a temp file in the same directory and
 /// an atomic rename, so an interruption never leaves a truncated file
 /// behind. The harvester writes its YAML the same way (`yaml/writer.rs`),
 /// for the same reason.
 pub fn write_atomic(path: &std::path::Path, content: &str) -> Result<(), String> {
-    use std::io::Write;
+    StagedWrite::new(path, content)?.commit()
+}
 
-    let parent = path
-        .parent()
-        .ok_or_else(|| format!("{} has no parent directory", path.display()))?;
-    let file_name = path
-        .file_name()
-        .and_then(|n| n.to_str())
-        .ok_or_else(|| format!("{} has no file name", path.display()))?;
-    let tmp = parent.join(format!(".{file_name}.tmp"));
-
-    let attempt = (|| -> std::io::Result<()> {
-        let mut file = std::fs::File::create(&tmp)?;
-        file.write_all(content.as_bytes())?;
-        file.sync_all()?;
-        // On Windows, rename refuses when the destination exists.
-        #[cfg(target_os = "windows")]
-        if path.exists() {
-            std::fs::remove_file(path)?;
+/// Write a law file and its companion so the law file changes last, and
+/// only when everything else already succeeded. Both temp files are
+/// written and synced before either rename; the companion is renamed
+/// first. A failure at any point before the final rename leaves the law
+/// file exactly as it was — the worst remaining case is a fresh companion
+/// beside an unchanged law file, which the next run overwrites.
+pub fn write_atomic_pair(
+    precious: (&std::path::Path, &str),
+    companion: (&std::path::Path, &str),
+) -> Result<(), String> {
+    let staged_precious = StagedWrite::new(precious.0, precious.1)?;
+    let staged_companion = match StagedWrite::new(companion.0, companion.1) {
+        Ok(s) => s,
+        Err(e) => {
+            let _ = std::fs::remove_file(&staged_precious.tmp);
+            return Err(e);
         }
-        std::fs::rename(&tmp, path)
-    })();
-
-    attempt.map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        format!("writing {}: {e}", path.display())
-    })
+    };
+    if let Err(e) = staged_companion.commit() {
+        let _ = std::fs::remove_file(&staged_precious.tmp);
+        return Err(e);
+    }
+    staged_precious.commit()
 }
 
 /// Split a corpus article number into the source article it belongs to and
@@ -954,6 +1065,120 @@ articles:
         // XML carries three official articles; 6 entries -> 3 is exactly
         // half and passes the threshold.
         assert!(rewrite(&corpus, &official, &report).is_ok());
+    }
+
+    #[test]
+    fn rewrite_refuses_a_source_set_that_shares_nothing_with_the_file() {
+        // A wrong BWB id pointing at a law of similar size: every entry
+        // fabricated, every official article missing, and the counts even.
+        // A size threshold alone waves the substitution through and every
+        // machine_readable is gone.
+        let official = parse_toestand(
+            r#"<toestand bwb-id="BWBR0000001"><wettekst>
+              <artikel><kop><label>Artikel</label><nr>1</nr></kop><al>Een.</al></artikel>
+              <artikel><kop><label>Artikel</label><nr>2</nr></kop><al>Twee.</al></artikel>
+            </wettekst></toestand>"#,
+        )
+        .unwrap();
+        let corpus: serde_yaml_ng::Value = serde_yaml_ng::from_str(
+            r#"
+articles:
+  - {number: '10', text: Tien., machine_readable: {a: 1}}
+  - {number: '11', text: Elf., machine_readable: {b: 2}}
+"#,
+        )
+        .unwrap();
+        let report = verify(&corpus, &official);
+        // The premise: zero overlap while the counts match.
+        assert!(!report
+            .verdicts
+            .values()
+            .any(|v| matches!(v, Verdict::Verified | Verdict::Drift { .. })));
+        let err = rewrite(&corpus, &official, &report).unwrap_err();
+        assert!(err.contains("different law"), "{err}");
+        // The refusal must tell the user the next step.
+        assert!(err.contains("without --rewrite"), "{err}");
+    }
+
+    #[test]
+    fn rewrite_refuses_to_flatten_a_part_entry_that_carries_work() {
+        // Three entries against two official articles: under the size
+        // threshold, but entry 2.2 addresses a lid and carries a
+        // machine_readable that the by-exact-number carry-over would drop.
+        let official = parse_toestand(
+            r#"<toestand bwb-id="BWBR0000001"><wettekst>
+              <artikel><kop><label>Artikel</label><nr>1</nr></kop><al>Een.</al></artikel>
+              <artikel><kop><label>Artikel</label><nr>2</nr></kop>
+                <lid><lidnr>1</lidnr><al>Eerste lid.</al></lid>
+                <lid><lidnr>2</lidnr><al>Tweede lid.</al></lid>
+              </artikel>
+            </wettekst></toestand>"#,
+        )
+        .unwrap();
+        let corpus: serde_yaml_ng::Value = serde_yaml_ng::from_str(
+            r#"
+articles:
+  - {number: '1', text: Een.}
+  - {number: '2.1', text: Eerste lid.}
+  - {number: '2.2', text: Tweede lid., machine_readable: {a: 1}}
+"#,
+        )
+        .unwrap();
+        let report = verify(&corpus, &official);
+        let err = rewrite(&corpus, &official, &report).unwrap_err();
+        assert!(err.contains("entry 2.2"), "{err}");
+        assert!(err.contains("machine_readable"), "{err}");
+        assert!(err.contains("by hand"), "{err}");
+    }
+
+    #[test]
+    fn part_entries_without_work_do_not_block_the_rewrite() {
+        // The same fragmentation, but the part entries carry nothing that
+        // the flattening would lose: the text survives inside the whole
+        // article, so the rewrite may proceed.
+        let official = parse_toestand(
+            r#"<toestand bwb-id="BWBR0000001"><wettekst>
+              <artikel><kop><label>Artikel</label><nr>1</nr></kop><al>Een.</al></artikel>
+              <artikel><kop><label>Artikel</label><nr>2</nr></kop>
+                <lid><lidnr>1</lidnr><al>Eerste lid.</al></lid>
+                <lid><lidnr>2</lidnr><al>Tweede lid.</al></lid>
+              </artikel>
+            </wettekst></toestand>"#,
+        )
+        .unwrap();
+        let corpus: serde_yaml_ng::Value = serde_yaml_ng::from_str(
+            r#"
+articles:
+  - {number: '1', text: Een., machine_readable: {a: 1}}
+  - {number: '2.1', text: Eerste lid.}
+  - {number: '2.2', text: Tweede lid.}
+"#,
+        )
+        .unwrap();
+        let report = verify(&corpus, &official);
+        let (doc, _) = rewrite(&corpus, &official, &report).unwrap();
+        let arts = doc.get("articles").unwrap().as_sequence().unwrap();
+        assert_eq!(arts.len(), 2);
+        // Work on a whole-article entry is still carried over.
+        assert!(arts[0].get("machine_readable").is_some());
+    }
+
+    #[test]
+    fn a_failing_companion_write_leaves_the_precious_file_untouched() {
+        let dir = tempfile::tempdir().unwrap();
+        let precious = dir.path().join("law.yaml");
+        std::fs::write(&precious, "oud").unwrap();
+        // A directory where the companion file should land makes its
+        // rename fail after both temp files were staged.
+        let companion = dir.path().join("sidecar.yaml");
+        std::fs::create_dir(&companion).unwrap();
+
+        let err = write_atomic_pair((&precious, "nieuw"), (&companion, "context")).unwrap_err();
+        assert!(err.contains("sidecar.yaml"), "{err}");
+        assert_eq!(std::fs::read_to_string(&precious).unwrap(), "oud");
+        // No temp litter either.
+        assert!(!dir.path().join(".law.yaml.tmp").exists());
+        assert!(!dir.path().join(".sidecar.yaml.tmp").exists());
     }
 
     #[test]

--- a/packages/pipeline/tests/law_source_cli.rs
+++ b/packages/pipeline/tests/law_source_cli.rs
@@ -102,6 +102,9 @@ fn test_an_empty_official_set_leaves_the_law_file_untouched() {
 
     assert_eq!(code, Some(1), "the gate must fail, not pass: {out}");
     assert!(out.contains("rewrite refused"), "{out}");
+    // A refusal without a next step is a dead end; the message must say
+    // what the user should do.
+    assert!(out.contains("check the bwb_id"), "{out}");
     assert_eq!(
         std::fs::read_to_string(&s.law).expect("law still readable"),
         LAW_YAML,
@@ -155,6 +158,75 @@ articles:
     );
 }
 
+/// A wrong BWB id that points at a law of similar size: no entry matches
+/// any official article, but the counts are even, so a size threshold
+/// alone would replace the whole file and erase every machine_readable
+/// with exit code 0. Zero overlap means a different law; the file stays.
+#[test]
+fn test_a_wrong_law_of_similar_size_leaves_the_law_file_untouched() {
+    let other_law = r#"<toestand bwb-id="BWBR0000001">
+  <wettekst>
+    <artikel><kop><label>Artikel</label><nr>10</nr></kop>
+      <al>Tiende artikel van een andere wet.</al>
+    </artikel>
+    <artikel><kop><label>Artikel</label><nr>11</nr></kop>
+      <al>Elfde artikel van een andere wet.</al>
+    </artikel>
+  </wettekst>
+</toestand>"#;
+
+    let s = setup(LAW_YAML, other_law);
+    let (code, out) = run_rewrite(&s.law, &s.cache);
+
+    assert_eq!(code, Some(1), "the gate must fail, not pass: {out}");
+    assert!(out.contains("rewrite refused"), "{out}");
+    assert_eq!(
+        std::fs::read_to_string(&s.law).expect("law still readable"),
+        LAW_YAML,
+        "the law file must keep its articles and machine_readable"
+    );
+}
+
+/// Fragmentation below the size threshold: three entries against two
+/// official articles passes any count, but entry 2.2 carries a
+/// machine_readable that the by-exact-number carry-over would silently
+/// drop when the entry is flattened into article 2.
+#[test]
+fn test_flattening_that_would_drop_work_is_refused() {
+    let fragmented = r#"bwb_id: BWBR0000001
+valid_from: '2024-01-01'
+url: https://example.com/BWBR0000001
+articles:
+  - number: '1'
+    text: Eerste artikel, officiele tekst.
+  - number: '2.1'
+    text: Eerste lid.
+  - number: '2.2'
+    text: Tweede lid.
+    machine_readable:
+      outputs: []
+"#;
+    let two_with_leden = r#"<toestand bwb-id="BWBR0000001"><wettekst>
+      <artikel><kop><label>Artikel</label><nr>1</nr></kop>
+        <al>Eerste artikel, officiele tekst.</al>
+      </artikel>
+      <artikel><kop><label>Artikel</label><nr>2</nr></kop>
+        <lid><lidnr>1</lidnr><al>Eerste lid.</al></lid>
+        <lid><lidnr>2</lidnr><al>Tweede lid.</al></lid>
+      </artikel>
+    </wettekst></toestand>"#;
+
+    let s = setup(fragmented, two_with_leden);
+    let (code, out) = run_rewrite(&s.law, &s.cache);
+
+    assert_eq!(code, Some(1), "{out}");
+    assert!(out.contains("rewrite refused"), "{out}");
+    assert_eq!(
+        std::fs::read_to_string(&s.law).expect("law still readable"),
+        fragmented
+    );
+}
+
 /// The guards must not block the job the rewrite exists for: correcting a
 /// drifted article against a sound official set.
 #[test]
@@ -175,6 +247,26 @@ fn test_a_drifted_article_is_still_corrected() {
     assert!(
         s.law.with_file_name(".source-context.yaml").exists(),
         "a completed rewrite writes the sidecar"
+    );
+}
+
+/// The pair is written law-file-last: when the sidecar cannot land, the
+/// law file must not have moved either. A directory squatting on the
+/// sidecar path makes exactly that rename fail while everything about the
+/// law file itself would succeed.
+#[test]
+fn test_a_failing_sidecar_write_leaves_the_law_file_untouched() {
+    let s = setup(LAW_YAML, TWO_ARTICLE_TOESTAND);
+    std::fs::create_dir(s.law.with_file_name(".source-context.yaml"))
+        .expect("squat the sidecar path");
+
+    let (code, out) = run_rewrite(&s.law, &s.cache);
+
+    assert_eq!(code, Some(1), "{out}");
+    assert_eq!(
+        std::fs::read_to_string(&s.law).expect("law still readable"),
+        LAW_YAML,
+        "the law file must not change when its sidecar cannot be written"
     );
 }
 

--- a/packages/pipeline/tests/law_source_cli.rs
+++ b/packages/pipeline/tests/law_source_cli.rs
@@ -1,0 +1,207 @@
+//! What `law-source --rewrite` does to the file on disk.
+//!
+//! The rewrite replaces a law file with what the official toestand says.
+//! When that toestand comes back empty or unrecognisably small, the file
+//! must survive untouched: an empty source set means the fetch or the
+//! parse failed, never that the law lost its articles. These tests run the
+//! real binary against a real file in a temp directory with a cached
+//! toestand, because the failure that motivated them erased a complete law
+//! from the corpus while the process reported success.
+
+use std::path::Path;
+use std::process::Command;
+
+const BWB_ID: &str = "BWBR0000001";
+const VALID_FROM: &str = "2024-01-01";
+
+/// A toestand that parses but holds no articles, the shape a changed
+/// response format or a wrong BWB id produces.
+const EMPTY_TOESTAND: &str =
+    r#"<toestand bwb-id="BWBR0000001"><wet-besluit><wettekst/></wet-besluit></toestand>"#;
+
+/// A toestand with the two articles the law actually has.
+const TWO_ARTICLE_TOESTAND: &str = r#"<toestand bwb-id="BWBR0000001">
+  <wettekst>
+    <artikel><kop><label>Artikel</label><nr>1</nr></kop>
+      <al>Eerste artikel, officiele tekst.</al>
+    </artikel>
+    <artikel><kop><label>Artikel</label><nr>2</nr></kop>
+      <al>Tweede artikel, officiele tekst.</al>
+    </artikel>
+  </wettekst>
+</toestand>"#;
+
+/// A law file with content worth protecting: two articles, one of them
+/// carrying a translation.
+const LAW_YAML: &str = r#"bwb_id: BWBR0000001
+valid_from: '2024-01-01'
+url: https://example.com/BWBR0000001
+articles:
+  - number: '1'
+    text: Eerste artikel, officiele tekst.
+    url: https://example.com/BWBR0000001#Artikel1
+    machine_readable:
+      outputs: []
+  - number: '2'
+    text: Tweede artikel, verouderde tekst.
+    url: https://example.com/BWBR0000001#Artikel2
+"#;
+
+struct Setup {
+    _dirs: (tempfile::TempDir, tempfile::TempDir),
+    law: std::path::PathBuf,
+    cache: std::path::PathBuf,
+}
+
+/// A law file in one temp directory, a cached toestand in another, so a
+/// permission change on the law directory cannot touch the cache.
+fn setup(law_yaml: &str, toestand_xml: &str) -> Setup {
+    let law_dir = tempfile::tempdir().expect("law dir");
+    let cache_dir = tempfile::tempdir().expect("cache dir");
+    let law = law_dir.path().join(format!("{VALID_FROM}.yaml"));
+    std::fs::write(&law, law_yaml).expect("write law");
+    std::fs::write(
+        cache_dir.path().join(format!("{BWB_ID}_{VALID_FROM}.xml")),
+        toestand_xml,
+    )
+    .expect("write cache");
+    Setup {
+        law,
+        cache: cache_dir.path().to_path_buf(),
+        _dirs: (law_dir, cache_dir),
+    }
+}
+
+fn run_rewrite(law: &Path, cache: &Path) -> (Option<i32>, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_law-source"))
+        .args([
+            "--offline",
+            "--rewrite",
+            "--cache",
+            cache.to_str().expect("utf-8 path"),
+            law.to_str().expect("utf-8 path"),
+        ])
+        .output()
+        .expect("the binary is built by cargo test");
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    (out.status.code(), text)
+}
+
+/// The failure that started this: an empty official set must not be read
+/// as "this law has no articles any more". The file keeps every article,
+/// every `machine_readable` and every link, and the run fails instead of
+/// reporting success.
+#[test]
+fn test_an_empty_official_set_leaves_the_law_file_untouched() {
+    let s = setup(LAW_YAML, EMPTY_TOESTAND);
+    let (code, out) = run_rewrite(&s.law, &s.cache);
+
+    assert_eq!(code, Some(1), "the gate must fail, not pass: {out}");
+    assert!(out.contains("rewrite refused"), "{out}");
+    assert_eq!(
+        std::fs::read_to_string(&s.law).expect("law still readable"),
+        LAW_YAML,
+        "the law file must be byte-for-byte what it was"
+    );
+    assert!(
+        !s.law.with_file_name(".source-context.yaml").exists(),
+        "a refused rewrite must not leave a sidecar"
+    );
+}
+
+/// A source set that would remove the majority of the file is the same
+/// emergency with something left over: refuse and keep the file.
+#[test]
+fn test_a_rewrite_that_removes_most_of_the_law_is_refused() {
+    // Six per-lid entries that all belong to official article 1. The
+    // whole-article rewrite would flatten them to one bare article,
+    // dropping the leden and the extra fields.
+    let fragmented = r#"bwb_id: BWBR0000001
+valid_from: '2024-01-01'
+url: https://example.com/BWBR0000001
+articles:
+  - number: '1.1'
+    text: Eerste lid.
+  - number: '1.2'
+    text: Tweede lid.
+  - number: 1.2.a
+    text: onderdeel a
+  - number: 1.2.b
+    text: onderdeel b
+  - number: 2.1
+    text: Ander eerste lid.
+  - number: 2.2
+    text: Ander tweede lid.
+"#;
+    let single_article = r#"<toestand bwb-id="BWBR0000001"><wettekst>
+      <artikel><kop><label>Artikel</label><nr>1</nr></kop>
+        <lid><lidnr>1</lidnr><al>Eerste lid.</al></lid>
+        <lid><lidnr>2</lidnr><al>Tweede lid.</al></lid>
+      </artikel>
+    </wettekst></toestand>"#;
+
+    let s = setup(fragmented, single_article);
+    let (code, out) = run_rewrite(&s.law, &s.cache);
+
+    assert_eq!(code, Some(1), "{out}");
+    assert!(out.contains("rewrite refused"), "{out}");
+    assert_eq!(
+        std::fs::read_to_string(&s.law).expect("law still readable"),
+        fragmented
+    );
+}
+
+/// The guards must not block the job the rewrite exists for: correcting a
+/// drifted article against a sound official set.
+#[test]
+fn test_a_drifted_article_is_still_corrected() {
+    let s = setup(LAW_YAML, TWO_ARTICLE_TOESTAND);
+    let (code, out) = run_rewrite(&s.law, &s.cache);
+
+    assert_eq!(code, Some(0), "{out}");
+    let rewritten = std::fs::read_to_string(&s.law).expect("law readable");
+    assert!(
+        rewritten.contains("Tweede artikel, officiele tekst."),
+        "the drifted text must be replaced: {rewritten}"
+    );
+    assert!(
+        rewritten.contains("machine_readable"),
+        "the translation must be carried over: {rewritten}"
+    );
+    assert!(
+        s.law.with_file_name(".source-context.yaml").exists(),
+        "a completed rewrite writes the sidecar"
+    );
+}
+
+/// A write that cannot complete must leave the law file exactly as it
+/// was. The old in-place write clobbered the file first and discovered the
+/// problem afterwards.
+#[cfg(unix)]
+#[test]
+fn test_a_failing_write_leaves_the_law_file_untouched() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let s = setup(LAW_YAML, TWO_ARTICLE_TOESTAND);
+    let law_dir = s.law.parent().expect("law dir").to_path_buf();
+
+    // Read-only directory: the existing file can still be opened and
+    // truncated in place, but no new file can be created in it, so the
+    // temp-file route fails cleanly where an in-place write would not.
+    std::fs::set_permissions(&law_dir, std::fs::Permissions::from_mode(0o555))
+        .expect("make law dir read-only");
+    let (code, out) = run_rewrite(&s.law, &s.cache);
+    std::fs::set_permissions(&law_dir, std::fs::Permissions::from_mode(0o755))
+        .expect("restore law dir");
+
+    assert_eq!(code, Some(1), "{out}");
+    assert_eq!(
+        std::fs::read_to_string(&s.law).expect("law still readable"),
+        LAW_YAML,
+        "a failed write must not have modified the law file"
+    );
+}


### PR DESCRIPTION
`law-source --rewrite` wiste bij een lege officiële artikelset de hele wet en meldde daarna `Ok(true)`. Zo verloor de Algemene wet inkomensafhankelijke regelingen 329 entries en al het vertaalwerk. Het rewrite-pad weigert nu vier vormen, met het `GateReport` als signaal in plaats van alleen de telling: een lege officiële set, een herschrijving zonder één `Verified` of `Drift`, minder dan de helft van de entries overhouden, en een entry die naar een lid of onderdeel wijst en `machine_readable` of `references` draagt. Die tweede dekt het verkeerde BWB-id: een bronset die niets deelt met het bestand is een andere wet, ook als de aantallen kloppen.

Fragmentatie zonder werk op de lid-entries wordt nog steeds platgeslagen, want de tekst overleeft in het hele artikel. Een uitwegvlag is er niet; elke weigering zegt in plaats daarvan wat de volgende stap is.

Het schrijven gaat per paar, met beide tempbestanden gesynct voordat er iets hernoemd wordt en het wetsbestand als laatste, zodat een onderbreking of een mislukte sidecar-write het wetsbestand ongemoeid laat. Elke bescherming heeft een test die op de oude code faalt.