### PR TITLE
feat(editor): integriteitspagina met traject-corpus-checks

### DIFF
--- a/frontend/src/TrajectIntegrityView.vue
+++ b/frontend/src/TrajectIntegrityView.vue
@@ -1,0 +1,46 @@
+<script setup>
+// Integriteitspagina van een traject: `/trajecten/{ref}/integriteit`.
+//
+// Top-level route (geen AppShell-child), net als de trajectkeuze en het
+// aanmaakformulier: de pagina draagt haar eigen top-title-bar met een terugknop
+// naar Instellingen, waar de link vandaan komt. Geen app-chrome, want dit is
+// een diagnose die je erbij pakt - geen sectie waar je in werkt.
+//
+// Het rapport zelf zit in TrajectIntegrityPane, zodat die los te testen is en
+// later ook in een paneel kan hangen.
+import { computed, watchEffect } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import TrajectIntegrityPane from './components/TrajectIntegrityPane.vue';
+
+const route = useRoute();
+const router = useRouter();
+
+const trajectRef = computed(() => route.params.trajectRef);
+
+watchEffect(() => {
+  document.title = 'Integriteit · RegelRecht';
+});
+
+function goBack() {
+  router.push({
+    name: 'instellingen-traject',
+    params: { trajectRef: trajectRef.value, tab: 'details' },
+  });
+}
+</script>
+
+<template>
+  <nldd-app-view>
+    <nldd-page sticky-header>
+      <nldd-top-title-bar
+        slot="header"
+        text="Integriteit"
+        back-text="Instellingen"
+        collapse-anchor="integriteit-pane-titel"
+        @back="goBack"
+      ></nldd-top-title-bar>
+
+      <TrajectIntegrityPane :traject-ref="trajectRef"></TrajectIntegrityPane>
+    </nldd-page>
+  </nldd-app-view>
+</template>

--- a/frontend/src/components/TrajectDetailsPane.vue
+++ b/frontend/src/components/TrajectDetailsPane.vue
@@ -199,7 +199,7 @@ async function confirmLeave() {
       <nldd-spacer size="24"></nldd-spacer>
       <nldd-list variant="box" arrow-navigation>
         <nldd-list-item size="md" button @click="openIntegrity">
-          <nldd-icon-cell size="20"><nldd-icon name="shield-check-mark"></nldd-icon></nldd-icon-cell>
+          <nldd-icon-cell size="20"><nldd-icon name="verified"></nldd-icon></nldd-icon-cell>
           <nldd-spacer-cell size="8"></nldd-spacer-cell>
           <nldd-text-cell
             text="Integriteit"

--- a/frontend/src/components/TrajectDetailsPane.vue
+++ b/frontend/src/components/TrajectDetailsPane.vue
@@ -3,6 +3,7 @@
 // Renders the detail list + owner-delete / contributor-leave, each behind a
 // confirmation modal. Loads on mount and whenever the traject changes.
 import { computed, nextTick, onMounted, ref, watch } from 'vue';
+import { useRouter } from 'vue-router';
 import {
   useTrajectDetail,
   writableSource,
@@ -10,6 +11,8 @@ import {
 } from '../composables/useTrajectDetail.js';
 import { deleteTraject, leaveTraject } from '../composables/useTrajects.js';
 import { paneChromeVisible } from '../constants.js';
+
+const router = useRouter();
 
 const props = defineProps({
   /** Traject to show (UUID id). */
@@ -41,6 +44,16 @@ const subpath = computed(() => {
 
 function orDash(v) {
   return v && String(v).trim() ? v : '—';
+}
+
+// De integriteitspagina hangt aan de URL-vorm van het traject (`{slug}-{8hex}`),
+// niet aan de UUID die deze pane verder gebruikt; `detail.ref` draagt die.
+function openIntegrity() {
+  if (!detail.value?.ref) return;
+  router.push({
+    name: 'traject-integriteit',
+    params: { trajectRef: detail.value.ref },
+  });
 }
 
 // --- Verwijderen (owner-only) ---
@@ -178,6 +191,25 @@ async function confirmLeave() {
         <nldd-text-cell :text="subpath"></nldd-text-cell>
       </nldd-list-item>
     </nldd-list>
+
+    <!-- Doorstap naar de integriteitspagina. Geen status of aantal hier: dat
+         zou de repo bij elke keer Instellingen openen opnieuw laten doorlezen,
+         terwijl je hier meestal iets heel anders komt doen. -->
+    <template v-if="detail.ref">
+      <nldd-spacer size="24"></nldd-spacer>
+      <nldd-list variant="box" arrow-navigation>
+        <nldd-list-item size="md" button @click="openIntegrity">
+          <nldd-icon-cell size="20"><nldd-icon name="shield-check-mark"></nldd-icon></nldd-icon-cell>
+          <nldd-spacer-cell size="8"></nldd-spacer-cell>
+          <nldd-text-cell
+            text="Integriteit"
+            supporting-text="Controleer de configuratie van het traject-corpus op mapnamen, dubbele wet-id's en verwijzingen die nergens uitkomen."
+          ></nldd-text-cell>
+          <nldd-spacer-cell size="8"></nldd-spacer-cell>
+          <nldd-icon-cell size="20"><nldd-icon name="chevron-right"></nldd-icon></nldd-icon-cell>
+        </nldd-list-item>
+      </nldd-list>
+    </template>
 
     <!-- De onomkeerbare actie in een eigen vlak, met een kopje erboven: zo zie je
          bij het scrollen dat er nog iets komt, in plaats van dat je een rode knop

--- a/frontend/src/components/TrajectIntegrityPane.test.js
+++ b/frontend/src/components/TrajectIntegrityPane.test.js
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import TrajectIntegrityPane from './TrajectIntegrityPane.vue';
+import { groupBySeverity } from '../composables/useTrajectIntegrity.js';
+
+// De pane haalt het rapport via useTrajectIntegrity -> apiFetchJson op; die
+// ene netwerkpoot sturen we hier (zelfde mock-vorm als TasksCategoriesPane).
+const apiFetchJson = vi.fn();
+vi.mock('../lib/apiFetch.js', () => ({
+  apiFetchJson: (...a) => apiFetchJson(...a),
+}));
+
+// Fictieve wetten en mapnamen: dit is een publieke repo, dus geen echte
+// traject- of repo-namen in fixtures.
+const ERROR_FINDING = {
+  severity: 'error',
+  kind: 'directory_name_mismatch',
+  path: 'waterschaps_verordening/hoogland/keur_alpha',
+  law_id: 'keur_alpha_hoogland',
+  message: "De wet in de map 'keur_alpha' heeft '$id: keur_alpha_hoogland'.",
+  remedy: "Hernoem de map naar 'keur_alpha_hoogland'.",
+};
+const WARNING_FINDING = {
+  severity: 'warning',
+  kind: 'scenario_directory_without_target',
+  path: 'wet/wet_alpha/scenarios',
+  law_id: 'wet_alpha',
+  message: "De scenario's evalueren 'wet_alpha' niet.",
+  remedy: 'Voeg een evaluatiestap toe.',
+};
+
+const CLEAN_REPORT = {
+  traject_ref: 'voorbeeldtraject-abcd1234',
+  source_id: 'traject-own',
+  checked_laws: 12,
+  checked_scenarios: 3,
+  findings: [],
+};
+const DIRTY_REPORT = {
+  ...CLEAN_REPORT,
+  findings: [ERROR_FINDING, WARNING_FINDING],
+};
+
+async function mountPane() {
+  const wrapper = mount(TrajectIntegrityPane, {
+    props: { trajectRef: 'voorbeeldtraject-abcd1234' },
+    attachTo: document.body,
+  });
+  // Flush de load() die onMounted aftrapt.
+  await wrapper.vm.$nextTick();
+  await Promise.resolve();
+  await Promise.resolve();
+  await wrapper.vm.$nextTick();
+  return wrapper;
+}
+
+describe('groupBySeverity', () => {
+  it('zet fouten boven waarschuwingen en laat lege groepen weg', () => {
+    const groups = groupBySeverity({ findings: [WARNING_FINDING, ERROR_FINDING] });
+    expect(groups.map((g) => g.severity)).toEqual(['error', 'warning']);
+    expect(groups[0].title).toBe('Fouten');
+    expect(groups[0].findings).toEqual([ERROR_FINDING]);
+  });
+
+  it('geeft een lege lijst voor een leeg of ontbrekend rapport', () => {
+    expect(groupBySeverity(null)).toEqual([]);
+    expect(groupBySeverity(CLEAN_REPORT)).toEqual([]);
+  });
+
+  it('laat een onbekende severity niet verdwijnen maar achteraan belanden', () => {
+    const groups = groupBySeverity({
+      findings: [{ ...WARNING_FINDING, severity: 'toekomstig' }, ERROR_FINDING],
+    });
+    expect(groups.map((g) => g.severity)).toEqual(['error', 'toekomstig']);
+  });
+});
+
+describe('TrajectIntegrityPane', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    apiFetchJson.mockReset();
+    document.body.innerHTML = '';
+  });
+
+  it('vraagt het rapport op voor het traject uit de props', async () => {
+    apiFetchJson.mockResolvedValue(CLEAN_REPORT);
+    await mountPane();
+    expect(apiFetchJson).toHaveBeenCalledTimes(1);
+    expect(apiFetchJson.mock.calls[0][0]).toBe(
+      '/api/trajects/voorbeeldtraject-abcd1234/integrity',
+    );
+  });
+
+  it('rendert de bevindingen gegroepeerd op severity, met omschrijving en remedie', async () => {
+    apiFetchJson.mockResolvedValue(DIRTY_REPORT);
+    const wrapper = await mountPane();
+    const html = wrapper.html();
+
+    // Beide koppen, met het aantal erbij.
+    expect(html).toContain('Fouten (1)');
+    expect(html).toContain('Waarschuwingen (1)');
+    // Fouten staan boven waarschuwingen.
+    expect(html.indexOf('Fouten (1)')).toBeLessThan(html.indexOf('Waarschuwingen (1)'));
+
+    // Elke bevinding draagt omschrijving + remedie + het pad waar hij zit.
+    const cells = wrapper.findAll('nldd-text-cell');
+    const error = cells.find((c) => c.attributes('text') === ERROR_FINDING.message);
+    expect(error).toBeTruthy();
+    expect(error.attributes('supporting-text')).toBe(ERROR_FINDING.remedy);
+    expect(error.attributes('overline')).toBe(ERROR_FINDING.path);
+
+    const warning = cells.find((c) => c.attributes('text') === WARNING_FINDING.message);
+    expect(warning.attributes('supporting-text')).toBe(WARNING_FINDING.remedy);
+
+    // Geen "alles in orde"-melding als er wél iets is.
+    expect(html).not.toContain('Geen problemen gevonden');
+  });
+
+  it('toont een bevestigende lege staat als er niets mis is', async () => {
+    apiFetchJson.mockResolvedValue(CLEAN_REPORT);
+    const wrapper = await mountPane();
+
+    const empty = wrapper
+      .findAll('nldd-inline-dialog')
+      .find((d) => d.attributes('text') === 'Geen problemen gevonden');
+    expect(empty).toBeTruthy();
+    expect(empty.attributes('variant')).toBe('success');
+    // De omvang van de controle staat erbij, anders leest "geen problemen"
+    // als "er is niets gecontroleerd".
+    expect(empty.attributes('supporting-text')).toContain('12 wetbestanden');
+    expect(empty.attributes('supporting-text')).toContain("3 scenario's");
+  });
+
+  it('toont de foutmelding van de backend als de controle niet kon draaien', async () => {
+    apiFetchJson.mockRejectedValue(new Error('GitHub is nu niet bereikbaar.'));
+    const wrapper = await mountPane();
+
+    const alert = wrapper
+      .findAll('nldd-inline-dialog')
+      .find((d) => d.attributes('variant') === 'alert');
+    expect(alert).toBeTruthy();
+    expect(alert.attributes('text')).toBe('Integriteitscontrole niet gelukt');
+    expect(alert.attributes('supporting-text')).toBe('GitHub is nu niet bereikbaar.');
+    // Geen rapport, dus ook geen lege staat die suggereert dat alles klopt.
+    expect(wrapper.html()).not.toContain('Geen problemen gevonden');
+  });
+
+  it('haalt het rapport opnieuw op via de verversknop', async () => {
+    apiFetchJson.mockResolvedValue(CLEAN_REPORT);
+    const wrapper = await mountPane();
+    expect(apiFetchJson).toHaveBeenCalledTimes(1);
+
+    const refresh = wrapper
+      .findAll('nldd-button')
+      .find((b) => b.attributes('text') === 'Opnieuw controleren');
+    expect(refresh).toBeTruthy();
+    await refresh.trigger('click');
+    await wrapper.vm.$nextTick();
+    expect(apiFetchJson).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/components/TrajectIntegrityPane.test.js
+++ b/frontend/src/components/TrajectIntegrityPane.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mount } from '@vue/test-utils';
 import TrajectIntegrityPane from './TrajectIntegrityPane.vue';
-import { groupBySeverity } from '../composables/useTrajectIntegrity.js';
+import { groupByLaw, impactSummary } from '../composables/useTrajectIntegrity.js';
 
 // De pane haalt het rapport via useTrajectIntegrity -> apiFetchJson op; die
 // ene netwerkpoot sturen we hier (zelfde mock-vorm als TasksCategoriesPane).
@@ -54,24 +54,65 @@ async function mountPane() {
   return wrapper;
 }
 
-describe('groupBySeverity', () => {
-  it('zet fouten boven waarschuwingen en laat lege groepen weg', () => {
-    const groups = groupBySeverity({ findings: [WARNING_FINDING, ERROR_FINDING] });
-    expect(groups.map((g) => g.severity)).toEqual(['error', 'warning']);
-    expect(groups[0].title).toBe('Fouten');
+describe('groupByLaw', () => {
+  it('groepeert per wet-map en zet de zwaarst getroffen wet bovenaan', () => {
+    const groups = groupByLaw({ findings: [WARNING_FINDING, ERROR_FINDING] });
+    expect(groups.map((g) => g.title)).toEqual(['keur_alpha', 'wet_alpha']);
     expect(groups[0].findings).toEqual([ERROR_FINDING]);
+    expect(groups[0].counts).toBe('1 fout');
+    expect(groups[1].counts).toBe('1 waarschuwing');
+  });
+
+  it('herleidt de wet-map uit versiebestanden en scenariopaden', () => {
+    const inFile = { ...ERROR_FINDING, path: 'wet/wet_alpha/2024-01-01.yaml' };
+    const inScenario = { ...WARNING_FINDING, path: 'wet/wet_alpha/scenarios/basis.feature' };
+    const groups = groupByLaw({ findings: [inFile, inScenario] });
+    expect(groups).toHaveLength(1);
+    expect(groups[0].title).toBe('wet_alpha');
+    // Binnen de wet: fouten boven waarschuwingen.
+    expect(groups[0].findings).toEqual([inFile, inScenario]);
+    expect(groups[0].counts).toBe('1 fout, 1 waarschuwing');
+  });
+
+  it('sorteert op impact: meer fouten eerst, dan waarschuwingen, dan alfabet', () => {
+    const twoErrors = [
+      { ...ERROR_FINDING, path: 'wet/wet_zwaar/a.yaml' },
+      { ...ERROR_FINDING, path: 'wet/wet_zwaar/b.yaml' },
+    ];
+    const groups = groupByLaw({
+      findings: [WARNING_FINDING, ERROR_FINDING, ...twoErrors],
+    });
+    expect(groups.map((g) => g.title)).toEqual(['wet_zwaar', 'keur_alpha', 'wet_alpha']);
   });
 
   it('geeft een lege lijst voor een leeg of ontbrekend rapport', () => {
-    expect(groupBySeverity(null)).toEqual([]);
-    expect(groupBySeverity(CLEAN_REPORT)).toEqual([]);
+    expect(groupByLaw(null)).toEqual([]);
+    expect(groupByLaw(CLEAN_REPORT)).toEqual([]);
   });
 
-  it('laat een onbekende severity niet verdwijnen maar achteraan belanden', () => {
-    const groups = groupBySeverity({
-      findings: [{ ...WARNING_FINDING, severity: 'toekomstig' }, ERROR_FINDING],
-    });
-    expect(groups.map((g) => g.severity)).toEqual(['error', 'toekomstig']);
+  it('zet bevindingen zonder pad samen in een traject-brede groep', () => {
+    const pathless = { ...ERROR_FINDING, path: null };
+    const groups = groupByLaw({ findings: [pathless] });
+    expect(groups.map((g) => g.title)).toEqual(['Traject-breed']);
+  });
+
+  it('laat een onbekende severity niet verdwijnen maar achteraan in de groep belanden', () => {
+    const future = { ...ERROR_FINDING, severity: 'toekomstig' };
+    const groups = groupByLaw({ findings: [future, ERROR_FINDING] });
+    expect(groups[0].findings).toEqual([ERROR_FINDING, future]);
+    expect(groups[0].counts).toBe('1 fout, 1 overig');
+  });
+});
+
+describe('impactSummary', () => {
+  it('telt het totaal en over hoeveel wetten het verdeeld is', () => {
+    expect(impactSummary({ findings: [ERROR_FINDING, WARNING_FINDING] })).toBe(
+      'In totaal 1 fout, 1 waarschuwing, verdeeld over 2 wetten.',
+    );
+  });
+
+  it('is leeg zonder bevindingen', () => {
+    expect(impactSummary(CLEAN_REPORT)).toBeNull();
   });
 });
 
@@ -91,18 +132,23 @@ describe('TrajectIntegrityPane', () => {
     );
   });
 
-  it('rendert de bevindingen gegroepeerd op severity, met omschrijving en remedie', async () => {
+  it('rendert de bevindingen gegroepeerd per wet, zwaarst getroffen eerst', async () => {
     apiFetchJson.mockResolvedValue(DIRTY_REPORT);
     const wrapper = await mountPane();
     const html = wrapper.html();
 
-    // Beide koppen, met het aantal erbij.
-    expect(html).toContain('Fouten (1)');
-    expect(html).toContain('Waarschuwingen (1)');
-    // Fouten staan boven waarschuwingen.
-    expect(html.indexOf('Fouten (1)')).toBeLessThan(html.indexOf('Waarschuwingen (1)'));
+    // Eén kop per wet, met de tellers erbij; de wet met de fout bovenaan.
+    expect(html).toContain('keur_alpha (1 fout)');
+    expect(html).toContain('wet_alpha (1 waarschuwing)');
+    expect(html.indexOf('keur_alpha (1 fout)')).toBeLessThan(
+      html.indexOf('wet_alpha (1 waarschuwing)'),
+    );
 
-    // Elke bevinding draagt omschrijving + remedie + het pad waar hij zit.
+    // De impactregel geeft het rapport zijn maat.
+    expect(html).toContain('In totaal 1 fout, 1 waarschuwing, verdeeld over 2 wetten.');
+
+    // Elke bevinding draagt omschrijving + remedie + het pad waar hij zit,
+    // en een eigen severity-icoon (fouten en waarschuwingen mengen per wet).
     const cells = wrapper.findAll('nldd-text-cell');
     const error = cells.find((c) => c.attributes('text') === ERROR_FINDING.message);
     expect(error).toBeTruthy();
@@ -111,6 +157,10 @@ describe('TrajectIntegrityPane', () => {
 
     const warning = cells.find((c) => c.attributes('text') === WARNING_FINDING.message);
     expect(warning.attributes('supporting-text')).toBe(WARNING_FINDING.remedy);
+
+    const icons = wrapper.findAll('nldd-icon').map((i) => i.attributes('name'));
+    expect(icons).toContain('error');
+    expect(icons).toContain('warning');
 
     // Geen "alles in orde"-melding als er wél iets is.
     expect(html).not.toContain('Geen problemen gevonden');

--- a/frontend/src/components/TrajectIntegrityPane.vue
+++ b/frontend/src/components/TrajectIntegrityPane.vue
@@ -85,7 +85,7 @@ function scopeSummary(r) {
       <nldd-inline-dialog
         v-if="!hasFindings"
         variant="success"
-        icon="seal-check-mark"
+        icon="certified"
         text="Geen problemen gevonden"
         :supporting-text="scopeSummary(report)"
       ></nldd-inline-dialog>

--- a/frontend/src/components/TrajectIntegrityPane.vue
+++ b/frontend/src/components/TrajectIntegrityPane.vue
@@ -12,7 +12,7 @@
 // en bij de verversknop - niet periodiek: het rapport verandert alleen als er
 // gepusht wordt, en dan weet de gebruiker dat zelf.
 import { onMounted, watch } from 'vue';
-import { useTrajectIntegrity } from '../composables/useTrajectIntegrity.js';
+import { SEVERITY_ICONS, useTrajectIntegrity } from '../composables/useTrajectIntegrity.js';
 import { paneChromeVisible } from '../constants.js';
 
 const props = defineProps({
@@ -20,7 +20,7 @@ const props = defineProps({
   trajectRef: { type: String, default: null },
 });
 
-const { report, groups, hasFindings, loading, error, load } = useTrajectIntegrity();
+const { report, groups, summary, hasFindings, loading, error, load } = useTrajectIntegrity();
 
 function reload() {
   load(props.trajectRef);
@@ -92,21 +92,23 @@ function scopeSummary(r) {
 
       <template v-else>
         <nldd-rich-text>
-          <p>{{ scopeSummary(report) }}</p>
+          <p>{{ scopeSummary(report) }} {{ summary }}</p>
         </nldd-rich-text>
         <nldd-spacer size="16"></nldd-spacer>
 
-        <template v-for="group in groups" :key="group.severity">
-          <nldd-title size="5"><h4>{{ group.title }} ({{ group.findings.length }})</h4></nldd-title>
+        <!-- Per wet, zwaarst getroffen eerst; het severity-icoon staat per
+             bevinding, want binnen één wet mengen fouten en waarschuwingen. -->
+        <template v-for="group in groups" :key="group.key">
+          <nldd-title size="5"><h4>{{ group.title }} ({{ group.counts }})</h4></nldd-title>
           <nldd-spacer size="8"></nldd-spacer>
           <nldd-list variant="box">
             <nldd-list-item
               v-for="(finding, i) in group.findings"
-              :key="`${group.severity}-${i}`"
+              :key="`${group.key}-${i}`"
               size="md"
             >
               <nldd-icon-cell size="20" vertical-alignment="top">
-                <nldd-icon :name="group.icon"></nldd-icon>
+                <nldd-icon :name="SEVERITY_ICONS[finding.severity] ?? 'info'"></nldd-icon>
               </nldd-icon-cell>
               <nldd-spacer-cell size="8"></nldd-spacer-cell>
               <nldd-text-cell

--- a/frontend/src/components/TrajectIntegrityPane.vue
+++ b/frontend/src/components/TrajectIntegrityPane.vue
@@ -1,0 +1,125 @@
+<script setup>
+// Integriteitsrapport van een traject: wat er mis is met de configuratie van
+// het traject-corpus, en per bevinding wat je eraan doet.
+//
+// De aanleiding: de wettenindex leest een wet-id af van de mapnaam, terwijl de
+// editor na het laden overgaat op het `$id` uit de YAML. Wijken die af, dan
+// mislukt alles wat daarna komt met "niet gevonden" - zonder dat ergens staat
+// waarom. Deze pagina maakt dat zichtbaar, met de remedie erbij.
+//
+// De pane doet zelf de netwerkpoot (zoals TrajectDetailsPane) zodat hij zowel
+// als losse pagina als in een paneel te gebruiken is. Laden gebeurt bij mount
+// en bij de verversknop - niet periodiek: het rapport verandert alleen als er
+// gepusht wordt, en dan weet de gebruiker dat zelf.
+import { onMounted, watch } from 'vue';
+import { useTrajectIntegrity } from '../composables/useTrajectIntegrity.js';
+import { paneChromeVisible } from '../constants.js';
+
+const props = defineProps({
+  /** Traject-ref uit de URL (`{slug}-{8hex}`). */
+  trajectRef: { type: String, default: null },
+});
+
+const { report, groups, hasFindings, loading, error, load } = useTrajectIntegrity();
+
+function reload() {
+  load(props.trajectRef);
+}
+onMounted(reload);
+watch(() => props.trajectRef, reload);
+
+/**
+ * Samenvattende regel onder de titel: hoeveel is er nagekeken. Zonder dit
+ * leest "Geen problemen gevonden" als "er is niets gecontroleerd".
+ */
+function scopeSummary(r) {
+  if (!r) return null;
+  const laws = `${r.checked_laws} ${r.checked_laws === 1 ? 'wetbestand' : 'wetbestanden'}`;
+  const scenarios = `${r.checked_scenarios} ${r.checked_scenarios === 1 ? 'scenario' : "scenario's"}`;
+  return `${laws} en ${scenarios} nagekeken in de eigen repo van dit traject.`;
+}
+</script>
+
+<template>
+  <nldd-simple-section>
+    <nldd-title v-if="paneChromeVisible(loading)" id="integriteit-pane-titel" size="3"><h3>Integriteit</h3></nldd-title>
+    <nldd-spacer v-if="paneChromeVisible(loading)" size="8"></nldd-spacer>
+    <nldd-rich-text v-if="paneChromeVisible(loading)">
+      <p>
+        Controle op de configuratie van het traject-corpus: mapnamen,
+        bestandsnamen, dubbele wet-id's en verwijzingen die nergens uitkomen.
+      </p>
+    </nldd-rich-text>
+    <nldd-spacer v-if="paneChromeVisible(loading)" size="16"></nldd-spacer>
+    <nldd-toolbar v-if="paneChromeVisible(loading)" label="Integriteitsacties">
+      <nldd-toolbar-item slot="start">
+        <nldd-button
+          variant="secondary"
+          size="md"
+          start-icon="refresh"
+          text="Opnieuw controleren"
+          :disabled="loading || undefined"
+          @click="reload"
+        ></nldd-button>
+      </nldd-toolbar-item>
+    </nldd-toolbar>
+    <nldd-spacer v-if="paneChromeVisible(loading)" size="16"></nldd-spacer>
+
+    <nldd-activity-indicator
+      v-if="loading"
+      text="Integriteit controleren"
+      show-text
+    ></nldd-activity-indicator>
+
+    <nldd-inline-dialog
+      v-else-if="error"
+      variant="alert"
+      text="Integriteitscontrole niet gelukt"
+      :supporting-text="error.message || 'De gegevens konden niet worden opgehaald.'"
+    >
+      <nldd-button slot="actions" variant="primary" text="Probeer opnieuw" @click="reload"></nldd-button>
+    </nldd-inline-dialog>
+
+    <template v-else-if="report">
+      <!-- Lege staat: bevestigend, en met de omvang van de controle erbij. -->
+      <nldd-inline-dialog
+        v-if="!hasFindings"
+        variant="success"
+        icon="seal-check-mark"
+        text="Geen problemen gevonden"
+        :supporting-text="scopeSummary(report)"
+      ></nldd-inline-dialog>
+
+      <template v-else>
+        <nldd-rich-text>
+          <p>{{ scopeSummary(report) }}</p>
+        </nldd-rich-text>
+        <nldd-spacer size="16"></nldd-spacer>
+
+        <template v-for="group in groups" :key="group.severity">
+          <nldd-title size="5"><h4>{{ group.title }} ({{ group.findings.length }})</h4></nldd-title>
+          <nldd-spacer size="8"></nldd-spacer>
+          <nldd-list variant="box">
+            <nldd-list-item
+              v-for="(finding, i) in group.findings"
+              :key="`${group.severity}-${i}`"
+              size="md"
+            >
+              <nldd-icon-cell size="20" vertical-alignment="top">
+                <nldd-icon :name="group.icon"></nldd-icon>
+              </nldd-icon-cell>
+              <nldd-spacer-cell size="8"></nldd-spacer-cell>
+              <nldd-text-cell
+                vertical-alignment="top"
+                :overline="finding.path || finding.law_id || undefined"
+                :text="finding.message"
+                :supporting-text="finding.remedy"
+              ></nldd-text-cell>
+            </nldd-list-item>
+          </nldd-list>
+          <nldd-spacer size="24"></nldd-spacer>
+        </template>
+      </template>
+    </template>
+  </nldd-simple-section>
+</template>

--- a/frontend/src/composables/useTrajectIntegrity.js
+++ b/frontend/src/composables/useTrajectIntegrity.js
@@ -1,0 +1,90 @@
+/**
+ * useTrajectIntegrity - haalt het integriteitsrapport van een traject op
+ * (`GET /api/trajects/:trajectRef/integrity`).
+ *
+ * Het rapport is een momentopname van de traject-branch: elke aanroep laat de
+ * backend de repo opnieuw doorlopen (die cachet zelf op blob-sha's, dus een
+ * herhaalde aanroep zonder nieuwe commits is goedkoop). De pagina laadt daarom
+ * bij openen en bij een expliciete verversing - er wordt niet gepolld.
+ *
+ * Zelfde vorm als `useTrajectDetail`: verse state per aanroep, `loading` en
+ * `error` als refs, en de state wordt vóór de await gewist zodat een tweede
+ * aanroep niet even het vorige rapport laat staan.
+ */
+import { computed, ref } from 'vue';
+import { apiFetchJson } from '../lib/apiFetch.js';
+
+/**
+ * Volgorde waarin bevindingen op de pagina staan: fouten (breken nu iets)
+ * boven waarschuwingen (waarschijnlijk een vergissing, werkt nog wel).
+ */
+export const SEVERITY_ORDER = ['error', 'warning'];
+
+/** Kop en icoon per severity-groep. */
+export const SEVERITY_LABELS = {
+  error: { title: 'Fouten', icon: 'error' },
+  warning: { title: 'Waarschuwingen', icon: 'warning' },
+};
+
+/**
+ * Groepeer de bevindingen van een rapport op severity, in de vaste volgorde
+ * van `SEVERITY_ORDER`. Lege groepen komen niet terug, zodat de pagina alleen
+ * koppen toont die ook bevindingen hebben. Een onbekende severity (nieuwe
+ * backend, oude frontend) belandt achteraan in plaats van te verdwijnen.
+ *
+ * @param {{findings?: Array}|null} report
+ * @returns {Array<{severity: string, title: string, icon: string, findings: Array}>}
+ */
+export function groupBySeverity(report) {
+  const findings = report?.findings ?? [];
+  const bySeverity = new Map();
+  for (const finding of findings) {
+    const key = finding?.severity ?? 'error';
+    if (!bySeverity.has(key)) bySeverity.set(key, []);
+    bySeverity.get(key).push(finding);
+  }
+  const known = SEVERITY_ORDER.filter((s) => bySeverity.has(s));
+  const unknown = [...bySeverity.keys()].filter((s) => !SEVERITY_ORDER.includes(s));
+  return [...known, ...unknown].map((severity) => ({
+    severity,
+    title: SEVERITY_LABELS[severity]?.title ?? severity,
+    icon: SEVERITY_LABELS[severity]?.icon ?? 'info',
+    findings: bySeverity.get(severity),
+  }));
+}
+
+export function useTrajectIntegrity() {
+  const report = ref(null);
+  const loading = ref(false);
+  const error = ref(null);
+
+  async function load(trajectRef) {
+    if (!trajectRef) return;
+    // Wissen vóór de await: een tweede aanroep (verversen, ander traject) mag
+    // het oude rapport niet laten staan terwijl het nieuwe onderweg is.
+    loading.value = true;
+    error.value = null;
+    report.value = null;
+    try {
+      report.value = await apiFetchJson(
+        `/api/trajects/${encodeURIComponent(trajectRef)}/integrity`,
+        {
+          // De backend schrijft zijn eigen Nederlandse uitleg in de body
+          // (bijv. "GitHub is nu niet bereikbaar..."); die is nuttiger dan
+          // een statuscode, dus die tonen we als hij er is.
+          errorMessage: (status, body) =>
+            body?.trim() || `Integriteitscontrole mislukt: ${status}`,
+        },
+      );
+    } catch (e) {
+      error.value = e;
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  const groups = computed(() => groupBySeverity(report.value));
+  const hasFindings = computed(() => (report.value?.findings?.length ?? 0) > 0);
+
+  return { report, groups, hasFindings, loading, error, load };
+}

--- a/frontend/src/composables/useTrajectIntegrity.js
+++ b/frontend/src/composables/useTrajectIntegrity.js
@@ -15,42 +15,105 @@ import { computed, ref } from 'vue';
 import { apiFetchJson } from '../lib/apiFetch.js';
 
 /**
- * Volgorde waarin bevindingen op de pagina staan: fouten (breken nu iets)
- * boven waarschuwingen (waarschijnlijk een vergissing, werkt nog wel).
+ * Volgorde waarin bevindingen binnen een wet-groep staan: fouten (breken nu
+ * iets) boven waarschuwingen (waarschijnlijk een vergissing, werkt nog wel).
  */
 export const SEVERITY_ORDER = ['error', 'warning'];
 
-/** Kop en icoon per severity-groep. */
-export const SEVERITY_LABELS = {
-  error: { title: 'Fouten', icon: 'error' },
-  warning: { title: 'Waarschuwingen', icon: 'warning' },
-};
+/** Icoon per severity, voor het icoon vóór elke bevinding. */
+export const SEVERITY_ICONS = { error: 'error', warning: 'warning' };
+
+/** Groepstitel voor bevindingen die niet bij één wet horen. */
+const TRAJECT_WIDE_TITLE = 'Traject-breed';
 
 /**
- * Groepeer de bevindingen van een rapport op severity, in de vaste volgorde
- * van `SEVERITY_ORDER`. Lege groepen komen niet terug, zodat de pagina alleen
- * koppen toont die ook bevindingen hebben. Een onbekende severity (nieuwe
- * backend, oude frontend) belandt achteraan in plaats van te verdwijnen.
+ * De wet-map waar een bevinding bij hoort, afgeleid uit het pad. Alle checks
+ * wijzen met `path` een plek in de map van een wet aan: de map zelf, een
+ * versiebestand erin, of (een bestand in) de `scenarios/`-map ernaast. De
+ * mapnaam - niet het `$id` - is de groepssleutel: bij een mapnaam≠$id-mismatch
+ * is de map het enige anker dat alle bevindingen van die wet delen.
+ */
+function lawDirFromPath(path) {
+  const segments = (path ?? '').split('/').filter(Boolean);
+  // Laatste segment met een punt is een bestandsnaam (wetten heten
+  // `<datum>.yaml`, scenario's `<naam>.feature`), geen map.
+  if (segments.length && segments[segments.length - 1].includes('.')) segments.pop();
+  if (segments.length && segments[segments.length - 1] === 'scenarios') segments.pop();
+  return segments[segments.length - 1] ?? null;
+}
+
+/** "2 fouten", "1 waarschuwing" - de teller in een groepskop. */
+function countsLabel(findings) {
+  const errors = findings.filter((f) => f.severity === 'error').length;
+  const warnings = findings.filter((f) => f.severity === 'warning').length;
+  const parts = [];
+  if (errors) parts.push(`${errors} ${errors === 1 ? 'fout' : 'fouten'}`);
+  if (warnings) parts.push(`${warnings} ${warnings === 1 ? 'waarschuwing' : 'waarschuwingen'}`);
+  const rest = findings.length - errors - warnings;
+  if (rest) parts.push(`${rest} overig`);
+  return parts.join(', ');
+}
+
+/**
+ * Groepeer de bevindingen van een rapport per wet (mapnaam uit het pad), de
+ * zwaarst getroffen wet eerst. Zo leest een lang rapport als "deze wetten
+ * hebben aandacht nodig" in plaats van één ongesorteerde foutenlijst.
+ *
+ * - Binnen een groep: fouten boven waarschuwingen (`SEVERITY_ORDER`); een
+ *   onbekende severity (nieuwe backend, oude frontend) belandt achteraan in
+ *   plaats van te verdwijnen.
+ * - Groepen onderling: meeste fouten eerst, dan meeste waarschuwingen, dan
+ *   alfabetisch - impact bovenaan.
+ * - Bevindingen zonder pad krijgen samen de groep "Traject-breed".
  *
  * @param {{findings?: Array}|null} report
- * @returns {Array<{severity: string, title: string, icon: string, findings: Array}>}
+ * @returns {Array<{key: string, title: string, counts: string, findings: Array}>}
  */
-export function groupBySeverity(report) {
+export function groupByLaw(report) {
   const findings = report?.findings ?? [];
-  const bySeverity = new Map();
+  const byLaw = new Map();
   for (const finding of findings) {
-    const key = finding?.severity ?? 'error';
-    if (!bySeverity.has(key)) bySeverity.set(key, []);
-    bySeverity.get(key).push(finding);
+    const dir = lawDirFromPath(finding?.path);
+    const key = dir ?? TRAJECT_WIDE_TITLE;
+    if (!byLaw.has(key)) byLaw.set(key, []);
+    byLaw.get(key).push(finding);
   }
-  const known = SEVERITY_ORDER.filter((s) => bySeverity.has(s));
-  const unknown = [...bySeverity.keys()].filter((s) => !SEVERITY_ORDER.includes(s));
-  return [...known, ...unknown].map((severity) => ({
-    severity,
-    title: SEVERITY_LABELS[severity]?.title ?? severity,
-    icon: SEVERITY_LABELS[severity]?.icon ?? 'info',
-    findings: bySeverity.get(severity),
-  }));
+  const severityRank = (f) => {
+    const i = SEVERITY_ORDER.indexOf(f?.severity);
+    return i === -1 ? SEVERITY_ORDER.length : i;
+  };
+  const groups = [...byLaw.entries()].map(([key, group]) => {
+    const sorted = [...group].sort((a, b) => severityRank(a) - severityRank(b));
+    return {
+      key,
+      title: key,
+      counts: countsLabel(sorted),
+      errorCount: sorted.filter((f) => f.severity === 'error').length,
+      warningCount: sorted.filter((f) => f.severity === 'warning').length,
+      findings: sorted,
+    };
+  });
+  groups.sort(
+    (a, b) =>
+      b.errorCount - a.errorCount ||
+      b.warningCount - a.warningCount ||
+      a.title.localeCompare(b.title),
+  );
+  return groups;
+}
+
+/**
+ * Samenvattende impactregel boven de groepen: het totaal, en over hoeveel
+ * wetten het verdeeld is. Geeft een lang rapport in één zin zijn maat.
+ */
+export function impactSummary(report) {
+  const groups = groupByLaw(report);
+  if (!groups.length) return null;
+  const total = countsLabel(groups.flatMap((g) => g.findings));
+  const laws = groups.filter((g) => g.title !== TRAJECT_WIDE_TITLE).length;
+  const spread =
+    laws > 1 ? `, verdeeld over ${laws} wetten` : laws === 1 ? ', in één wet' : '';
+  return `In totaal ${total}${spread}.`;
 }
 
 export function useTrajectIntegrity() {
@@ -83,8 +146,9 @@ export function useTrajectIntegrity() {
     }
   }
 
-  const groups = computed(() => groupBySeverity(report.value));
+  const groups = computed(() => groupByLaw(report.value));
+  const summary = computed(() => impactSummary(report.value));
   const hasFindings = computed(() => (report.value?.findings?.length ?? 0) > 0);
 
-  return { report, groups, hasFindings, loading, error, load };
+  return { report, groups, summary, hasFindings, loading, error, load };
 }

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -193,6 +193,19 @@ const router = createRouter({
       meta: { title: 'Trajecten', requiresAuth: true },
     },
     {
+      // Integriteit van een traject: de runtime-diagnose van het
+      // traject-corpus (mapnamen vs `$id`, dubbele id's, losse verwijzingen).
+      // Top-level route zoals de trajectkeuze: eigen chrome, geen app-shell -
+      // je pakt deze pagina erbij vanuit Instellingen en gaat daarna terug.
+      //
+      // `:trajectRef` is met hetzelfde `{slug}-{8hex}`-patroon gepind als de
+      // andere traject-routes, zodat een wet-slug hier nooit op matcht.
+      path: '/trajecten/:trajectRef([a-z0-9-]+-[0-9a-f]{8})/integriteit',
+      name: 'traject-integriteit',
+      component: () => import('./TrajectIntegrityView.vue'),
+      meta: { title: 'Integriteit', requiresAuth: true },
+    },
+    {
       // Nieuw traject aanmaken - eigen pagina met het gedeelde aanmaakformulier
       // (TrajectCreateForm). Ook top-level (geen app-chrome). Het statische pad
       // `/editor/nieuw-traject` scoort boven de dynamische `/editor/...`-routes

--- a/frontend/src/router.test.js
+++ b/frontend/src/router.test.js
@@ -65,6 +65,17 @@ describe('route disambiguation (traject vs no-traject)', () => {
     expect(r.params.lawId).toBeUndefined();
   });
 
+  // De integriteitspagina is een top-level route (eigen chrome), maar deelt
+  // het `/trajecten/{ref}/...`-pad met de AppShell-kinderen. Deze test pint
+  // vast dat hij daar niet door een van die kinderen wordt opgeslokt.
+  it('routes a traject integriteit URL to traject-integriteit', () => {
+    const r = router.resolve(`/trajecten/${REF}/integriteit`);
+    expect(r.name).toBe('traject-integriteit');
+    expect(r.params.trajectRef).toBe(REF);
+    expect(r.meta.requiresAuth).toBe(true);
+    expect(r.meta.title).toBe('Integriteit');
+  });
+
   it('routes a plain law-id corpus URL to corpus-juris (no traject)', () => {
     const r = router.resolve('/corpus-juris/wet_op_de_zorgtoeslag');
     expect(r.name).toBe('corpus-juris');

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -4118,6 +4118,7 @@ dependencies = [
  "regelrecht-auth",
  "regelrecht-corpus",
  "regelrecht-github",
+ "regelrecht-law-model",
  "regelrecht-pipeline",
  "regelrecht-shared",
  "reqwest 0.12.28",

--- a/packages/corpus/src/source_map.rs
+++ b/packages/corpus/src/source_map.rs
@@ -882,6 +882,104 @@ fn collect_implements_from_doc(doc: &LawDoc) -> Vec<String> {
     out
 }
 
+/// How one law points at another.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LawReferenceKind {
+    /// An input field resolved from another law's output
+    /// (`source: {regulation: …, output: …}`).
+    SourceRegulation,
+    /// The IoC link from a lower regulation to the higher law whose
+    /// `open_term` it fills (`machine_readable.implements[].law`).
+    Implements,
+}
+
+/// One `$id` a law body points at, with the kind of link it came from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LawReference {
+    pub law_id: String,
+    pub kind: LawReferenceKind,
+}
+
+/// Collect every other law `$id` this body points at: the `source.regulation`
+/// targets of its input fields plus its `implements` declarations. Each
+/// `(kind, id)` pair appears at most once; order of first occurrence is kept.
+///
+/// Deliberately a **structural walk** over the parsed document rather than a
+/// path-pinned lookup: this feeds the integrity report, whose whole job is to
+/// find dangling references, so it must not silently miss one that sits at a
+/// nesting the schema grows later. A body that does not parse yields no
+/// references (the caller reports the parse failure separately) — same
+/// tolerance as [`collect_law_implements`].
+pub fn collect_law_references(yaml: &str) -> Vec<LawReference> {
+    let value: serde_yaml_ng::Value = match serde_yaml_ng::from_str(yaml) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+    let mut seen = HashSet::new();
+    let mut out = Vec::new();
+    walk_law_references(&value, &mut seen, &mut out);
+    out
+}
+
+/// Record one reference, unless the same `(kind, id)` was already seen.
+fn push_law_reference(
+    kind: LawReferenceKind,
+    id: &str,
+    seen: &mut HashSet<(LawReferenceKind, String)>,
+    out: &mut Vec<LawReference>,
+) {
+    if !id.is_empty() && seen.insert((kind, id.to_string())) {
+        out.push(LawReference {
+            law_id: id.to_string(),
+            kind,
+        });
+    }
+}
+
+/// Recursive half of [`collect_law_references`].
+fn walk_law_references(
+    value: &serde_yaml_ng::Value,
+    seen: &mut HashSet<(LawReferenceKind, String)>,
+    out: &mut Vec<LawReference>,
+) {
+    match value {
+        serde_yaml_ng::Value::Mapping(map) => {
+            for (key, child) in map {
+                match key.as_str() {
+                    // `source: {regulation: "other_law", output: …}`
+                    Some("source") => {
+                        if let Some(id) = child.get("regulation").and_then(|v| v.as_str()) {
+                            push_law_reference(LawReferenceKind::SourceRegulation, id, seen, out);
+                        }
+                    }
+                    // `implements: [{law: "higher_law", …}]`
+                    Some("implements") => {
+                        if let Some(items) = child.as_sequence() {
+                            for item in items {
+                                if let Some(id) = item.get("law").and_then(|v| v.as_str()) {
+                                    push_law_reference(LawReferenceKind::Implements, id, seen, out);
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            // Recurse after the direct matches so `out` follows the document
+            // order rather than the recursion's.
+            for (_, child) in map {
+                walk_law_references(child, seen, out);
+            }
+        }
+        serde_yaml_ng::Value::Sequence(items) => {
+            for item in items {
+                walk_law_references(item, seen, out);
+            }
+        }
+        _ => {}
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -1591,5 +1689,71 @@ articles:
         // Malformed YAML: Err — the index generator must fail on this
         // instead of committing "implements nothing".
         assert!(try_collect_law_implements("not: [valid").is_err());
+    }
+
+    #[test]
+    fn test_collect_law_references_picks_up_both_link_kinds() {
+        let yaml = "\
+$id: wet_a
+articles:
+  - number: '1'
+    machine_readable:
+      execution:
+        input:
+          - name: inkomen
+            type: amount
+            source:
+              regulation: wet_b
+              output: toetsingsinkomen
+          - name: verzekerd
+            type: boolean
+            source:
+              regulation: wet_c
+              output: is_verzekerd
+      implements:
+        - law: wet_d
+          article: '4'
+          open_term: tarief
+";
+        assert_eq!(
+            collect_law_references(yaml),
+            vec![
+                LawReference {
+                    law_id: "wet_d".to_string(),
+                    kind: LawReferenceKind::Implements,
+                },
+                LawReference {
+                    law_id: "wet_b".to_string(),
+                    kind: LawReferenceKind::SourceRegulation,
+                },
+                LawReference {
+                    law_id: "wet_c".to_string(),
+                    kind: LawReferenceKind::SourceRegulation,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_collect_law_references_dedupes_and_tolerates_garbage() {
+        let yaml = "\
+$id: wet_a
+articles:
+  - number: '1'
+    machine_readable:
+      execution:
+        input:
+          - name: een
+            source:
+              regulation: wet_b
+              output: x
+          - name: twee
+            source:
+              regulation: wet_b
+              output: y
+";
+        assert_eq!(collect_law_references(yaml).len(), 1);
+        assert!(collect_law_references("not: [valid").is_empty());
+        assert!(collect_law_references("$id: wet_a\narticles: []\n").is_empty());
     }
 }

--- a/packages/editor-api/Cargo.toml
+++ b/packages/editor-api/Cargo.toml
@@ -21,6 +21,7 @@ regelrecht-auth = { path = "../auth" }
 regelrecht-shared = { path = "../shared", features = ["telemetry"] }
 regelrecht-corpus = { path = "../corpus", features = ["github", "annotation-validation"] }
 regelrecht-github = { path = "../github" }
+regelrecht-law-model = { path = "../law-model" }
 regelrecht-pipeline = { path = "../pipeline" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tower = { workspace = true, features = ["util"] }

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -890,8 +890,14 @@ async fn implementors_in_scope(scope: &ReadScope, law_id: &str) -> Vec<String> {
 
 /// Law ids a scenario file evaluates, extracted from its execution steps.
 ///
-/// A target is the law named in an `I evaluate "<output>" of "<law_id>"`
-/// step. The Gherkin keyword may be `When`, `Then`, `And`, `But` or `*` —
+/// A target is the law named in an evaluation step: `I evaluate "<output>"
+/// of "<law_id>"` (`bdd/grammar.yaml`, step `evaluate`) and its multi-output
+/// twin `I evaluate outputs "<outputs>" of "<law_id>"` (step
+/// `evaluate_outputs`). Both name the law the scenario puts to work, so
+/// leaving the second out would hide a scenario from the law it tests — and
+/// make the integrity report call that law's own folder untargeted.
+///
+/// The Gherkin keyword may be `When`, `Then`, `And`, `But` or `*` —
 /// the frontend step matcher (`frontend/src/gherkin/steps.js`) matches step
 /// text without its keyword, so all of these run as execution steps.
 /// `Given law "…" is loaded` lines are dependencies, not targets.
@@ -910,7 +916,11 @@ pub(crate) fn extract_target_law_ids(content: &str) -> Vec<String> {
         else {
             continue;
         };
-        let Some(rest) = step.trim_start().strip_prefix("I evaluate \"") else {
+        let step = step.trim_start();
+        let Some(rest) = step
+            .strip_prefix("I evaluate outputs \"")
+            .or_else(|| step.strip_prefix("I evaluate \""))
+        else {
             continue;
         };
         // rest = `<output>" of "<law_id>"…`
@@ -4973,6 +4983,23 @@ mod tests {
         assert_eq!(
             extract_target_law_ids(content),
             vec!["law_a", "law_b", "law_c", "law_d", "law_e"]
+        );
+    }
+
+    #[test]
+    fn extract_targets_covers_the_multi_output_evaluation_step() {
+        // `evaluate_outputs` (bdd/grammar.yaml) names its law in the same
+        // place as `evaluate`. Missing it would hide the scenario from the
+        // law it tests — and make the integrity report claim the law's own
+        // scenario folder targets nothing.
+        let content = r#"
+    When I evaluate outputs "a, b" of "law_multi"
+    When I evaluate "c" of "law_single"
+    When I evaluate outputs "d" of "law_multi"
+"#;
+        assert_eq!(
+            extract_target_law_ids(content),
+            vec!["law_multi", "law_single"]
         );
     }
 

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -325,7 +325,12 @@ fn law_read_error(
 /// The result — including the deferred 428 — is stored on the
 /// [`TrajectScope`] and only surfaced by reads that actually target the
 /// writable-own source.
-async fn resolve_own_read_token(
+///
+/// `pub(crate)`: the integrity scan reads the writable-own repo directly
+/// (no law-by-law routing), so it resolves the very same token instead of
+/// growing a second answer to "which credential may read this repo for
+/// this caller" — see [`crate::traject_integrity`].
+pub(crate) async fn resolve_own_read_token(
     state: &AppState,
     account_id: Uuid,
     headers: &axum::http::HeaderMap,
@@ -891,7 +896,11 @@ async fn implementors_in_scope(scope: &ReadScope, law_id: &str) -> Vec<String> {
 /// text without its keyword, so all of these run as execution steps.
 /// `Given law "…" is loaded` lines are dependencies, not targets.
 /// Deduplicated, order of first occurrence preserved.
-fn extract_target_law_ids(content: &str) -> Vec<String> {
+///
+/// `pub(crate)`: the integrity report resolves the same targets against the
+/// federated corpus to spot scenarios pointing at a law id that no longer
+/// exists (see [`crate::traject_integrity`]).
+pub(crate) fn extract_target_law_ids(content: &str) -> Vec<String> {
     let mut out: Vec<String> = Vec::new();
     for line in content.lines() {
         let trimmed = line.trim_start();
@@ -914,6 +923,43 @@ fn extract_target_law_ids(content: &str) -> Vec<String> {
         let Some((law_id, _)) = rest.split_once('"') else {
             continue;
         };
+        if !law_id.is_empty() && !out.iter().any(|l| l == law_id) {
+            out.push(law_id.to_string());
+        }
+    }
+    out
+}
+
+/// Law ids a scenario file declares as **dependencies**, from its
+/// `law "<law_id>" is loaded` steps (`bdd/grammar.yaml`, step `load_law`).
+///
+/// The counterpart of [`extract_target_law_ids`]: those are the laws the
+/// scenario *evaluates*, these are the ones it loads to make an evaluation
+/// possible. The keyword is `Given` in practice, but every Gherkin keyword is
+/// accepted for the same reason [`extract_target_law_ids`] does — the step
+/// matcher works on the text, not the keyword.
+///
+/// Deduplicated, order of first occurrence preserved.
+pub(crate) fn extract_loaded_law_ids(content: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for line in content.lines() {
+        let trimmed = line.trim_start();
+        let Some(step) = ["Given ", "When ", "Then ", "And ", "But ", "* "]
+            .iter()
+            .find_map(|kw| trimmed.strip_prefix(kw))
+        else {
+            continue;
+        };
+        let Some(rest) = step.trim_start().strip_prefix("law \"") else {
+            continue;
+        };
+        let Some((law_id, tail)) = rest.split_once('"') else {
+            continue;
+        };
+        // Only the `is loaded` step — not some other future `law "…"` step.
+        if !tail.trim_start().starts_with("is loaded") {
+            continue;
+        }
         if !law_id.is_empty() && !out.iter().any(|l| l == law_id) {
             out.push(law_id.to_string());
         }

--- a/packages/editor-api/src/credentials.rs
+++ b/packages/editor-api/src/credentials.rs
@@ -506,6 +506,7 @@ mod tests {
             pipeline_api_url: None,
             harvest_admin_url: None,
             reload_lock: Arc::new(Mutex::new(())),
+            integrity: Default::default(),
             trajects: Arc::new(TrajectCorpusCache::new()),
         }
     }

--- a/packages/editor-api/src/lib.rs
+++ b/packages/editor-api/src/lib.rs
@@ -16,5 +16,6 @@ pub mod state;
 pub mod task_requests;
 pub mod traject_corpus;
 pub mod traject_index_diagnosis;
+pub mod traject_integrity;
 pub mod trajects;
 pub mod user_notes;

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -33,6 +33,7 @@ mod task_requests;
 mod tasks_api;
 mod traject_corpus;
 mod traject_index_diagnosis;
+mod traject_integrity;
 mod trajects;
 mod user_notes;
 mod user_settings;
@@ -143,6 +144,7 @@ async fn main() {
         harvest_admin_url,
         reload_lock: Arc::new(tokio::sync::Mutex::new(())),
         trajects: Arc::new(traject_corpus::TrajectCorpusCache::new()),
+        integrity: Arc::new(traject_integrity::IntegrityCache::new()),
     };
 
     let index_file = PathBuf::from(&static_dir).join("index.html");
@@ -432,6 +434,13 @@ async fn main() {
         .route(
             "/api/trajects/{traject_ref}/corpus/documents/{*doc_path}",
             get(corpus_handlers::get_traject_document),
+        )
+        // Integrity report over the traject's own corpus repo. A read, so
+        // reader-tier like its neighbours: seeing what is wrong with a
+        // traject you are a member of needs no write privilege.
+        .route(
+            "/api/trajects/{traject_ref}/integrity",
+            get(traject_integrity::get_traject_integrity),
         )
         .route_layer(axum_middleware::from_fn_with_state(
             app_state.clone(),

--- a/packages/editor-api/src/state.rs
+++ b/packages/editor-api/src/state.rs
@@ -10,6 +10,7 @@ use tokio::sync::{Mutex, RwLock};
 
 use crate::config::AppConfig;
 use crate::traject_corpus::TrajectCorpusCache;
+use crate::traject_integrity::IntegrityCache;
 
 #[derive(Clone)]
 pub struct AppState {
@@ -41,6 +42,12 @@ pub struct AppState {
     /// traject in the session, save handlers route through this cache
     /// instead of [`AppState::corpus`].
     pub trajects: Arc<TrajectCorpusCache>,
+    /// Content-addressed memo behind the traject integrity report (see
+    /// [`crate::traject_integrity::IntegrityCache`]). Lives here rather than
+    /// on the per-traject corpus snapshot because that snapshot is rebuilt
+    /// on a TTL, which would throw the memo away and re-read every law body
+    /// on the next visit.
+    pub integrity: Arc<IntegrityCache>,
 }
 
 impl OidcAppState for AppState {

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -388,6 +388,20 @@ impl TrajectCorpus {
             .map(String::as_str)
     }
 
+    /// The registry entry of this traject's **writable-own** source — the
+    /// repo the editor commits to. `None` only when the traject's source
+    /// config no longer lists it (a shape the build path doesn't produce).
+    ///
+    /// Shared by every caller that needs the source's own coordinates
+    /// rather than a law's: the index-failure diagnosis
+    /// ([`Self::own_source_target`]) and the integrity scan, which reads
+    /// the repo's whole file tree instead of one law.
+    pub fn own_source(&self) -> Option<&Source> {
+        self.corpus
+            .registry
+            .get_source(&self.writable_own_source_id)
+    }
+
     /// The GitHub coordinates of the writable-own source, for the in-band
     /// diagnosis of a failed index scan (see
     /// [`crate::traject_index_diagnosis`]). `None` when that source isn't
@@ -398,10 +412,7 @@ impl TrajectCorpus {
     /// being re-derived from the traject name, so the probe asks about the
     /// branch the scan actually read.
     pub fn own_source_target(&self) -> Option<OwnSourceTarget> {
-        let source = self
-            .corpus
-            .registry
-            .get_source(&self.writable_own_source_id)?;
+        let source = self.own_source()?;
         let SourceType::GitHub { github } = &source.source_type else {
             return None;
         };

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -434,16 +434,17 @@ impl TrajectCorpus {
     /// Re-resolve the server-side token configured for the writable-own
     /// source, if any.
     ///
-    /// Only for the error path: when a request carries no personal token
-    /// the failed scan authenticated with this one, so the diagnosis has to
-    /// use it too or it would probe a different access path than the one
-    /// that broke. Resolved on demand and dropped by the caller — no token
-    /// is ever stored on this shared, cross-user snapshot.
+    /// For the callers that talk to GitHub directly instead of through the
+    /// backend: when a request carries no personal token, this is the
+    /// credential the backend itself would have used, so they have to
+    /// re-resolve it or they walk a different access path than the ordinary
+    /// reads. The index diagnosis needs that to probe the path that actually
+    /// broke ([`crate::traject_index_diagnosis`]); the integrity scan needs
+    /// it to enumerate the branch at all ([`crate::traject_integrity`]).
+    /// Resolved on demand and dropped by the caller — no token is ever
+    /// stored on this shared, cross-user snapshot.
     pub fn own_server_token(&self) -> Option<String> {
-        let source = self
-            .corpus
-            .registry
-            .get_source(&self.writable_own_source_id)?;
+        let source = self.own_source()?;
         regelrecht_corpus::auth::CredentialResolver::new(self.corpus.auth_file.as_deref())
             .resolve_source(source)
             .ok()

--- a/packages/editor-api/src/traject_integrity.rs
+++ b/packages/editor-api/src/traject_integrity.rs
@@ -1,0 +1,1848 @@
+//! Integrity report over a traject's own corpus repo: the *content* half of
+//! the in-band diagnosis.
+//!
+//! # Why this exists
+//!
+//! The corpus index enumerates a GitHub-backed source by **path**, without
+//! reading a single body: a law's id is taken to be its directory name (see
+//! `SourceMap::load_metadata_entry`). The editor, once a body is loaded,
+//! re-resolves that law to the `$id` inside the YAML. When the two disagree
+//! the id the editor asks for is an id the index has never heard of, and every
+//! follow-up — enrich, the scenario list, the version list — comes back 404.
+//! Nothing on that path can say why: each individual answer ("not found") is a
+//! perfectly ordinary one.
+//!
+//! [`crate::traject_index_diagnosis`] answers "may I read this repo at all".
+//! This module is its counterpart: the repo reads fine — is what is *in* it
+//! internally consistent? Both run in-band, on the caller's own read token,
+//! for the same reason: the repo may be private and user-token-only, so the
+//! only credential that can see it is the one on the request.
+//!
+//! # Shape
+//!
+//! [`scan_own_source`] does all the I/O and reduces every file to a small,
+//! content-derived [`LawFacts`] / [`ScenarioFacts`]. [`run_checks`] is a pure
+//! function over that [`CorpusScan`] — no GitHub, no state — so every check has
+//! a unit test rather than an integration fixture (same split as
+//! `validation::validate_scopes` in the corpus crate).
+//!
+//! # Cost
+//!
+//! One Trees call enumerates the whole branch with a blob sha per file. Facts
+//! are memoised on that sha in [`IntegrityCache`], so a second call on an
+//! unchanged branch reads **no** bodies at all — it costs exactly the one
+//! Trees request. After a push only the changed blobs are fetched.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::path::Path;
+use std::sync::Arc;
+
+use axum::extract::{Path as UrlPath, State};
+use axum::http::StatusCode;
+use axum::{Extension, Json};
+use serde::Serialize;
+use tokio::sync::RwLock;
+use tower_sessions::Session;
+use uuid::Uuid;
+
+use regelrecht_corpus::models::SourceType;
+use regelrecht_corpus::source_map::{collect_law_references, LawReferenceKind};
+use regelrecht_github::GithubClient;
+use regelrecht_law_model::parse_law_header;
+
+use crate::accounts::AccountRecord;
+use crate::corpus_handlers::{
+    extract_loaded_law_ids, extract_target_law_ids, require_traject_corpus_from_ref,
+    resolve_own_read_token,
+};
+use crate::state::AppState;
+use crate::traject_corpus::TrajectCorpus;
+
+/// How many law/scenario bodies are fetched at once on a cold scan.
+///
+/// Sequential reads would make a first scan of a corpus-sized repo take a
+/// minute; unbounded parallelism would fire a hundred Contents calls at a
+/// shared, rate-limited token in one burst. Eight keeps a cold scan in the
+/// low seconds while staying well inside GitHub's concurrency guidance.
+const READ_CONCURRENCY: usize = 8;
+
+/// Reserved subtree in a traject's own repo that holds note sidecars, not
+/// laws. Its `annotations/{law_id}/annotations.yaml` shape collides with the
+/// law convention `{layer}/{law_id}/{date}.yaml`, so the index skips it
+/// (see `github::group_best_versions`) and so must this scan — otherwise
+/// every annotated law would be reported as a law without an `$id`.
+const ANNOTATIONS_DIR: &str = "annotations";
+
+// ---------------------------------------------------------------------------
+// Report shape (the JSON the page renders)
+// ---------------------------------------------------------------------------
+
+/// How bad a finding is. Errors break something today; warnings point at
+/// something that is probably a mistake but still works.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    Error,
+    Warning,
+}
+
+/// The closed set of problems this report can find.
+///
+/// A stable key, not a sentence: the frontend groups on it and an operator can
+/// count occurrences across trajects by it, so the wording of the Dutch
+/// message may change without breaking either. Adding a variant is a
+/// deliberate act — there is no catch-all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FindingKind {
+    /// A law's directory name differs from the `$id` in its YAML. The
+    /// original cause this page was built for.
+    DirectoryNameMismatch,
+    /// A version file's date stem differs from its `valid_from`.
+    FileNameMismatch,
+    /// The layer directory differs from the body's `regulatory_layer`.
+    LayerDirectoryMismatch,
+    /// Two directories declare the same `$id`.
+    DuplicateLawId,
+    /// A `source.regulation` / `implements` target that exists nowhere in
+    /// the federated traject corpus.
+    UnresolvedLawReference,
+    /// A scenario step naming a law id that exists nowhere in the federated
+    /// traject corpus.
+    UnresolvedScenarioReference,
+    /// A `scenarios/` folder in which no feature file evaluates the law the
+    /// folder sits next to.
+    ScenarioDirectoryWithoutTarget,
+    /// A file that could not be read, so the checks over it did not run.
+    FileUnreadable,
+}
+
+impl FindingKind {
+    /// Severity is a property of the *kind*, never chosen per finding, so the
+    /// two can't drift apart across the call sites that raise them.
+    fn severity(self) -> Severity {
+        match self {
+            // A scenario folder that targets nothing still runs — it is a
+            // strong smell (usually a leftover after a rename), not a break.
+            Self::ScenarioDirectoryWithoutTarget => Severity::Warning,
+            _ => Severity::Error,
+        }
+    }
+
+    /// Stable sort rank, so a report's order doesn't depend on the order the
+    /// checks happen to run in.
+    fn rank(self) -> u8 {
+        match self {
+            Self::DirectoryNameMismatch => 0,
+            Self::DuplicateLawId => 1,
+            Self::LayerDirectoryMismatch => 2,
+            Self::FileNameMismatch => 3,
+            Self::UnresolvedLawReference => 4,
+            Self::UnresolvedScenarioReference => 5,
+            Self::FileUnreadable => 6,
+            Self::ScenarioDirectoryWithoutTarget => 7,
+        }
+    }
+}
+
+/// One problem found, with everything the reader needs to act on it: where it
+/// sits, what is wrong, and what to do about it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct Finding {
+    pub severity: Severity,
+    pub kind: FindingKind,
+    /// Path of the offending file or directory, relative to the source root
+    /// (so it reads the same as the paths in the repo's own tree).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    /// The law this is about, as far as it can be established.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub law_id: Option<String>,
+    /// What is wrong, in Dutch, in one sentence.
+    pub message: String,
+    /// What to do about it, in Dutch, concretely enough to act on without
+    /// knowing the corpus conventions.
+    pub remedy: String,
+}
+
+/// `GET /api/trajects/{traject_ref}/integrity` response body.
+#[derive(Debug, Serialize)]
+pub struct IntegrityReport {
+    pub traject_ref: String,
+    /// The source that was read — the traject's writable-own repo.
+    pub source_id: String,
+    /// How many law files were inspected.
+    pub checked_laws: usize,
+    /// How many `.feature` files were inspected.
+    pub checked_scenarios: usize,
+    /// Empty when nothing is wrong. Errors first, then warnings.
+    pub findings: Vec<Finding>,
+}
+
+// ---------------------------------------------------------------------------
+// What a scan reduces the repo to
+// ---------------------------------------------------------------------------
+
+/// The content-derived facts one law file contributes to the checks.
+///
+/// Everything here comes from the body; nothing from the path. That split is
+/// the point — every check compares one against the other.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct LawFacts {
+    /// The top-level `$id`.
+    pub declared_id: Option<String>,
+    /// The top-level `regulatory_layer` (schema enum, upper case).
+    pub regulatory_layer: Option<String>,
+    /// The top-level `valid_from`. May be a `#`-reference rather than a date.
+    pub valid_from: Option<String>,
+    /// Every other law this body points at.
+    pub references: Vec<(LawReferenceKind, String)>,
+}
+
+impl LawFacts {
+    /// Reduce a law body to the facts the checks need.
+    fn from_yaml(body: &str) -> Self {
+        let header = parse_law_header(body);
+        Self {
+            declared_id: header.id,
+            regulatory_layer: header.regulatory_layer,
+            valid_from: header.valid_from,
+            references: collect_law_references(body)
+                .into_iter()
+                .map(|r| (r.kind, r.law_id))
+                .collect(),
+        }
+    }
+}
+
+/// The content-derived facts one `.feature` file contributes.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct ScenarioFacts {
+    /// Law ids the file *evaluates* (`I evaluate "…" of "<id>"`).
+    pub evaluated_ids: Vec<String>,
+    /// Law ids the file *loads* (`law "<id>" is loaded`).
+    pub loaded_ids: Vec<String>,
+}
+
+impl ScenarioFacts {
+    fn from_feature(body: &str) -> Self {
+        Self {
+            evaluated_ids: extract_target_law_ids(body),
+            loaded_ids: extract_loaded_law_ids(body),
+        }
+    }
+
+    /// Every law id the file names, in either role.
+    fn referenced_ids(&self) -> impl Iterator<Item = &String> {
+        self.evaluated_ids.iter().chain(self.loaded_ids.iter())
+    }
+}
+
+/// One file the scan looked at: its source-root-relative path plus either the
+/// facts read from it, or why they could not be read.
+///
+/// A read failure is data, not an abort: one throttled blob must not take down
+/// the whole report, so it becomes its own finding and every other check keeps
+/// running (with the honest caveat that this file was not inspected).
+#[derive(Debug, Clone)]
+pub(crate) struct ScannedFile<T> {
+    pub relative_path: String,
+    pub facts: Result<Arc<T>, String>,
+}
+
+/// Everything [`run_checks`] works from.
+#[derive(Debug, Default)]
+pub(crate) struct CorpusScan {
+    pub laws: Vec<ScannedFile<LawFacts>>,
+    pub scenarios: Vec<ScannedFile<ScenarioFacts>>,
+    /// Law ids the traject's federated index knows — including the seed
+    /// sources, which are already fully loaded and need no reading here.
+    pub indexed_law_ids: HashSet<String>,
+    /// The source's in-repo subpath (`regulation/nl/`, with trailing slash),
+    /// or empty when the source is the repo root.
+    ///
+    /// Paths are kept source-relative everywhere the checks reason about them
+    /// — the first segment being the regulatory layer is a structural rule,
+    /// and a configurable prefix in front of it would only be in the way. It
+    /// is put back for the *reader*: a remedy that says "rename this folder"
+    /// has to name the folder as it appears in the repository, or the reader
+    /// goes looking for it one directory too deep.
+    pub path_prefix: String,
+}
+
+impl CorpusScan {
+    /// A source-relative path as it appears in the repository.
+    fn at(&self, relative_path: &str) -> String {
+        format!("{}{relative_path}", self.path_prefix)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Path structure
+// ---------------------------------------------------------------------------
+
+/// A law file's path decomposed into the parts the checks compare against the
+/// body: `{layer}/[{org}/…]{law_dir}/{stem}.yaml`, relative to the source root.
+///
+/// The optional organisation segment is real: the corpus places
+/// `gemeentelijke_verordening/<gemeente>/<wet>/<datum>.yaml`. Only the first
+/// segment (the layer) and the last directory (which the index uses as the law
+/// id) carry meaning; whatever sits between them is free organisation.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct LawPathParts<'a> {
+    /// First path segment — the regulatory-layer directory.
+    pub layer_dir: &'a str,
+    /// Last directory — the one the index reads as the law's `$id`.
+    pub law_dir: &'a str,
+    /// The law's directory path, e.g. `wet/participatiewet`.
+    pub dir: &'a str,
+    /// Filename without the `.yaml` suffix — a date, by convention.
+    pub stem: &'a str,
+}
+
+/// Decompose a source-root-relative law path, or `None` when it isn't shaped
+/// like a law file at all (too shallow, wrong extension, or the reserved
+/// annotations subtree).
+pub(crate) fn split_law_path(relative_path: &str) -> Option<LawPathParts<'_>> {
+    let stem = relative_path.strip_suffix(".yaml")?;
+    let parts: Vec<&str> = relative_path.split('/').collect();
+    if parts.len() < 3 || parts[0] == ANNOTATIONS_DIR {
+        return None;
+    }
+    let dir_len = relative_path.len() - parts[parts.len() - 1].len() - 1;
+    Some(LawPathParts {
+        layer_dir: parts[0],
+        law_dir: parts[parts.len() - 2],
+        dir: &relative_path[..dir_len],
+        stem: &stem[dir_len + 1..],
+    })
+}
+
+/// A scenario file's path decomposed: `{law_dir_path}/scenarios/{file}.feature`.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct ScenarioPathParts<'a> {
+    /// The `scenarios/` folder itself, e.g. `wet/participatiewet/scenarios`.
+    pub scenarios_dir: &'a str,
+    /// The law directory the folder sits in, e.g. `wet/participatiewet`.
+    pub law_dir_path: &'a str,
+}
+
+/// Decompose a source-root-relative scenario path, or `None` when it isn't a
+/// `.feature` file directly inside a `scenarios/` folder that sits inside a
+/// law directory.
+pub(crate) fn split_scenario_path(relative_path: &str) -> Option<ScenarioPathParts<'_>> {
+    let parts: Vec<&str> = relative_path.split('/').collect();
+    if !relative_path.ends_with(".feature") || parts.len() < 3 {
+        return None;
+    }
+    if parts[parts.len() - 2] != "scenarios" {
+        return None;
+    }
+    let scenarios_len = relative_path.len() - parts[parts.len() - 1].len() - 1;
+    let scenarios_dir = &relative_path[..scenarios_len];
+    let law_dir_path = &scenarios_dir[..scenarios_len - "scenarios".len() - 1];
+    Some(ScenarioPathParts {
+        scenarios_dir,
+        law_dir_path,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// The checks (pure)
+// ---------------------------------------------------------------------------
+
+/// Run every check over a scan. Pure: no I/O, no clock, no state — the whole
+/// point of reducing the repo to a [`CorpusScan`] first.
+///
+/// Findings come back deterministically ordered: errors before warnings, then
+/// by kind, then by path.
+pub(crate) fn run_checks(scan: &CorpusScan) -> Vec<Finding> {
+    // Which `$id`s each law directory declares. Normally one per directory;
+    // more than one means its version files disagree, which the mismatch
+    // check below reports per (directory, id) pair.
+    let mut declared_by_dir: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
+    for law in &scan.laws {
+        let (Some(parts), Ok(facts)) = (split_law_path(&law.relative_path), &law.facts) else {
+            continue;
+        };
+        if let Some(id) = facts.declared_id.as_deref() {
+            declared_by_dir.entry(parts.dir).or_default().insert(id);
+        }
+    }
+
+    // The id universe references resolve against: what the index enumerated
+    // PLUS what the bodies actually declare.
+    //
+    // The union matters. A law whose directory name differs from its `$id` is
+    // in the index under the directory name only, so resolving references
+    // against the index alone would report every pointer to that law as
+    // dangling — a cascade of consequences on top of the one finding that
+    // names the cause. The reference checks answer "does this law exist in
+    // this corpus at all", and by its own `$id` it plainly does.
+    let mut known_ids: HashSet<&str> = scan.indexed_law_ids.iter().map(String::as_str).collect();
+    for ids in declared_by_dir.values() {
+        known_ids.extend(ids.iter().copied());
+    }
+
+    let mut findings = Vec::new();
+    check_unreadable_files(scan, &mut findings);
+    check_directory_names(&declared_by_dir, &scan.path_prefix, &mut findings);
+    check_duplicate_ids(&declared_by_dir, &scan.path_prefix, &mut findings);
+    check_file_names(scan, &mut findings);
+    check_layer_directories(scan, &mut findings);
+    check_law_references(scan, &known_ids, &mut findings);
+    check_scenario_references(scan, &known_ids, &mut findings);
+    check_scenario_targets(scan, &declared_by_dir, &mut findings);
+
+    findings.sort_by(|a, b| {
+        (a.severity, a.kind.rank(), &a.path, &a.law_id, &a.message).cmp(&(
+            b.severity,
+            b.kind.rank(),
+            &b.path,
+            &b.law_id,
+            &b.message,
+        ))
+    });
+    findings
+}
+
+/// A file that could not be read leaves a hole in the report; say so rather
+/// than let the reader believe the checks covered it.
+fn check_unreadable_files(scan: &CorpusScan, out: &mut Vec<Finding>) {
+    let unreadable = scan
+        .laws
+        .iter()
+        .filter_map(|f| f.facts.as_ref().err().map(|e| (&f.relative_path, e)))
+        .chain(
+            scan.scenarios
+                .iter()
+                .filter_map(|f| f.facts.as_ref().err().map(|e| (&f.relative_path, e))),
+        );
+    for (relative_path, error) in unreadable {
+        let path = scan.at(relative_path);
+        out.push(Finding {
+            severity: FindingKind::FileUnreadable.severity(),
+            kind: FindingKind::FileUnreadable,
+            path: Some(path.clone()),
+            law_id: None,
+            message: format!(
+                "Het bestand '{path}' kon niet gelezen worden ({error}); de controles op dit \
+                 bestand zijn daardoor niet uitgevoerd."
+            ),
+            remedy: "Laad de pagina opnieuw. Blijft het misgaan, controleer dan of het bestand \
+                     nog op de traject-branch staat en of je toegang tot de repo hebt."
+                .to_string(),
+        });
+    }
+}
+
+/// Check 1 — the directory name must equal the `$id`.
+///
+/// This is the one that started it: the index keys GitHub-backed laws on the
+/// directory name without reading a byte, so a disagreement makes the law
+/// unreachable under the id the editor asks for.
+fn check_directory_names(
+    declared_by_dir: &BTreeMap<&str, BTreeSet<&str>>,
+    path_prefix: &str,
+    out: &mut Vec<Finding>,
+) {
+    for (relative_dir, ids) in declared_by_dir {
+        let law_dir = relative_dir.rsplit('/').next().unwrap_or(relative_dir);
+        let dir = format!("{path_prefix}{relative_dir}");
+        for id in ids {
+            if *id == law_dir {
+                continue;
+            }
+            let parent = dir.strip_suffix(law_dir).unwrap_or("");
+            out.push(Finding {
+                severity: FindingKind::DirectoryNameMismatch.severity(),
+                kind: FindingKind::DirectoryNameMismatch,
+                path: Some(dir.clone()),
+                law_id: Some((*id).to_string()),
+                message: format!(
+                    "De wet in de map '{dir}' heeft '$id: {id}', maar de map heet '{law_dir}'. \
+                     De wettenindex gebruikt de mapnaam als wet-id, dus deze wet is onvindbaar \
+                     onder haar eigen id: verrijken, versies en scenario's mislukken met \
+                     'niet gevonden'."
+                ),
+                remedy: format!(
+                    "Hernoem de map '{dir}' naar '{parent}{id}', zodat de mapnaam gelijk is aan \
+                     het $id. Wil je juist de mapnaam aanhouden, verander dan het $id in de \
+                     YAML naar '{law_dir}' — en pas overal mee waar die wet wordt aangeroepen."
+                ),
+            });
+        }
+    }
+}
+
+/// Check 4 — one `$id`, one directory.
+fn check_duplicate_ids(
+    declared_by_dir: &BTreeMap<&str, BTreeSet<&str>>,
+    path_prefix: &str,
+    out: &mut Vec<Finding>,
+) {
+    let mut dirs_by_id: BTreeMap<&str, Vec<String>> = BTreeMap::new();
+    for (dir, ids) in declared_by_dir {
+        for id in ids {
+            dirs_by_id
+                .entry(id)
+                .or_default()
+                .push(format!("{path_prefix}{dir}"));
+        }
+    }
+    for (id, dirs) in dirs_by_id {
+        if dirs.len() < 2 {
+            continue;
+        }
+        let list = dirs.join("', '");
+        out.push(Finding {
+            severity: FindingKind::DuplicateLawId.severity(),
+            kind: FindingKind::DuplicateLawId,
+            path: Some(dirs[0].clone()),
+            law_id: Some(id.to_string()),
+            message: format!(
+                "Het wet-id '{id}' wordt door meerdere mappen gedeclareerd: '{list}'. Bij een \
+                 dubbel id houdt de wettenindex er één over; de andere wet verdwijnt uit de \
+                 bibliotheek."
+            ),
+            remedy: format!(
+                "Geef elke wet een eigen $id, of verwijder de map die er niet meer hoort te \
+                 staan. Zijn het twee versies van dezelfde wet, zet ze dan als losse \
+                 datumbestanden in één map '{id}'."
+            ),
+        });
+    }
+}
+
+/// Check 2 — the file's date stem must equal `valid_from`.
+///
+/// A `#`-reference `valid_from` (resolved at run time from an action output)
+/// has no literal date to compare against and is skipped; so is an absent one
+/// (the schema does not require the field).
+fn check_file_names(scan: &CorpusScan, out: &mut Vec<Finding>) {
+    for law in &scan.laws {
+        let (Some(parts), Ok(facts)) = (split_law_path(&law.relative_path), &law.facts) else {
+            continue;
+        };
+        let Some(valid_from) = facts.valid_from.as_deref() else {
+            continue;
+        };
+        if valid_from.starts_with('#') || valid_from == parts.stem {
+            continue;
+        }
+        let path = scan.at(&law.relative_path);
+        out.push(Finding {
+            severity: FindingKind::FileNameMismatch.severity(),
+            kind: FindingKind::FileNameMismatch,
+            path: Some(path.clone()),
+            law_id: facts.declared_id.clone(),
+            message: format!(
+                "Het bestand '{path}' heeft 'valid_from: {valid_from}', maar heet '{}.yaml'. De \
+                 bestandsnaam bepaalt welke versie de index als geldig kiest, dus die keuze \
+                 klopt hier niet met de wet zelf.",
+                parts.stem
+            ),
+            remedy: format!(
+                "Hernoem het bestand naar '{}/{valid_from}.yaml', of pas 'valid_from' in de YAML \
+                 aan naar '{}'.",
+                scan.at(parts.dir),
+                parts.stem
+            ),
+        });
+    }
+}
+
+/// Check 3 — the layer directory must equal `regulatory_layer`.
+///
+/// Compared case-insensitively: the schema enum is upper case
+/// (`GEMEENTELIJKE_VERORDENING`), the directory convention lower case. Only
+/// the first segment is the layer; an organisation segment between it and the
+/// law directory is normal (`gemeentelijke_verordening/<gemeente>/<wet>/`).
+fn check_layer_directories(scan: &CorpusScan, out: &mut Vec<Finding>) {
+    // One finding per (directory, layer) pair, not per version file: five
+    // versions in a misplaced folder are one move, not five.
+    let mut seen: BTreeSet<(&str, &str)> = BTreeSet::new();
+    for law in &scan.laws {
+        let (Some(parts), Ok(facts)) = (split_law_path(&law.relative_path), &law.facts) else {
+            continue;
+        };
+        let Some(layer) = facts.regulatory_layer.as_deref() else {
+            continue;
+        };
+        if layer.eq_ignore_ascii_case(parts.layer_dir) || !seen.insert((parts.dir, layer)) {
+            continue;
+        }
+        let expected_dir = scan.at(&format!(
+            "{}{}",
+            layer.to_ascii_lowercase(),
+            &parts.dir[parts.layer_dir.len()..]
+        ));
+        let dir = scan.at(parts.dir);
+        out.push(Finding {
+            severity: FindingKind::LayerDirectoryMismatch.severity(),
+            kind: FindingKind::LayerDirectoryMismatch,
+            path: Some(dir.clone()),
+            law_id: facts.declared_id.clone(),
+            message: format!(
+                "De wet in '{dir}' heeft 'regulatory_layer: {layer}', maar staat in de laag-map \
+                 '{}'. De mapindeling en de wet spreken elkaar dus tegen.",
+                parts.layer_dir
+            ),
+            remedy: format!(
+                "Verplaats de map naar '{expected_dir}', of pas 'regulatory_layer' aan naar \
+                 '{}'.",
+                parts.layer_dir.to_ascii_uppercase()
+            ),
+        });
+    }
+}
+
+/// Check 5 — every `source.regulation` / `implements` target must exist.
+fn check_law_references(scan: &CorpusScan, known_ids: &HashSet<&str>, out: &mut Vec<Finding>) {
+    for law in &scan.laws {
+        let (Some(parts), Ok(facts)) = (split_law_path(&law.relative_path), &law.facts) else {
+            continue;
+        };
+        let law_label = facts.declared_id.clone().unwrap_or_else(|| {
+            // No `$id` to name it by: the directory is the next best handle,
+            // and the reader can find the file from the path anyway.
+            parts.law_dir.to_string()
+        });
+        for (kind, target) in &facts.references {
+            if known_ids.contains(target.as_str()) {
+                continue;
+            }
+            let via = match kind {
+                LawReferenceKind::SourceRegulation => "verwijst via 'source.regulation' naar",
+                LawReferenceKind::Implements => "declareert 'implements' op",
+            };
+            out.push(Finding {
+                severity: FindingKind::UnresolvedLawReference.severity(),
+                kind: FindingKind::UnresolvedLawReference,
+                path: Some(scan.at(&law.relative_path)),
+                law_id: Some(law_label.clone()),
+                message: format!(
+                    "'{law_label}' {via} '{target}', maar geen enkele wet in dit traject-corpus \
+                     heeft dat $id. Een berekening die deze verwijzing volgt, loopt vast."
+                ),
+                remedy: format!(
+                    "Corrigeer '{target}' naar het $id van de bedoelde wet, of voeg die wet toe \
+                     aan dit traject."
+                ),
+            });
+        }
+    }
+}
+
+/// Check 6 — every law id a scenario names must exist.
+fn check_scenario_references(scan: &CorpusScan, known_ids: &HashSet<&str>, out: &mut Vec<Finding>) {
+    for scenario in &scan.scenarios {
+        let Ok(facts) = &scenario.facts else {
+            continue;
+        };
+        for target in facts.referenced_ids() {
+            if known_ids.contains(target.as_str()) {
+                continue;
+            }
+            let path = scan.at(&scenario.relative_path);
+            out.push(Finding {
+                severity: FindingKind::UnresolvedScenarioReference.severity(),
+                kind: FindingKind::UnresolvedScenarioReference,
+                path: Some(path.clone()),
+                law_id: Some(target.clone()),
+                message: format!(
+                    "Het scenario '{path}' noemt wet '{target}', maar geen enkele wet in dit \
+                     traject-corpus heeft dat $id. Dit scenario kan niet draaien."
+                ),
+                remedy: format!(
+                    "Corrigeer '{target}' in de stap naar het $id van de bedoelde wet, of voeg \
+                     die wet toe aan dit traject."
+                ),
+            });
+        }
+    }
+}
+
+/// Check 7 — a `scenarios/` folder should test the law it sits next to.
+///
+/// Compared against the `$id` the neighbouring body *declares*, not the
+/// directory name: when those two disagree, check 1 already owns that problem
+/// and repeating it here as a second, differently-worded finding would send
+/// the reader down the wrong path.
+fn check_scenario_targets(
+    scan: &CorpusScan,
+    declared_by_dir: &BTreeMap<&str, BTreeSet<&str>>,
+    out: &mut Vec<Finding>,
+) {
+    // Evaluated ids per `scenarios/` folder, plus the law directory it belongs
+    // to. A folder with no readable feature file at all yields no group — the
+    // unreadable-file finding covers that case.
+    let mut evaluated_per_dir: BTreeMap<(&str, &str), BTreeSet<&str>> = BTreeMap::new();
+    for scenario in &scan.scenarios {
+        let (Some(parts), Ok(facts)) = (
+            split_scenario_path(&scenario.relative_path),
+            &scenario.facts,
+        ) else {
+            continue;
+        };
+        let entry = evaluated_per_dir
+            .entry((parts.scenarios_dir, parts.law_dir_path))
+            .or_default();
+        entry.extend(facts.evaluated_ids.iter().map(String::as_str));
+    }
+
+    for ((relative_scenarios_dir, law_dir_path), evaluated) in evaluated_per_dir {
+        // Which law does this folder sit next to? Its declared `$id`s, or —
+        // for a folder without a readable law file — the directory name.
+        let neighbour_dir_name = law_dir_path.rsplit('/').next().unwrap_or(law_dir_path);
+        let scenarios_dir = scan.at(relative_scenarios_dir);
+        let expected: BTreeSet<&str> = declared_by_dir
+            .get(law_dir_path)
+            .map(|ids| ids.iter().copied().collect())
+            .unwrap_or_else(|| BTreeSet::from([neighbour_dir_name]));
+        if expected.iter().any(|id| evaluated.contains(id)) {
+            continue;
+        }
+        let target = expected.iter().copied().collect::<Vec<_>>().join("' of '");
+        let evaluated_list = if evaluated.is_empty() {
+            "geen enkele wet".to_string()
+        } else {
+            format!(
+                "alleen '{}'",
+                evaluated.iter().copied().collect::<Vec<_>>().join("', '")
+            )
+        };
+        out.push(Finding {
+            severity: FindingKind::ScenarioDirectoryWithoutTarget.severity(),
+            kind: FindingKind::ScenarioDirectoryWithoutTarget,
+            path: Some(scenarios_dir.clone()),
+            law_id: expected.iter().next().map(|id| (*id).to_string()),
+            message: format!(
+                "De scenario's in '{scenarios_dir}' evalueren {evaluated_list} — niet '{target}', \
+                 de wet waar deze map bij hoort. De wet zelf wordt hier dus niet getoetst."
+            ),
+            remedy: format!(
+                "Voeg een stap toe die '{target}' evalueert (bijvoorbeeld: Then I evaluate \
+                 \"<uitkomst>\" of \"{target}\"), of verplaats deze scenario's naar de map van \
+                 de wet die ze wél evalueren."
+            ),
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Cache
+// ---------------------------------------------------------------------------
+
+/// What one enumerated blob reduced to, keyed by its sha.
+#[derive(Debug, Clone)]
+enum CachedFacts {
+    Law(Arc<LawFacts>),
+    Scenario(Arc<ScenarioFacts>),
+}
+
+/// Content-addressed memo of the integrity scan, per traject.
+///
+/// The key is the blob sha the Trees enumeration reported: two enumerations
+/// reporting the same sha are byte-identical, so a repeat scan without new
+/// commits reuses every entry and reads no bodies at all. After a push only
+/// the changed blobs miss.
+///
+/// Process-wide (on [`AppState`]) rather than on the per-traject index
+/// snapshot on purpose: that snapshot is rebuilt every minute, which would
+/// throw the memo away and re-read the whole repo on the next visit — exactly
+/// what this must not do. Each scan swaps in a map holding only the shas it
+/// just saw, so a traject's entry stays O(its repo) however much the content
+/// churns; the outer map is bounded by the number of trajects visited.
+#[derive(Default)]
+pub struct IntegrityCache {
+    per_traject: RwLock<HashMap<Uuid, Arc<HashMap<String, CachedFacts>>>>,
+}
+
+impl IntegrityCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    async fn get(&self, traject_id: Uuid) -> Arc<HashMap<String, CachedFacts>> {
+        self.per_traject
+            .read()
+            .await
+            .get(&traject_id)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    async fn store(&self, traject_id: Uuid, memo: HashMap<String, CachedFacts>) {
+        self.per_traject
+            .write()
+            .await
+            .insert(traject_id, Arc::new(memo));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Scanning (the I/O half)
+// ---------------------------------------------------------------------------
+
+/// A file the enumeration found, before its body was read.
+#[derive(Clone)]
+struct EnumeratedFile {
+    /// Path relative to the source root — what the report shows.
+    relative_path: String,
+    /// Path relative to the repo root — what GitHub is asked for.
+    repo_path: String,
+    /// Blob sha from the enumeration, when the source reports one. `None`
+    /// means "no content identity available", so no memo entry either.
+    sha: Option<String>,
+    is_law: bool,
+}
+
+/// Enumerate the traject's own source and reduce every law/scenario file to
+/// its facts, reusing everything the cache already knows by blob sha.
+async fn scan_own_source(
+    state: &AppState,
+    traject: &TrajectCorpus,
+    token: Option<&str>,
+) -> Result<CorpusScan, (StatusCode, String)> {
+    let source = traject.own_source().ok_or_else(|| {
+        tracing::error!(
+            traject = %traject.traject_id,
+            source_id = %traject.writable_own_source_id,
+            "traject has no writable-own source in its registry"
+        );
+        (
+            StatusCode::BAD_GATEWAY,
+            "De eigen repo van dit traject is niet geconfigureerd, dus er valt niets te \
+             controleren."
+                .to_string(),
+        )
+    })?;
+
+    // The source's in-repo subpath, normalised to the `foo/bar/` form the
+    // report prefixes paths with.
+    let path_prefix = match &source.source_type {
+        SourceType::GitHub { github } => github
+            .path
+            .as_deref()
+            .map(|p| p.trim_matches('/'))
+            .filter(|p| !p.is_empty())
+            .map(|p| format!("{p}/"))
+            .unwrap_or_default(),
+        // A local source is rooted at its configured directory, so there is
+        // nothing above the source root to name.
+        SourceType::Local { .. } => String::new(),
+    };
+
+    let (files, bodies) = match &source.source_type {
+        SourceType::GitHub { github } => {
+            // Plain `new()`: it honours the same `GITHUB_API_BASE` seam every
+            // other GitHub read in this process does, so the scan reaches the
+            // host the traject's normal reads reach.
+            let client = GithubClient::new().map_err(|e| {
+                tracing::error!(
+                    traject = %traject.traject_id,
+                    error = %e,
+                    "integrity scan: failed to build GitHub client"
+                );
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "De integriteitscontrole kon niet worden gestart.".to_string(),
+                )
+            })?;
+            let client = Arc::new(client);
+            let repo = github.full_repo();
+            let git_ref = github.effective_ref().to_string();
+            // One Trees call for the whole branch: paths plus a blob sha per
+            // file, which is what makes the memo below possible at all.
+            let entries = client
+                .list_tree_files(&repo, &git_ref, token)
+                .await
+                .map_err(|e| github_read_error(traject.traject_id, &repo, e))?
+                // `None` is the 304 "tree unchanged" answer, which needs a
+                // previously cached ETag on this very client — and the client
+                // is built one line above. Unreachable in practice; treat a
+                // surprise as an empty enumeration rather than a panic.
+                .unwrap_or_default();
+            let files = classify_tree_entries(entries, github.path.as_deref());
+            let bodies = BodyReader::Github {
+                client,
+                repo,
+                git_ref,
+                token: token.map(str::to_string),
+            };
+            (files, bodies)
+        }
+        // Local source (dev / preview stack): walk the checkout through the
+        // backend. No blob shas, so no memo — reading a local tree is cheap
+        // enough that re-reading it per request is not worth a second
+        // caching scheme.
+        SourceType::Local { .. } => {
+            let Some(entry) = traject
+                .corpus
+                .backends
+                .get(&traject.writable_own_source_id)
+                .cloned()
+            else {
+                return Ok(CorpusScan {
+                    indexed_law_ids: indexed_ids(traject),
+                    path_prefix,
+                    ..CorpusScan::default()
+                });
+            };
+            let listing = {
+                let backend = entry.backend.lock().await;
+                backend
+                    .list_files_recursive(Path::new(""), None)
+                    .await
+                    .map_err(|e| {
+                        tracing::warn!(traject = %traject.traject_id, error = %e, "integrity scan: listing failed");
+                        (
+                            StatusCode::BAD_GATEWAY,
+                            "De bestanden van dit traject konden niet worden opgesomd."
+                                .to_string(),
+                        )
+                    })?
+            };
+            let files = classify_local_entries(listing);
+            (files, BodyReader::Backend(entry.backend))
+        }
+    };
+
+    let cached = state.integrity.get(traject.traject_id).await;
+    let (scanned, fresh_memo) = read_facts(&files, &cached, &bodies).await;
+    state.integrity.store(traject.traject_id, fresh_memo).await;
+
+    let mut scan = CorpusScan {
+        indexed_law_ids: indexed_ids(traject),
+        path_prefix,
+        ..CorpusScan::default()
+    };
+    for (file, facts) in files.iter().zip(scanned) {
+        match facts {
+            ScannedFacts::Law(facts) => scan.laws.push(ScannedFile {
+                relative_path: file.relative_path.clone(),
+                facts,
+            }),
+            ScannedFacts::Scenario(facts) => scan.scenarios.push(ScannedFile {
+                relative_path: file.relative_path.clone(),
+                facts,
+            }),
+        }
+    }
+    Ok(scan)
+}
+
+/// Law ids the traject's federated index knows about, across all its sources.
+fn indexed_ids(traject: &TrajectCorpus) -> HashSet<String> {
+    traject
+        .corpus
+        .source_map
+        .laws()
+        .map(|law| law.law_id.clone())
+        .collect()
+}
+
+/// Narrow a Trees listing to the law and scenario files under the source's
+/// in-repo subpath, in source-root-relative form.
+fn classify_tree_entries(
+    entries: Vec<regelrecht_github::TreeEntryFile>,
+    subpath: Option<&str>,
+) -> Vec<EnumeratedFile> {
+    let prefix = subpath
+        .map(|s| s.trim_end_matches('/'))
+        .filter(|s| !s.is_empty())
+        .map(|s| format!("{s}/"));
+    let mut out = Vec::new();
+    for entry in entries {
+        let relative_path = match &prefix {
+            Some(p) => match entry.path.strip_prefix(p.as_str()) {
+                Some(rest) => rest.to_string(),
+                None => continue,
+            },
+            None => entry.path.clone(),
+        };
+        let Some(is_law) = classify_relative_path(&relative_path) else {
+            continue;
+        };
+        out.push(EnumeratedFile {
+            relative_path,
+            repo_path: entry.path,
+            sha: entry.sha,
+            is_law,
+        });
+    }
+    out.sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
+    out
+}
+
+/// Same narrowing for a local checkout, whose listing is already
+/// source-root-relative and carries no shas.
+fn classify_local_entries(
+    entries: Vec<regelrecht_corpus::backend::RecursiveFileEntry>,
+) -> Vec<EnumeratedFile> {
+    let mut out: Vec<EnumeratedFile> = entries
+        .into_iter()
+        .filter_map(|e| {
+            let is_law = classify_relative_path(&e.relative_path)?;
+            Some(EnumeratedFile {
+                repo_path: e.relative_path.clone(),
+                relative_path: e.relative_path,
+                sha: None,
+                is_law,
+            })
+        })
+        .collect();
+    out.sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
+    out
+}
+
+/// `Some(true)` for a law file, `Some(false)` for a scenario file, `None` for
+/// everything else in the repo (documents, sidecars, READMEs, CI config).
+fn classify_relative_path(relative_path: &str) -> Option<bool> {
+    if split_law_path(relative_path).is_some() {
+        Some(true)
+    } else if split_scenario_path(relative_path).is_some() {
+        Some(false)
+    } else {
+        None
+    }
+}
+
+/// Where bodies come from for this scan. Cheap to clone (everything shared
+/// behind an `Arc`) so a batch of reads can be spawned in parallel.
+#[derive(Clone)]
+enum BodyReader {
+    Github {
+        client: Arc<GithubClient>,
+        repo: String,
+        git_ref: String,
+        token: Option<String>,
+    },
+    Backend(Arc<tokio::sync::Mutex<Box<dyn regelrecht_corpus::backend::RepoBackend>>>),
+}
+
+impl BodyReader {
+    async fn read(&self, file: &EnumeratedFile) -> Result<String, String> {
+        match self {
+            Self::Github {
+                client,
+                repo,
+                git_ref,
+                token,
+            } => client
+                .fetch_file_raw(repo, git_ref, &file.repo_path, token.as_deref())
+                .await
+                .map_err(|e| short_error(&e.to_string())),
+            // Local checkout: the backend mutex serialises these, which is
+            // fine — a local read costs no round trip.
+            Self::Backend(backend) => {
+                let guard = backend.lock().await;
+                match guard.read_file(Path::new(&file.relative_path)).await {
+                    Ok(Some(body)) => Ok(body),
+                    Ok(None) => Err("bestand niet gevonden".to_string()),
+                    Err(e) => Err(short_error(&e.to_string())),
+                }
+            }
+        }
+    }
+}
+
+/// Per-file outcome, kept parallel to the enumeration so the caller can zip
+/// them back together without re-deriving the law/scenario split.
+enum ScannedFacts {
+    Law(Result<Arc<LawFacts>, String>),
+    Scenario(Result<Arc<ScenarioFacts>, String>),
+}
+
+impl ScannedFacts {
+    /// Reduce a freshly-read body (or a read failure) to its facts.
+    fn from_body(is_law: bool, body: Result<String, String>) -> Self {
+        match (body, is_law) {
+            (Ok(body), true) => Self::Law(Ok(Arc::new(LawFacts::from_yaml(&body)))),
+            (Ok(body), false) => Self::Scenario(Ok(Arc::new(ScenarioFacts::from_feature(&body)))),
+            (Err(e), true) => Self::Law(Err(e)),
+            (Err(e), false) => Self::Scenario(Err(e)),
+        }
+    }
+
+    /// The memo entry this outcome contributes, if any. A failed read is
+    /// never memoised: the next call must retry rather than serve the
+    /// failure for as long as the blob stays unchanged.
+    fn to_cached(&self) -> Option<CachedFacts> {
+        match self {
+            Self::Law(Ok(facts)) => Some(CachedFacts::Law(facts.clone())),
+            Self::Scenario(Ok(facts)) => Some(CachedFacts::Scenario(facts.clone())),
+            _ => None,
+        }
+    }
+}
+
+/// Resolve every enumerated file to its facts: from the memo when the blob sha
+/// is unchanged, otherwise by reading the body. Returns the per-file outcomes
+/// (parallel to `files`) plus the memo for the next call, holding only the
+/// shas seen now.
+async fn read_facts(
+    files: &[EnumeratedFile],
+    cached: &HashMap<String, CachedFacts>,
+    bodies: &BodyReader,
+) -> (Vec<ScannedFacts>, HashMap<String, CachedFacts>) {
+    let mut out: Vec<Option<ScannedFacts>> = (0..files.len()).map(|_| None).collect();
+    let mut misses: Vec<usize> = Vec::new();
+
+    for (i, file) in files.iter().enumerate() {
+        // A hit of the wrong shape (a path that changed from law to scenario
+        // under the same sha — an empty file, say) falls through to a re-read
+        // rather than being forced into the wrong bucket.
+        let hit = file.sha.as_ref().and_then(|sha| cached.get(sha));
+        match (hit, file.is_law) {
+            (Some(CachedFacts::Law(facts)), true) => {
+                out[i] = Some(ScannedFacts::Law(Ok(facts.clone())));
+            }
+            (Some(CachedFacts::Scenario(facts)), false) => {
+                out[i] = Some(ScannedFacts::Scenario(Ok(facts.clone())));
+            }
+            _ => misses.push(i),
+        }
+    }
+
+    // Bodies are fetched in bounded-parallel batches: one at a time is too
+    // slow on a cold, corpus-sized repo; all at once is a burst against a
+    // shared rate limit. Each body is reduced to its (small) facts as soon as
+    // it lands, so peak memory is one batch of bodies, never the whole corpus.
+    for batch in misses.chunks(READ_CONCURRENCY) {
+        let mut set = tokio::task::JoinSet::new();
+        for &i in batch {
+            let bodies = bodies.clone();
+            let file = files[i].clone();
+            set.spawn(async move {
+                let body = bodies.read(&file).await;
+                (i, ScannedFacts::from_body(file.is_law, body))
+            });
+        }
+        while let Some(joined) = set.join_next().await {
+            match joined {
+                Ok((i, facts)) => out[i] = Some(facts),
+                // A panicked read task is a bug, not a corpus problem; leave
+                // the slot empty so it surfaces as an unreadable file below.
+                Err(e) => tracing::error!(error = %e, "integrity scan: body read task failed"),
+            }
+        }
+    }
+
+    let mut memo: HashMap<String, CachedFacts> = HashMap::new();
+    let out: Vec<ScannedFacts> = out
+        .into_iter()
+        .enumerate()
+        .map(|(i, facts)| {
+            facts.unwrap_or_else(|| {
+                ScannedFacts::from_body(files[i].is_law, Err("lezen afgebroken".to_string()))
+            })
+        })
+        .collect();
+    for (file, facts) in files.iter().zip(&out) {
+        if let (Some(sha), Some(entry)) = (&file.sha, facts.to_cached()) {
+            memo.insert(sha.clone(), entry);
+        }
+    }
+    (out, memo)
+}
+
+/// Trim a backend error to something that fits in a user-facing sentence.
+/// The full text is logged by the layer that raised it; here it is context,
+/// not the message.
+fn short_error(error: &str) -> String {
+    const MAX: usize = 120;
+    let one_line = error.replace(['\n', '\r'], " ");
+    if one_line.chars().count() <= MAX {
+        return one_line;
+    }
+    one_line.chars().take(MAX - 1).chain(['…']).collect()
+}
+
+/// The Trees enumeration is the one call that can sink the whole report:
+/// without it there is nothing to check. Answer 502 with a plain sentence and
+/// log the raw cause for operators.
+fn github_read_error(
+    traject_id: Uuid,
+    repo: &str,
+    error: regelrecht_github::GithubError,
+) -> (StatusCode, String) {
+    tracing::warn!(
+        traject = %traject_id,
+        repo = %repo,
+        error = %error,
+        "integrity scan: could not enumerate the traject branch"
+    );
+    (
+        StatusCode::BAD_GATEWAY,
+        "De bestanden van dit traject konden niet bij GitHub worden opgehaald, dus de \
+         integriteitscontrole kon niet draaien. Probeer het over een paar minuten opnieuw."
+            .to_string(),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+/// `GET /api/trajects/{traject_ref}/integrity`
+///
+/// Behind the same membership guard as every other traject route, and reading
+/// with the same credential the traject's normal reads use — the caller's own
+/// GitHub token when the source has no server-side one (a user-token repo is
+/// never read with the central token).
+pub async fn get_traject_integrity(
+    State(state): State<AppState>,
+    session: Session,
+    Extension(account): Extension<AccountRecord>,
+    UrlPath(traject_ref): UrlPath<String>,
+    headers: axum::http::HeaderMap,
+) -> Result<Json<IntegrityReport>, (StatusCode, String)> {
+    let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
+    // Same resolution (and same deferred 428 into the koppel-flow) as every
+    // other read of the writable-own source. Surfaced immediately here, since
+    // this endpoint reads nothing else.
+    let token = resolve_own_read_token(&state, account.id, &headers, &traject).await?;
+
+    let scan = scan_own_source(&state, &traject, token.as_deref()).await?;
+    let findings = run_checks(&scan);
+
+    tracing::debug!(
+        traject = %traject.traject_id,
+        laws = scan.laws.len(),
+        scenarios = scan.scenarios.len(),
+        findings = findings.len(),
+        "integrity report built"
+    );
+
+    Ok(Json(IntegrityReport {
+        traject_ref,
+        source_id: traject.writable_own_source_id.clone(),
+        checked_laws: scan.laws.len(),
+        checked_scenarios: scan.scenarios.len(),
+        findings,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Fictional corpus fixtures throughout — no real repo, traject or law
+    /// names (this is a public repository).
+    fn law(path: &str, facts: LawFacts) -> ScannedFile<LawFacts> {
+        ScannedFile {
+            relative_path: path.to_string(),
+            facts: Ok(Arc::new(facts)),
+        }
+    }
+
+    fn scenario(path: &str, evaluated: &[&str], loaded: &[&str]) -> ScannedFile<ScenarioFacts> {
+        ScannedFile {
+            relative_path: path.to_string(),
+            facts: Ok(Arc::new(ScenarioFacts {
+                evaluated_ids: evaluated.iter().map(|s| s.to_string()).collect(),
+                loaded_ids: loaded.iter().map(|s| s.to_string()).collect(),
+            })),
+        }
+    }
+
+    /// A well-formed law body's facts: everything agrees with the path
+    /// `{layer}/{id}/{valid_from}.yaml`.
+    fn healthy(id: &str, layer: &str, valid_from: &str) -> LawFacts {
+        LawFacts {
+            declared_id: Some(id.to_string()),
+            regulatory_layer: Some(layer.to_string()),
+            valid_from: Some(valid_from.to_string()),
+            references: Vec::new(),
+        }
+    }
+
+    fn scan(
+        laws: Vec<ScannedFile<LawFacts>>,
+        scenarios: Vec<ScannedFile<ScenarioFacts>>,
+    ) -> CorpusScan {
+        let indexed_law_ids = laws
+            .iter()
+            .filter_map(|l| split_law_path(&l.relative_path).map(|p| p.law_dir.to_string()))
+            .collect();
+        CorpusScan {
+            laws,
+            scenarios,
+            indexed_law_ids,
+            // Same subpath as the real corpus repo, so the fixtures prove
+            // that findings name paths as they appear in the repository.
+            path_prefix: "regulation/nl/".to_string(),
+        }
+    }
+
+    fn kinds(findings: &[Finding]) -> Vec<FindingKind> {
+        findings.iter().map(|f| f.kind).collect()
+    }
+
+    fn of_kind(findings: &[Finding], kind: FindingKind) -> Vec<&Finding> {
+        findings.iter().filter(|f| f.kind == kind).collect()
+    }
+
+    // --- path splitting ---
+
+    #[test]
+    fn law_paths_split_with_and_without_an_organisation_segment() {
+        let plain = split_law_path("wet/wet_alpha/2025-01-01.yaml").expect("law path");
+        assert_eq!(plain.layer_dir, "wet");
+        assert_eq!(plain.law_dir, "wet_alpha");
+        assert_eq!(plain.dir, "wet/wet_alpha");
+        assert_eq!(plain.stem, "2025-01-01");
+
+        let nested = split_law_path("waterschaps_verordening/hoogland/keur_alpha/2025-01-01.yaml")
+            .expect("law path");
+        assert_eq!(nested.layer_dir, "waterschaps_verordening");
+        assert_eq!(nested.law_dir, "keur_alpha");
+        assert_eq!(nested.dir, "waterschaps_verordening/hoogland/keur_alpha");
+    }
+
+    #[test]
+    fn non_law_paths_are_not_mistaken_for_laws() {
+        // Too shallow, wrong extension, and the reserved annotations subtree.
+        assert!(split_law_path("wet/2025-01-01.yaml").is_none());
+        assert!(split_law_path("wet/wet_alpha/README.md").is_none());
+        assert!(split_law_path("annotations/wet_alpha/annotations.yaml").is_none());
+    }
+
+    #[test]
+    fn scenario_paths_split_into_folder_and_neighbouring_law_dir() {
+        let parts =
+            split_scenario_path("wet/wet_alpha/scenarios/basis.feature").expect("scenario path");
+        assert_eq!(parts.scenarios_dir, "wet/wet_alpha/scenarios");
+        assert_eq!(parts.law_dir_path, "wet/wet_alpha");
+        // A feature file that isn't inside a `scenarios/` folder isn't one.
+        assert!(split_scenario_path("wet/wet_alpha/basis.feature").is_none());
+    }
+
+    // --- check 1: directory name vs $id ---
+
+    #[test]
+    fn directory_name_matching_the_id_is_clean() {
+        let findings = run_checks(&scan(
+            vec![law(
+                "wet/wet_alpha/2025-01-01.yaml",
+                healthy("wet_alpha", "WET", "2025-01-01"),
+            )],
+            vec![],
+        ));
+        assert!(findings.is_empty(), "{findings:?}");
+    }
+
+    #[test]
+    fn directory_name_differing_from_the_id_is_an_error_with_a_rename_remedy() {
+        let findings = run_checks(&scan(
+            vec![law(
+                "waterschaps_verordening/hoogland/keur_alpha/2025-01-01.yaml",
+                healthy(
+                    "keur_alpha_hoogland",
+                    "WATERSCHAPS_VERORDENING",
+                    "2025-01-01",
+                ),
+            )],
+            vec![],
+        ));
+        assert_eq!(kinds(&findings), vec![FindingKind::DirectoryNameMismatch]);
+        let f = &findings[0];
+        assert_eq!(f.severity, Severity::Error);
+        // Paths read as they appear in the repository — the source's own
+        // subpath included, so the reader finds the folder where it says.
+        assert_eq!(
+            f.path.as_deref(),
+            Some("regulation/nl/waterschaps_verordening/hoogland/keur_alpha")
+        );
+        assert_eq!(f.law_id.as_deref(), Some("keur_alpha_hoogland"));
+        // The remedy names the exact new folder path, not just "rename it".
+        assert!(
+            f.remedy
+                .contains("regulation/nl/waterschaps_verordening/hoogland/keur_alpha_hoogland"),
+            "{}",
+            f.remedy
+        );
+    }
+
+    // --- check 2: file name vs valid_from ---
+
+    #[test]
+    fn a_file_named_after_its_valid_from_is_clean() {
+        let findings = run_checks(&scan(
+            vec![law(
+                "wet/wet_alpha/2024-07-01.yaml",
+                healthy("wet_alpha", "WET", "2024-07-01"),
+            )],
+            vec![],
+        ));
+        assert!(findings.is_empty(), "{findings:?}");
+    }
+
+    #[test]
+    fn a_file_named_differently_from_its_valid_from_is_an_error() {
+        let findings = run_checks(&scan(
+            vec![law(
+                "wet/wet_alpha/2024-07-01.yaml",
+                healthy("wet_alpha", "WET", "2025-01-01"),
+            )],
+            vec![],
+        ));
+        assert_eq!(kinds(&findings), vec![FindingKind::FileNameMismatch]);
+        assert!(
+            findings[0]
+                .remedy
+                .contains("regulation/nl/wet/wet_alpha/2025-01-01.yaml"),
+            "{}",
+            findings[0].remedy
+        );
+    }
+
+    #[test]
+    fn an_absent_or_referenced_valid_from_is_not_compared() {
+        // Absent (the schema doesn't require it) and `#`-referenced (resolved
+        // at run time) both have no literal date to compare against.
+        let findings = run_checks(&scan(
+            vec![
+                law(
+                    "wet/wet_alpha/2024-07-01.yaml",
+                    LawFacts {
+                        valid_from: None,
+                        ..healthy("wet_alpha", "WET", "")
+                    },
+                ),
+                law(
+                    "wet/wet_beta/2024-07-01.yaml",
+                    healthy("wet_beta", "WET", "#inwerkingtreding"),
+                ),
+            ],
+            vec![],
+        ));
+        assert!(findings.is_empty(), "{findings:?}");
+    }
+
+    // --- check 3: layer directory vs regulatory_layer ---
+
+    #[test]
+    fn a_layer_directory_matching_the_body_is_clean_case_insensitively() {
+        let findings = run_checks(&scan(
+            vec![law(
+                "gemeentelijke_verordening/hoogstad/apv_alpha/2025-01-01.yaml",
+                healthy("apv_alpha", "GEMEENTELIJKE_VERORDENING", "2025-01-01"),
+            )],
+            vec![],
+        ));
+        assert!(findings.is_empty(), "{findings:?}");
+    }
+
+    #[test]
+    fn a_law_in_the_wrong_layer_directory_is_an_error_once_per_directory() {
+        // Two versions in the same misplaced folder are one move, one finding.
+        let findings = run_checks(&scan(
+            vec![
+                law(
+                    "wet/beleid_alpha/2024-01-01.yaml",
+                    healthy("beleid_alpha", "BELEIDSREGEL", "2024-01-01"),
+                ),
+                law(
+                    "wet/beleid_alpha/2025-01-01.yaml",
+                    healthy("beleid_alpha", "BELEIDSREGEL", "2025-01-01"),
+                ),
+            ],
+            vec![],
+        ));
+        assert_eq!(kinds(&findings), vec![FindingKind::LayerDirectoryMismatch]);
+        assert!(
+            findings[0]
+                .remedy
+                .contains("regulation/nl/beleidsregel/beleid_alpha"),
+            "{}",
+            findings[0].remedy
+        );
+    }
+
+    // --- check 4: duplicate $id ---
+
+    #[test]
+    fn distinct_ids_across_directories_are_clean() {
+        let findings = run_checks(&scan(
+            vec![
+                law(
+                    "wet/wet_alpha/2025-01-01.yaml",
+                    healthy("wet_alpha", "WET", "2025-01-01"),
+                ),
+                law(
+                    "wet/wet_beta/2025-01-01.yaml",
+                    healthy("wet_beta", "WET", "2025-01-01"),
+                ),
+            ],
+            vec![],
+        ));
+        assert!(findings.is_empty(), "{findings:?}");
+    }
+
+    #[test]
+    fn the_same_id_in_two_directories_is_an_error() {
+        let findings = run_checks(&scan(
+            vec![
+                law(
+                    "wet/wet_alpha/2025-01-01.yaml",
+                    healthy("wet_alpha", "WET", "2025-01-01"),
+                ),
+                law(
+                    "wet/wet_alpha_kopie/2025-01-01.yaml",
+                    healthy("wet_alpha", "WET", "2025-01-01"),
+                ),
+            ],
+            vec![],
+        ));
+        // The copy also trips check 1 (its folder name isn't its id); the
+        // duplicate is reported once, naming both folders.
+        let dupes = of_kind(&findings, FindingKind::DuplicateLawId);
+        assert_eq!(dupes.len(), 1);
+        assert!(
+            dupes[0]
+                .message
+                .contains("regulation/nl/wet/wet_alpha_kopie"),
+            "{dupes:?}"
+        );
+        assert!(
+            dupes[0].message.contains("regulation/nl/wet/wet_alpha'"),
+            "{dupes:?}"
+        );
+    }
+
+    // --- check 5: cross-law references ---
+
+    #[test]
+    fn references_to_existing_laws_are_clean() {
+        let findings = run_checks(&scan(
+            vec![
+                law(
+                    "wet/wet_alpha/2025-01-01.yaml",
+                    LawFacts {
+                        references: vec![
+                            (LawReferenceKind::SourceRegulation, "wet_beta".to_string()),
+                            (LawReferenceKind::Implements, "wet_beta".to_string()),
+                        ],
+                        ..healthy("wet_alpha", "WET", "2025-01-01")
+                    },
+                ),
+                law(
+                    "wet/wet_beta/2025-01-01.yaml",
+                    healthy("wet_beta", "WET", "2025-01-01"),
+                ),
+            ],
+            vec![],
+        ));
+        assert!(findings.is_empty(), "{findings:?}");
+    }
+
+    #[test]
+    fn a_reference_to_an_unknown_id_is_an_error_per_reference() {
+        let findings = run_checks(&scan(
+            vec![law(
+                "wet/wet_alpha/2025-01-01.yaml",
+                LawFacts {
+                    references: vec![
+                        (LawReferenceKind::SourceRegulation, "wet_zoek".to_string()),
+                        (LawReferenceKind::Implements, "wet_weg".to_string()),
+                    ],
+                    ..healthy("wet_alpha", "WET", "2025-01-01")
+                },
+            )],
+            vec![],
+        ));
+        assert_eq!(
+            kinds(&findings),
+            vec![
+                FindingKind::UnresolvedLawReference,
+                FindingKind::UnresolvedLawReference
+            ]
+        );
+        let targets: Vec<&str> = findings
+            .iter()
+            .filter_map(|f| f.law_id.as_deref())
+            .collect();
+        assert_eq!(targets, vec!["wet_alpha", "wet_alpha"]);
+        assert!(findings.iter().any(|f| f.message.contains("wet_zoek")));
+        assert!(findings.iter().any(|f| f.message.contains("wet_weg")));
+    }
+
+    #[test]
+    fn a_reference_to_a_law_whose_folder_name_is_wrong_still_resolves() {
+        // The scenario from the field: the folder says `keur_alpha`, the body
+        // says `keur_alpha_hoogland`. Only check 1 fires — the reference to
+        // the declared id is a perfectly good reference, and drowning the
+        // cause in consequences would point the reader the wrong way.
+        let findings = run_checks(&scan(
+            vec![
+                law(
+                    "waterschaps_verordening/hoogland/keur_alpha/2025-01-01.yaml",
+                    healthy(
+                        "keur_alpha_hoogland",
+                        "WATERSCHAPS_VERORDENING",
+                        "2025-01-01",
+                    ),
+                ),
+                law(
+                    "wet/wet_alpha/2025-01-01.yaml",
+                    LawFacts {
+                        references: vec![(
+                            LawReferenceKind::SourceRegulation,
+                            "keur_alpha_hoogland".to_string(),
+                        )],
+                        ..healthy("wet_alpha", "WET", "2025-01-01")
+                    },
+                ),
+            ],
+            vec![],
+        ));
+        assert_eq!(kinds(&findings), vec![FindingKind::DirectoryNameMismatch]);
+    }
+
+    // --- check 6: scenario references ---
+
+    #[test]
+    fn scenario_steps_naming_known_laws_are_clean() {
+        let findings = run_checks(&scan(
+            vec![
+                law(
+                    "wet/wet_alpha/2025-01-01.yaml",
+                    healthy("wet_alpha", "WET", "2025-01-01"),
+                ),
+                law(
+                    "wet/wet_beta/2025-01-01.yaml",
+                    healthy("wet_beta", "WET", "2025-01-01"),
+                ),
+            ],
+            vec![scenario(
+                "wet/wet_alpha/scenarios/basis.feature",
+                &["wet_alpha"],
+                &["wet_beta"],
+            )],
+        ));
+        assert!(findings.is_empty(), "{findings:?}");
+    }
+
+    #[test]
+    fn a_scenario_step_naming_an_unknown_law_is_an_error() {
+        let findings = run_checks(&scan(
+            vec![law(
+                "wet/wet_alpha/2025-01-01.yaml",
+                healthy("wet_alpha", "WET", "2025-01-01"),
+            )],
+            vec![scenario(
+                "wet/wet_alpha/scenarios/basis.feature",
+                &["wet_alpha"],
+                &["wet_verdwenen"],
+            )],
+        ));
+        assert_eq!(
+            kinds(&findings),
+            vec![FindingKind::UnresolvedScenarioReference]
+        );
+        assert_eq!(findings[0].law_id.as_deref(), Some("wet_verdwenen"));
+    }
+
+    // --- check 7: a scenarios folder should test its neighbour ---
+
+    #[test]
+    fn a_scenario_folder_evaluating_its_neighbour_is_clean() {
+        let findings = run_checks(&scan(
+            vec![law(
+                "wet/wet_alpha/2025-01-01.yaml",
+                healthy("wet_alpha", "WET", "2025-01-01"),
+            )],
+            vec![
+                scenario("wet/wet_alpha/scenarios/een.feature", &[], &[]),
+                scenario("wet/wet_alpha/scenarios/twee.feature", &["wet_alpha"], &[]),
+            ],
+        ));
+        assert!(findings.is_empty(), "{findings:?}");
+    }
+
+    #[test]
+    fn a_scenario_folder_evaluating_only_other_laws_is_a_warning() {
+        let findings = run_checks(&scan(
+            vec![
+                law(
+                    "wet/wet_alpha/2025-01-01.yaml",
+                    healthy("wet_alpha", "WET", "2025-01-01"),
+                ),
+                law(
+                    "wet/wet_beta/2025-01-01.yaml",
+                    healthy("wet_beta", "WET", "2025-01-01"),
+                ),
+            ],
+            vec![scenario(
+                "wet/wet_alpha/scenarios/basis.feature",
+                &["wet_beta"],
+                &[],
+            )],
+        ));
+        assert_eq!(
+            kinds(&findings),
+            vec![FindingKind::ScenarioDirectoryWithoutTarget]
+        );
+        assert_eq!(findings[0].severity, Severity::Warning);
+        assert_eq!(
+            findings[0].path.as_deref(),
+            Some("regulation/nl/wet/wet_alpha/scenarios")
+        );
+    }
+
+    #[test]
+    fn a_scenario_folder_next_to_a_renamed_law_targets_the_declared_id() {
+        // Folder `keur_alpha`, body `$id: keur_alpha_hoogland`, scenario
+        // evaluating the declared id: check 7 stays green (the scenario does
+        // test its neighbour) while check 1 reports the rename — the exact
+        // combination seen in the field.
+        let findings = run_checks(&scan(
+            vec![law(
+                "waterschaps_verordening/hoogland/keur_alpha/2025-01-01.yaml",
+                healthy(
+                    "keur_alpha_hoogland",
+                    "WATERSCHAPS_VERORDENING",
+                    "2025-01-01",
+                ),
+            )],
+            vec![scenario(
+                "waterschaps_verordening/hoogland/keur_alpha/scenarios/basis.feature",
+                &["keur_alpha_hoogland"],
+                &[],
+            )],
+        ));
+        assert_eq!(kinds(&findings), vec![FindingKind::DirectoryNameMismatch]);
+    }
+
+    // --- unreadable files ---
+
+    #[test]
+    fn an_unreadable_file_is_its_own_finding_and_the_rest_still_runs() {
+        let mut s = scan(
+            vec![law(
+                "wet/wet_beta/2024-01-01.yaml",
+                healthy("wet_beta", "WET", "2025-01-01"),
+            )],
+            vec![],
+        );
+        s.laws.push(ScannedFile {
+            relative_path: "wet/wet_alpha/2025-01-01.yaml".to_string(),
+            facts: Err("HTTP 403".to_string()),
+        });
+        let findings = run_checks(&s);
+        assert_eq!(
+            kinds(&findings),
+            vec![FindingKind::FileNameMismatch, FindingKind::FileUnreadable]
+        );
+        assert!(findings[1].message.contains("HTTP 403"), "{findings:?}");
+        assert_eq!(
+            findings[1].path.as_deref(),
+            Some("regulation/nl/wet/wet_alpha/2025-01-01.yaml")
+        );
+    }
+
+    // --- ordering & serialisation ---
+
+    #[test]
+    fn errors_sort_above_warnings() {
+        let findings = run_checks(&scan(
+            vec![law(
+                "wet/wet_alpha/2024-01-01.yaml",
+                healthy("wet_omega", "WET", "2024-01-01"),
+            )],
+            vec![scenario("wet/wet_alpha/scenarios/basis.feature", &[], &[])],
+        ));
+        assert_eq!(
+            kinds(&findings),
+            vec![
+                FindingKind::DirectoryNameMismatch,
+                FindingKind::ScenarioDirectoryWithoutTarget
+            ]
+        );
+    }
+
+    #[test]
+    fn severity_and_kind_serialise_as_stable_keys() {
+        let json = serde_json::to_value(Finding {
+            severity: Severity::Warning,
+            kind: FindingKind::ScenarioDirectoryWithoutTarget,
+            path: None,
+            law_id: None,
+            message: "m".to_string(),
+            remedy: "r".to_string(),
+        })
+        .expect("serialises");
+        assert_eq!(json["severity"], "warning");
+        assert_eq!(json["kind"], "scenario_directory_without_target");
+        // Absent optionals stay out of the payload entirely.
+        assert!(json.get("path").is_none());
+    }
+
+    #[test]
+    fn a_clean_corpus_yields_an_empty_list_not_an_error() {
+        assert!(run_checks(&CorpusScan::default()).is_empty());
+    }
+
+    // --- facts extraction ---
+
+    #[test]
+    fn law_facts_come_from_the_body_only() {
+        let facts = LawFacts::from_yaml(
+            r#"$id: wet_alpha
+regulatory_layer: WET
+valid_from: '2025-01-01'
+articles:
+  - number: '1'
+    machine_readable:
+      execution:
+        input:
+          - name: bedrag
+            source:
+              regulation: wet_beta
+              output: bedrag
+      implements:
+        - law: wet_gamma
+          article: '2'
+          open_term: tarief
+"#,
+        );
+        assert_eq!(facts.declared_id.as_deref(), Some("wet_alpha"));
+        assert_eq!(facts.regulatory_layer.as_deref(), Some("WET"));
+        assert_eq!(facts.valid_from.as_deref(), Some("2025-01-01"));
+        assert_eq!(
+            facts.references,
+            vec![
+                (LawReferenceKind::Implements, "wet_gamma".to_string()),
+                (LawReferenceKind::SourceRegulation, "wet_beta".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn scenario_facts_split_evaluated_from_loaded_laws() {
+        let facts = ScenarioFacts::from_feature(
+            r#"Feature: Alpha
+
+  Background:
+    Given law "wet_beta" is loaded
+
+  Scenario: Basis
+    Then I evaluate "bedrag" of "wet_alpha"
+"#,
+        );
+        assert_eq!(facts.evaluated_ids, vec!["wet_alpha"]);
+        assert_eq!(facts.loaded_ids, vec!["wet_beta"]);
+    }
+
+    #[test]
+    fn short_error_keeps_messages_inside_a_sentence() {
+        assert_eq!(short_error("kort"), "kort");
+        assert_eq!(short_error("twee\nregels"), "twee regels");
+        let long = short_error(&"x".repeat(500));
+        assert_eq!(long.chars().count(), 120);
+        assert!(long.ends_with('…'));
+    }
+}

--- a/packages/editor-api/src/traject_integrity.rs
+++ b/packages/editor-api/src/traject_integrity.rs
@@ -16,7 +16,10 @@
 //! This module is its counterpart: the repo reads fine — is what is *in* it
 //! internally consistent? Both run in-band, on the caller's own read token,
 //! for the same reason: the repo may be private and user-token-only, so the
-//! only credential that can see it is the one on the request.
+//! only credential that can see it is the one on the request. And both apply
+//! the same precedence when there is no personal token: the source's
+//! server-side one, which is what the traject's ordinary reads authenticate
+//! with.
 //!
 //! # Shape
 //!
@@ -1200,10 +1203,18 @@ pub async fn get_traject_integrity(
     headers: axum::http::HeaderMap,
 ) -> Result<Json<IntegrityReport>, (StatusCode, String)> {
     let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
-    // Same resolution (and same deferred 428 into the koppel-flow) as every
-    // other read of the writable-own source. Surfaced immediately here, since
-    // this endpoint reads nothing else.
     let token = resolve_own_read_token(&state, account.id, &headers, &traject).await?;
+    // No personal token means the backend reads this source with the
+    // server-side credential configured for it — and `resolve_own_read_token`
+    // answers `None` precisely because the backend carries that credential
+    // itself. This scan bypasses the backend and talks to GitHub directly, so
+    // it has to re-resolve that token or a private repo with a service token
+    // would be enumerated anonymously and 404 every time. Same fallback, in
+    // the same order, as the index diagnosis (`require_traject_index`).
+    let token = match token {
+        Some(tok) => Some(tok),
+        None => traject.own_server_token(),
+    };
 
     let scan = scan_own_source(&state, &traject, token.as_deref()).await?;
     let findings = run_checks(&scan);
@@ -1831,9 +1842,14 @@ articles:
 
   Scenario: Basis
     Then I evaluate "bedrag" of "wet_alpha"
+
+  Scenario: Meerdere uitkomsten
+    When I evaluate outputs "bedrag, recht" of "wet_omega"
 "#,
         );
-        assert_eq!(facts.evaluated_ids, vec!["wet_alpha"]);
+        // Both evaluation steps count as targets — a folder whose scenarios
+        // only use the multi-output form still tests its law.
+        assert_eq!(facts.evaluated_ids, vec!["wet_alpha", "wet_omega"]);
         assert_eq!(facts.loaded_ids, vec!["wet_beta"]);
     }
 

--- a/packages/editor-api/tests/list_scenarios_test.rs
+++ b/packages/editor-api/tests/list_scenarios_test.rs
@@ -46,6 +46,7 @@ fn empty_state(pool: PgPool) -> AppState {
         pipeline_api_url: None,
         harvest_admin_url: None,
         reload_lock: Arc::new(Mutex::new(())),
+        integrity: Default::default(),
         trajects: Arc::new(TrajectCorpusCache::new()),
     }
 }
@@ -249,6 +250,7 @@ async fn list_scenarios_global_returns_target_law_ids() {
         pipeline_api_url: None,
         harvest_admin_url: None,
         reload_lock: Arc::new(Mutex::new(())),
+        integrity: Default::default(),
         trajects: Arc::new(TrajectCorpusCache::new()),
     };
 

--- a/packages/editor-api/tests/promote_law_test.rs
+++ b/packages/editor-api/tests/promote_law_test.rs
@@ -50,6 +50,7 @@ fn empty_state(pool: PgPool) -> AppState {
         pipeline_api_url: None,
         harvest_admin_url: None,
         reload_lock: Arc::new(Mutex::new(())),
+        integrity: Default::default(),
         trajects: Arc::new(TrajectCorpusCache::new()),
     }
 }

--- a/packages/editor-api/tests/promote_user_token_write_test.rs
+++ b/packages/editor-api/tests/promote_user_token_write_test.rs
@@ -65,6 +65,7 @@ fn state_with_user_token_mode(pool: PgPool, oauth: GithubOAuth) -> AppState {
         pipeline_api_url: None,
         harvest_admin_url: None,
         reload_lock: Arc::new(Mutex::new(())),
+        integrity: Default::default(),
         trajects: Arc::new(TrajectCorpusCache::new()),
     }
 }

--- a/packages/editor-api/tests/save_annotations_test.rs
+++ b/packages/editor-api/tests/save_annotations_test.rs
@@ -66,6 +66,7 @@ fn empty_state(pool: PgPool) -> AppState {
         pipeline_api_url: None,
         harvest_admin_url: None,
         reload_lock: Arc::new(Mutex::new(())),
+        integrity: Default::default(),
         trajects: Arc::new(TrajectCorpusCache::new()),
     }
 }

--- a/packages/editor-api/tests/service_token_write_precedence_test.rs
+++ b/packages/editor-api/tests/service_token_write_precedence_test.rs
@@ -83,6 +83,7 @@ fn state_with_user_token_mode(pool: PgPool, oauth: GithubOAuth) -> AppState {
         pipeline_api_url: None,
         harvest_admin_url: None,
         reload_lock: Arc::new(Mutex::new(())),
+        integrity: Default::default(),
         trajects: Arc::new(TrajectCorpusCache::new()),
     }
 }

--- a/packages/editor-api/tests/traject_harvest_request_test.rs
+++ b/packages/editor-api/tests/traject_harvest_request_test.rs
@@ -49,6 +49,7 @@ fn empty_state(pool: PgPool) -> AppState {
         pipeline_api_url: None,
         harvest_admin_url: None,
         reload_lock: Arc::new(Mutex::new(())),
+        integrity: Default::default(),
         trajects: Arc::new(TrajectCorpusCache::new()),
     }
 }

--- a/packages/editor-api/tests/traject_index_user_token_test.rs
+++ b/packages/editor-api/tests/traject_index_user_token_test.rs
@@ -79,6 +79,7 @@ fn state_with_user_token_mode(pool: PgPool, oauth: GithubOAuth) -> AppState {
         pipeline_api_url: None,
         harvest_admin_url: None,
         reload_lock: Arc::new(Mutex::new(())),
+        integrity: Default::default(),
         trajects: Arc::new(TrajectCorpusCache::new()),
     }
 }

--- a/packages/editor-api/tests/traject_integrity_test.rs
+++ b/packages/editor-api/tests/traject_integrity_test.rs
@@ -96,7 +96,13 @@ fn state_with_user_token_mode(pool: PgPool, oauth: GithubOAuth) -> AppState {
             github_oauth: Some(oauth),
             task_enrich_provider: "claude".to_string(),
         }),
-        http_client: reqwest::Client::new(),
+        // regelrecht_auth::http_client(), niet reqwest::Client::new(): editor-api
+        // bouwt reqwest met `rustls-tls-webpki-roots-no-provider`, dus rustls
+        // kiest geen backend uit zichzelf. Een test heeft geen `main` die de
+        // provider installeert, dus doet deze helper dat - anders paniekt de
+        // eerste client met "No provider set". Zo doen de andere editor-api
+        // integratietests het ook.
+        http_client: regelrecht_auth::http_client(),
         pool: Some(pool),
         pipeline_api_url: None,
         harvest_admin_url: None,

--- a/packages/editor-api/tests/traject_integrity_test.rs
+++ b/packages/editor-api/tests/traject_integrity_test.rs
@@ -1,0 +1,350 @@
+//! Integriteitsrapport over de eigen repo van een traject, end-to-end tegen
+//! een nagespeelde GitHub.
+//!
+//! De pure checks zijn per stuk gedekt door de unit-tests in
+//! `traject_integrity.rs`; wat daar niet in past is de **bekabeling**:
+//!
+//! * met welk credential de scan de repo opsomt. Een writable-own met een
+//!   geconfigureerd service-token is "writable at rest", en de per-request
+//!   tokenresolutie antwoordt dan bewust `None` — juist omdat de backend het
+//!   token zelf draagt. De scan praat langs de backend heen rechtstreeks met
+//!   GitHub, dus die moet dat server-token opnieuw resolven; doet hij dat
+//!   niet, dan somt hij een privé-repo anoniem op en faalt elke aanroep met
+//!   een 502. Deze test pint dat vast: de Trees- en Contents-mocks matchen
+//!   alléén op `Bearer <service-token>`.
+//! * dat een verwijzing naar een wet uit een *andere* bron van het traject
+//!   (de seed) gewoon resolvet, en de mapnaam-afwijking wél wordt gemeld.
+//! * dat een tweede aanroep zonder nieuwe commits geen enkele body opnieuw
+//!   leest (de memo op blob-sha).
+//!
+//! GitHub wordt gespeeld door wiremock via de proces-brede
+//! `GITHUB_API_BASE`-seam en het service-token komt uit een env var — beide
+//! proces-breed, dus alle scenario's staan in ÉÉN test (zelfde afweging als
+//! `service_token_write_precedence_test.rs`). Alle namen zijn fictief: dit is
+//! een publieke repo.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use axum::extract::{Extension, Path, State};
+use axum::http::HeaderMap;
+use pretty_assertions::assert_eq;
+use sqlx::PgPool;
+use tokio::sync::{Mutex, RwLock};
+use tower_sessions::Session;
+use tower_sessions_memory_store::MemoryStore;
+use uuid::Uuid;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use regelrecht_auth::handlers::{
+    SESSION_KEY_EMAIL, SESSION_KEY_EMAIL_VERIFIED, SESSION_KEY_NAME, SESSION_KEY_SUB,
+};
+use regelrecht_editor_api::accounts::AccountRecord;
+use regelrecht_editor_api::config::AppConfig;
+use regelrecht_editor_api::github_oauth::GithubOAuth;
+use regelrecht_editor_api::state::{AppState, CorpusState};
+use regelrecht_editor_api::traject_corpus::TrajectCorpusCache;
+use regelrecht_editor_api::traject_integrity::{get_traject_integrity, FindingKind};
+
+use regelrecht_pipeline::test_utils::TestDb;
+
+const OWN_REPO: &str = "example-org/regelrecht-corpus-example";
+const OWN_BRANCH: &str = "traject-voorbeeld";
+const OWN_SUBPATH: &str = "corpus/regulation";
+const SERVICE_AUTH_REF: &str = "example-integrity-token-ref";
+const SERVICE_TOKEN_ENV: &str = "CORPUS_AUTH_EXAMPLE_INTEGRITY_TOKEN_REF_TOKEN";
+const SERVICE_TOKEN: &str = "service-token";
+
+/// De wet met een kloppende map: mapnaam == `$id`, bestandsnaam ==
+/// `valid_from`, en een verwijzing naar een wet uit de seed-bron.
+const CLEAN_PATH: &str = "wet/wet_alpha/2025-01-01.yaml";
+const CLEAN_BODY: &str = "\
+$id: wet_alpha
+valid_from: '2025-01-01'
+articles:
+  - number: '1'
+    machine_readable:
+      execution:
+        input:
+          - name: bedrag
+            type: amount
+            source:
+              regulation: wet_seed_voorbeeld
+              output: grondslag
+";
+
+/// De wet met de afwijking waar de pagina om begonnen is: de map heet
+/// `wet_beta`, de YAML declareert `wet_beta_afwijkend`.
+const MISMATCH_PATH: &str = "wet/wet_beta/2025-01-01.yaml";
+const MISMATCH_BODY: &str = "\
+$id: wet_beta_afwijkend
+valid_from: '2025-01-01'
+";
+
+const SEED_LAW_ID: &str = "wet_seed_voorbeeld";
+
+fn state_with_user_token_mode(pool: PgPool, oauth: GithubOAuth) -> AppState {
+    AppState {
+        corpus: Arc::new(RwLock::new(CorpusState::empty())),
+        oidc_client: None,
+        end_session_url: None,
+        config: Arc::new(AppConfig {
+            oidc: None,
+            base_url: None,
+            github_oauth: Some(oauth),
+            task_enrich_provider: "claude".to_string(),
+        }),
+        http_client: reqwest::Client::new(),
+        pool: Some(pool),
+        pipeline_api_url: None,
+        harvest_admin_url: None,
+        reload_lock: Arc::new(Mutex::new(())),
+        integrity: Default::default(),
+        trajects: Arc::new(TrajectCorpusCache::new()),
+    }
+}
+
+async fn seed_account(pool: &PgPool, email: &str) -> (Uuid, String) {
+    let sub = format!("sub-{email}");
+    let (id,): (Uuid,) = sqlx::query_as(
+        "INSERT INTO accounts (person_sub, email, name) VALUES ($1, $2, $3) RETURNING id",
+    )
+    .bind(&sub)
+    .bind(email)
+    .bind("Test User")
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    (id, sub)
+}
+
+/// Traject met een GitHub writable-own (service-token via `auth_ref`) plus
+/// een lokale seed als centraal corpus.
+async fn seeded_traject(pool: &PgPool, owner_id: Uuid, seed_dir: &std::path::Path) -> Uuid {
+    let (gh_owner, gh_repo) = OWN_REPO.split_once('/').unwrap();
+    let (traject_id,): (Uuid,) = sqlx::query_as(
+        "INSERT INTO trajects (name, description, scope, created_by)
+         VALUES ('Test', '', '', $1) RETURNING id",
+    )
+    .bind(owner_id)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO traject_members (traject_id, account_id, role)
+         VALUES ($1, $2, 'owner')",
+    )
+    .bind(traject_id)
+    .bind(owner_id)
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO traject_corpus_sources
+         (traject_id, source_id, name, source_type,
+          gh_owner, gh_repo, gh_branch, gh_base_branch, gh_path,
+          priority, auth_ref, is_writable_own)
+         VALUES ($1, 'traject-own-test', 'Eigen repo', 'github'::corpus_source_type,
+                 $2, $3, $4, 'main', $5,
+                 0, $6, TRUE)",
+    )
+    .bind(traject_id)
+    .bind(gh_owner)
+    .bind(gh_repo)
+    .bind(OWN_BRANCH)
+    .bind(OWN_SUBPATH)
+    .bind(SERVICE_AUTH_REF)
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO traject_corpus_sources
+         (traject_id, source_id, name, source_type, local_path,
+          priority, scopes, is_writable_own)
+         VALUES ($1, 'central-seed', 'Centrale Corpus', 'local'::corpus_source_type, $2,
+                 2, '[]'::jsonb, FALSE)",
+    )
+    .bind(traject_id)
+    .bind(seed_dir.to_string_lossy().to_string())
+    .execute(pool)
+    .await
+    .unwrap();
+    traject_id
+}
+
+fn traject_ref(traject_id: Uuid) -> String {
+    format!("test-{}", &traject_id.to_string()[..8])
+}
+
+async fn session_for(sub: &str) -> Session {
+    let session = Session::new(None, Arc::new(MemoryStore::default()), None);
+    session.insert(SESSION_KEY_SUB, sub).await.unwrap();
+    session.insert(SESSION_KEY_NAME, "Test User").await.unwrap();
+    session
+        .insert(SESSION_KEY_EMAIL, "alice@test.local")
+        .await
+        .unwrap();
+    session
+        .insert(SESSION_KEY_EMAIL_VERIFIED, true)
+        .await
+        .unwrap();
+    session
+}
+
+/// De wet die het "centrale corpus" bijdraagt — het doel van de
+/// `source.regulation`-verwijzing in `CLEAN_BODY`.
+fn write_seed_law(seed_dir: &std::path::Path) {
+    let law_dir = seed_dir.join("wet").join(SEED_LAW_ID);
+    std::fs::create_dir_all(&law_dir).unwrap();
+    std::fs::write(
+        law_dir.join("2025-01-01.yaml"),
+        format!("$id: {SEED_LAW_ID}\nname: Seed-versie\nvalid_from: '2025-01-01'\n"),
+    )
+    .unwrap();
+}
+
+/// Branch-check bij het opzetten van de backend: de traject-branch bestaat
+/// al, dus geen bootstrap-flow.
+async fn mount_branch_exists(server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/repos/{OWN_REPO}/git/ref/heads/{OWN_BRANCH}"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ref": format!("refs/heads/{OWN_BRANCH}"),
+            "object": { "sha": "branch-sha" },
+        })))
+        .mount(server)
+        .await;
+}
+
+/// Trees-listing van de traject-branch, mét blob-sha per bestand (de memo
+/// hangt eraan) — alleen leesbaar mét het service-token.
+async fn mount_tree(server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/{OWN_REPO}/git/trees/{OWN_BRANCH}")))
+        .and(header("authorization", format!("Bearer {SERVICE_TOKEN}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "sha": "tree-sha",
+            "truncated": false,
+            "tree": [
+                {"path": OWN_SUBPATH, "type": "tree"},
+                {"path": format!("{OWN_SUBPATH}/{CLEAN_PATH}"), "type": "blob", "sha": "blob-alpha"},
+                {"path": format!("{OWN_SUBPATH}/{MISMATCH_PATH}"), "type": "blob", "sha": "blob-beta"},
+                {"path": "README.md", "type": "blob", "sha": "blob-readme"},
+            ],
+        })))
+        .mount(server)
+        .await;
+}
+
+/// Eén law-body, eveneens alleen met het service-token te lezen.
+async fn mount_body(server: &MockServer, relative_path: &str, body: &'static str) {
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/repos/{OWN_REPO}/contents/{OWN_SUBPATH}/{relative_path}"
+        )))
+        .and(header("authorization", format!("Bearer {SERVICE_TOKEN}")))
+        .respond_with(ResponseTemplate::new(200).set_body_string(body))
+        .mount(server)
+        .await;
+}
+
+/// Hoeveel body-reads (Contents-GETs) wiremock tot nu toe zag.
+async fn contents_requests(server: &MockServer) -> usize {
+    server
+        .received_requests()
+        .await
+        .unwrap()
+        .iter()
+        .filter(|r| {
+            r.url
+                .path()
+                .starts_with(&format!("/repos/{OWN_REPO}/contents/"))
+        })
+        .count()
+}
+
+#[tokio::test]
+async fn integrity_scan_reads_with_the_service_token_and_memoises_bodies() {
+    let server = MockServer::start().await;
+    std::env::set_var("GITHUB_API_BASE", server.uri());
+    std::env::set_var(SERVICE_TOKEN_ENV, SERVICE_TOKEN);
+
+    let db = TestDb::new().await;
+    let central = tempfile::tempdir().unwrap();
+    write_seed_law(central.path());
+
+    // User-token-modus AAN én een gebruiker zónder gekoppeld GitHub-account:
+    // een writable-own met service-token mag daar niet op stuklopen.
+    let oauth = GithubOAuth::for_tests(true);
+    let state = state_with_user_token_mode(db.pool.clone(), oauth);
+
+    let (owner_id, sub) = seed_account(&db.pool, "alice@test.local").await;
+    let account = AccountRecord {
+        id: owner_id,
+        person_sub: sub.clone(),
+        email: "alice@test.local".to_string(),
+        name: "Test User".to_string(),
+    };
+
+    let traject_id = seeded_traject(&db.pool, owner_id, central.path()).await;
+    let tref = traject_ref(traject_id);
+
+    mount_branch_exists(&server).await;
+    mount_tree(&server).await;
+    mount_body(&server, CLEAN_PATH, CLEAN_BODY).await;
+    mount_body(&server, MISMATCH_PATH, MISMATCH_BODY).await;
+
+    let session = session_for(&sub).await;
+    let report = get_traject_integrity(
+        State(state.clone()),
+        session.clone(),
+        Extension(account.clone()),
+        Path(tref.clone()),
+        HeaderMap::new(),
+    )
+    .await
+    .expect("integriteitsrapport moet met het service-token te bouwen zijn")
+    .0;
+
+    // Twee wetbestanden nagekeken; de README telt niet mee.
+    assert_eq!(report.checked_laws, 2);
+    assert_eq!(report.checked_scenarios, 0);
+
+    // Precies één bevinding: de mapnaam die van het `$id` afwijkt. De
+    // verwijzing naar de seed-wet resolvet via de federatie-index, dus die
+    // levert géén tweede (gevolg-)bevinding op.
+    let kinds: Vec<FindingKind> = report.findings.iter().map(|f| f.kind).collect();
+    assert_eq!(kinds, vec![FindingKind::DirectoryNameMismatch]);
+    let finding = &report.findings[0];
+    assert_eq!(finding.law_id.as_deref(), Some("wet_beta_afwijkend"));
+    assert_eq!(
+        finding.path.as_deref(),
+        Some("corpus/regulation/wet/wet_beta")
+    );
+
+    let after_first = contents_requests(&server).await;
+    assert_eq!(after_first, 2, "koude scan leest beide bodies");
+
+    // Tweede aanroep zonder nieuwe commits: dezelfde blob-sha's, dus de memo
+    // dekt alles en er gaat geen enkele body opnieuw over de lijn.
+    let again = get_traject_integrity(
+        State(state),
+        session,
+        Extension(account),
+        Path(tref),
+        HeaderMap::new(),
+    )
+    .await
+    .expect("tweede aanroep moet ook slagen")
+    .0;
+    assert_eq!(again.findings.len(), 1);
+    assert_eq!(
+        contents_requests(&server).await,
+        after_first,
+        "een herhaalde scan op ongewijzigde blob-sha's leest geen bodies opnieuw"
+    );
+}

--- a/packages/editor-api/tests/traject_own_index_test.rs
+++ b/packages/editor-api/tests/traject_own_index_test.rs
@@ -77,6 +77,7 @@ fn state_with_user_token_mode(pool: PgPool, oauth: GithubOAuth) -> AppState {
         pipeline_api_url: None,
         harvest_admin_url: None,
         reload_lock: Arc::new(Mutex::new(())),
+        integrity: Default::default(),
         trajects: Arc::new(TrajectCorpusCache::new()),
     }
 }

--- a/packages/editor-api/tests/traject_reads_test.rs
+++ b/packages/editor-api/tests/traject_reads_test.rs
@@ -57,6 +57,7 @@ fn empty_state(pool: PgPool) -> AppState {
         pipeline_api_url: None,
         harvest_admin_url: None,
         reload_lock: Arc::new(Mutex::new(())),
+        integrity: Default::default(),
         trajects: Arc::new(TrajectCorpusCache::new()),
     }
 }

--- a/packages/editor-api/tests/traject_user_token_reads_test.rs
+++ b/packages/editor-api/tests/traject_user_token_reads_test.rs
@@ -83,6 +83,7 @@ fn state_with_user_token_mode(pool: PgPool, oauth: GithubOAuth) -> AppState {
         pipeline_api_url: None,
         harvest_admin_url: None,
         reload_lock: Arc::new(Mutex::new(())),
+        integrity: Default::default(),
         trajects: Arc::new(TrajectCorpusCache::new()),
     }
 }

--- a/packages/editor-api/tests/trajects_test.rs
+++ b/packages/editor-api/tests/trajects_test.rs
@@ -51,6 +51,7 @@ fn empty_state(pool: PgPool) -> AppState {
         pipeline_api_url: None,
         harvest_admin_url: None,
         reload_lock: Arc::new(Mutex::new(())),
+        integrity: Default::default(),
         trajects: Arc::new(TrajectCorpusCache::new()),
     }
 }

--- a/packages/editor-api/tests/user_notes_test.rs
+++ b/packages/editor-api/tests/user_notes_test.rs
@@ -45,6 +45,7 @@ fn empty_state(pool: PgPool) -> AppState {
         pipeline_api_url: None,
         harvest_admin_url: None,
         reload_lock: Arc::new(Mutex::new(())),
+        integrity: Default::default(),
         trajects: Arc::new(TrajectCorpusCache::new()),
     }
 }


### PR DESCRIPTION
## Waarom

De wettenindex leest het id van een GitHub-backed wet af van de **mapnaam**, via padopsomming zonder de YAML te openen (`source_map::load_metadata_entry`). De editor gaat na het laden over op het `$id` uit de body (`useLaw.js`). Wijken die twee af, dan vraagt de editor om een id dat de index nooit heeft gezien, en 404't alles wat daarna komt: "Genereer een voorstel" faalt met "Verrijking aanvragen mislukt", scenario's en versies blijven leeg. Elk afzonderlijk antwoord ("niet gevonden") is volstrekt gewoon, dus nergens staat wat er mis is.

Deze PR maakt die klasse van configuratiefouten zichtbaar, mét de fix erbij.

`traject_index_diagnosis.rs` beantwoordt "mag ik deze repo lezen". Dit is de inhoudelijke tegenhanger: de repo leest prima — klopt wat erin staat?

## Wat

### Endpoint

`GET /api/trajects/{traject_ref}/integrity`, achter dezelfde membership-guard als de andere traject-routes en lezend met hetzelfde per-request token (`resolve_own_read_token`) — een repo die alleen met een gebruikerstoken te lezen is, wordt nooit met een servertoken benaderd.

Zeven checks over de eigen repo van het traject:

| # | Check | Severity |
|---|---|---|
| 1 | Mapnaam ≠ `$id` | fout |
| 2 | Bestandsnaam ≠ `valid_from` | fout |
| 3 | Laag-map ≠ `regulatory_layer` (extra organisatie-segment getolereerd) | fout |
| 4 | Twee mappen met hetzelfde `$id` | fout |
| 5 | `source.regulation` / `implements` naar een onbekend `$id` | fout |
| 6 | Scenario-stap naar een onbekend `$id` | fout |
| 7 | `scenarios/`-map die de buurwet niet evalueert | waarschuwing |

Elke bevinding draagt severity, een stabiele kind-sleutel, het pad zoals het in de repo staat, een Nederlandse omschrijving en een concrete remedie ("Hernoem de map `…/wet_a` naar `…/wet_a_x`, zodat de mapnaam gelijk is aan het `$id`"). Geen bevindingen levert een lege lijst op, geen fout.

Twee ontwerpkeuzes die het rapport bruikbaar houden:

- **Verwijzingen resolven tegen index ∪ gedeclareerde `$id`s.** Een wet met een afwijkende mapnaam staat alleen ónder die mapnaam in de index; alleen daartegen resolven zou elke verwijzing naar die wet als dangling melden — een lawine van gevolgen bovenop de ene bevinding die de oorzaak noemt.
- **Check 7 vergelijkt met het gedeclareerde `$id`**, niet met de mapnaam. Bij een afwijking hoort dat probleem bij check 1; het hier nog eens anders verwoord herhalen wijst de lezer de verkeerde kant op.

### Kosten

Eén Trees-call somt de hele branch op, inclusief een blob-sha per bestand. De uit een body afgeleide feiten worden op die sha gememoiseerd (proceswijd, per traject), dus een **herhaalde aanroep zonder nieuwe commits leest geen enkele body opnieuw** — hij kost precies die ene Trees-request. Na een push worden alleen de gewijzigde blobs opgehaald, in batches van acht parallel. De memo hangt bewust aan `AppState` en niet aan de per-traject index-snapshot: die wordt elke minuut vernieuwd, wat de memo juist zou weggooien.

Een mislukte leesactie op één bestand levert een eigen bevinding op ("kon niet gelezen worden"); de rest van de checks draait gewoon door.

### Pagina

`/trajecten/{ref}/integriteit` (`requiresAuth`, titel "Integriteit"), bereikbaar via Instellingen → Algemeen. Laad-, fout- en lege staat, en anders de bevindingen gegroepeerd op severity — fouten boven waarschuwingen — elk met omschrijving en remedie. Herlaadt bij openen; een verversknop als aanvulling, geen polling.

**Geen extra CSS**: alles is opgebouwd uit bestaande NDD-componenten (`nldd-simple-section`, `nldd-list variant="box"`, `nldd-inline-dialog`, `nldd-activity-indicator`, `nldd-toolbar`).

### DRY

- `collect_law_references` komt naast `collect_law_implements` in de corpus-crate te staan (structurele walk, zodat een verwijzing op een nieuwe nestingdiepte niet stilletjes gemist wordt).
- De bestaande `extract_target_law_ids` wordt hergebruikt en krijgt er een `law "…" is loaded`-variant naast; de grammatica zelf blijft ongemoeid. Hij dekt nu wel beide evaluatiestappen uit `grammar.yaml` — ook `I evaluate outputs "…" of "…"`, die de wet op dezelfde plek noemt.
- `TrajectCorpus::own_source()` deelt de registry-lookup met `own_source_target()`.

## Buiten scope

De waarschuwingsbalk in de editor-view zelf, een statuskaart op Instellingen, self-healing/aliassen in de index, checks in de CLI-validator, en datafixes in bestaande corpus-repo's.

## Tests

- 28 unit-tests op de check-functies (elk van de zeven checks rood én groen), plus padsplitsing, ordening, serialisatie en de feiten-extractie. Fixtures gebruiken uitsluitend fictieve wet- en mapnamen.
- Een end-to-end test tegen een nagespeelde GitHub: de scan somt de branch op met het server-token van de bron (de mocks matchen alleen daarop) en een tweede aanroep op ongewijzigde blob-sha's leest geen enkele body opnieuw.
- Frontend-tests voor gerenderd rapport, lege staat, fout-staat, de verversknop en de groepering; plus een router-test die vastpint dat het pad niet door een AppShell-child wordt opgeslokt.
- `just format`, `just lint`, `just build-check`, `just validate` en `npm test -w frontend` (773 tests) zijn groen, net als de volledige Rust-suite van `editor-api` en `corpus` — inclusief de testcontainers-suites, gedraaid tegen een losse Postgres via `TEST_POSTGRES_URL`.

