### PR TITLE
fix(editor): takenstatus in de editor en ongequote artikelnummers in de review-split

### DIFF
--- a/frontend/src/EditorView.vue
+++ b/frontend/src/EditorView.vue
@@ -8,8 +8,7 @@ import { useEngine } from './composables/useEngine.js';
 import { useAuth } from './composables/useAuth.js';
 import { useTrajects } from './composables/useTrajects.js';
 import { useFeatureFlags } from './composables/useFeatureFlags.js';
-import { useTaskActions, usePollWhile } from './composables/useTasks.js';
-import { reviewTarget } from './lib/taskReview.js';
+import { useEnrichState } from './composables/useEnrichState.js';
 import { useTaskReview } from './composables/useTaskReview.js';
 import { useNotes, useResolvedDraftNotes } from './composables/useNotes.js';
 import { useDraftNotes } from './composables/useDraftNotes.js';
@@ -1757,55 +1756,25 @@ async function rejectReview() {
 // --- Verrijken aanvragen (levert een job_review-taak op) -----------------
 // Fire-and-forget request; the resulting job_review task shows up in the
 // taken-lijst in Home on its next poll (TasksSidebarItem/TasksListPane poll
-// via useTasks() every 30s). Use the non-polling useTaskActions() here -
-// EditorView doesn't need the shared task list/badge count, and joining
-// useTasks() unconditionally in setup() would start that poll for every
-// editor visitor, including anonymous ones.
-const { requestEnrich, running: runningJobs, tasks: openTasks } = useTaskActions();
-// Staat er al een beoordeelbaar voorstel klaar voor deze wet? Dan meldt de lege
-// pane dat, in plaats van opnieuw te laten genereren.
-// Eén verrijking levert een taak per gewijzigd artikel, dus meestal staan er
-// meerdere open voor deze wet. Je kijkt naar één artikel, dus de taak van dát
-// artikel gaat voor; is die er niet, dan de eerste van de wet - beter naar een
-// naburig voorstel wijzen dan naar niets.
-const pendingReviewTask = computed(() => {
-  const forLaw = openTasks.value.filter(
-    (t) => t.task_type === 'job_review' && t.payload?.law_id === lawId.value,
-  );
-  if (!forLaw.length) return null;
-  const here = String(selectedArticleNumber.value ?? '');
-  return forLaw.find((t) => String(t.payload?.article ?? '') === here) ?? forLaw[0];
+// via useTasks() every 30s). Gedeeld met LibraryView, dat dezelfde wet in
+// dezelfde panes toont: useEnrichState houdt de bezig-/voorstel-staat bij en
+// ververst de gedeelde takenlijst waar dat nodig is (mount, na een aanvraag),
+// zonder de 30s-poll van useTasks() te starten voor elke editor-bezoeker.
+const {
+  isEnriching,
+  reviewReady,
+  reviewArticleForPane,
+  openReviewForLaw,
+  openTasksForLaw,
+  requestEnrich,
+} = useEnrichState({
+  trajectRef: activeTrajectRef,
+  lawId,
+  articleNumber: selectedArticleNumber,
+  // Niet melden dat er een voorstel klaarstaat terwijl je die taak al aan het
+  // beoordelen bent.
+  reviewActive,
 });
-// Niet melden terwijl je die taak al aan het beoordelen bent.
-const reviewReady = computed(() => !!pendingReviewTask.value && !reviewActive.value);
-const reviewArticleForPane = computed(() =>
-  pendingReviewTask.value?.payload?.article == null
-    ? ''
-    : String(pendingReviewTask.value.payload.article),
-);
-function openReviewForLaw() {
-  const target = reviewTarget(pendingReviewTask.value);
-  if (target) router.push(target);
-}
-// Loopt er al een verrijking voor deze wet? Dan meldt de lege pane dat in
-// plaats van opnieuw de knoppen aan te bieden.
-// Naar de takenlijst, gefilterd op deze wet: daar staat de lopende aanvraag.
-function openTasksForLaw() {
-  if (!activeTrajectRef.value || !lawId.value) return;
-  router.push({
-    name: 'taken-traject',
-    params: {
-      trajectRef: activeTrajectRef.value,
-      categorie: 'wet',
-      contextLawId: lawId.value,
-    },
-  });
-}
-// Alleen pollen zolang je naar de bezig-staat kijkt; zie usePollWhile.
-const isEnriching = computed(() =>
-  runningJobs.value.some((job) => job.job_type === 'enrich' && job.law_id === lawId.value),
-);
-usePollWhile(isEnriching);
 const enrichFeedback = ref(null); // { variant, text } | null
 // An actual traject open (write access implies a traject, see `canEdit`
 // above) and a law loaded - mirrors the gates other write actions in this
@@ -1824,7 +1793,7 @@ const isEnrichPane = (view) => view === 'machine' || view === 'yaml';
 async function enrichLaw() {
   if (!activeTrajectRef.value || !lawId.value) return;
   try {
-    const { alreadyRunning, tooMany } = await requestEnrich(activeTrajectRef.value, lawId.value);
+    const { alreadyRunning, tooMany } = await requestEnrich();
     if (alreadyRunning) {
       enrichFeedback.value = { variant: 'warning', text: 'Er loopt al een verrijking voor deze wet.' };
     } else if (tooMany) {

--- a/frontend/src/LibraryView.vue
+++ b/frontend/src/LibraryView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, shallowRef, nextTick, watch, watchEffect, onMounted, onBeforeUnmount, inject } from 'vue';
+import { ref, computed, shallowRef, nextTick, watch, watchEffect, onBeforeUnmount, inject } from 'vue';
 import { useRoute, useRouter, onBeforeRouteUpdate, onBeforeRouteLeave } from 'vue-router';
 import * as yaml from 'js-yaml';
 import ArticleText from './components/ArticleText.vue';
@@ -18,11 +18,11 @@ import TasksListPane from './components/TasksListPane.vue';
 import TasksSidebarItem from './components/TasksSidebarItem.vue';
 import { useAuth } from './composables/useAuth.js';
 import { useCorpusLaws } from './composables/useCorpusLaws.js';
-// useTaskActions, niet useTasks: LibraryView heeft alleen de refresh nodig na
-// een geannuleerde job en mag daarvoor niet de 30s-poll aanzetten (die hoort
-// bij de taken-componenten, en anonieme bezoekers pollen nooit).
-import { useTaskActions, usePollWhile } from './composables/useTasks.js';
-import { reviewTarget } from './lib/taskReview.js';
+// useEnrichState (bovenop useTaskActions), niet useTasks: LibraryView heeft
+// alleen gerichte refreshes nodig - na een geannuleerde job, na een eigen
+// aanvraag - en mag daarvoor niet de 30s-poll aanzetten (die hoort bij de
+// taken-componenten, en anonieme bezoekers pollen nooit).
+import { useEnrichState } from './composables/useEnrichState.js';
 import { lawFetchInit } from './composables/useLaw.js';
 import { useTrajects, refreshTrajects } from './composables/useTrajects.js';
 import { lawsListUrl, lawUrl, lawUploadUrl, changedLawsUrl } from './composables/corpusUrls.js';
@@ -101,39 +101,6 @@ function goToAccountRequest() {
 // so it can reserve converting target names against create/rename collisions.
 const docJobs = useTrajectDocumentJobs(activeTrajectRef);
 const { jobs: conversionJobs, cancelJob: cancelConversionJob } = docJobs;
-const { refresh: refreshTasks, requestEnrich, running: runningJobs, tasks: openTasks } = useTaskActions();
-
-// Loopt er al een verrijking voor deze wet? Dan toont de lege pane dat in
-// plaats van de knoppen; een tweede aanvraag zou toch op een 409 stuiten.
-const isEnriching = computed(() =>
-  runningJobs.value.some(
-    (job) => job.job_type === 'enrich' && job.law_id === selectedLawId.value,
-  ),
-);
-// Alleen pollen zolang je naar de bezig-staat kijkt; zie usePollWhile.
-
-// Staat er al een beoordeelbaar voorstel klaar voor deze wet? Een verrijking
-// levert een taak per gewijzigd artikel, dus die van het geopende artikel gaat
-// voor; anders de eerste van de wet.
-const pendingReviewTask = computed(() => {
-  const forLaw = openTasks.value.filter(
-    (t) => t.task_type === 'job_review' && t.payload?.law_id === selectedLawId.value,
-  );
-  if (!forLaw.length) return null;
-  const here = String(selectedArticleNumber.value ?? '');
-  return forLaw.find((t) => String(t.payload?.article ?? '') === here) ?? forLaw[0];
-});
-const reviewReady = computed(() => !!pendingReviewTask.value);
-const reviewArticleForPane = computed(() =>
-  pendingReviewTask.value?.payload?.article == null
-    ? ''
-    : String(pendingReviewTask.value.payload.article),
-);
-function openReviewForLaw() {
-  const target = reviewTarget(pendingReviewTask.value);
-  if (target) router.push(target);
-}
-
 // Verrijken kan ook vanuit de corpusweergave, met dezelfde twee knoppen als in
 // een traject. De knop staat er dus altijd zodra er een wet is; ontbreekt de
 // login of het traject, dan routeert hij net als "Bewerken" ernaast in plaats
@@ -142,25 +109,6 @@ function openReviewForLaw() {
 const canEnrich = computed(() => !!selectedLawId.value);
 
 const enrichError = ref('');
-
-// `running` wordt alleen door een refresh gevuld; deze view pollt niet. Eén keer
-// bij mount is genoeg om na een herlaad te weten of er al iets loopt.
-onMounted(() => {
-  if (authenticated.value) refreshTasks();
-});
-// Naar de takenlijst, gefilterd op deze wet: dezelfde context waar de lopende
-// aanvraag als rij met activity-indicator staat.
-function openTasksForLaw() {
-  if (!activeTrajectRef.value || !selectedLawId.value) return;
-  router.push({
-    name: 'taken-traject',
-    params: {
-      trajectRef: activeTrajectRef.value,
-      categorie: 'wet',
-      contextLawId: selectedLawId.value,
-    },
-  });
-}
 
 async function enrichSelectedLaw(anchorEl) {
   if (!selectedLawId.value) return;
@@ -172,15 +120,12 @@ async function enrichSelectedLaw(anchorEl) {
   }
   enrichError.value = '';
   try {
-    const { alreadyRunning, tooMany } = await requestEnrich(
-      activeTrajectRef.value,
-      selectedLawId.value,
-    );
+    // requestEnrich ververst zelf de takenlijst, dus de pane staat daarna in de
+    // bezig-staat. alreadyRunning heeft daarom geen eigen melding nodig: dat is
+    // precies wat de pane dan toont.
+    const { alreadyRunning, tooMany } = await requestEnrich();
     if (tooMany) enrichError.value = 'Je hebt te veel verrijkingen tegelijk lopen.';
-    // alreadyRunning heeft geen melding nodig: de refresh hieronder zet de pane
-    // in de bezig-staat, en dat is precies wat er aan de hand is.
     else if (!alreadyRunning) enrichError.value = '';
-    await refreshTasks();
   } catch {
     enrichError.value = 'Verrijking aanvragen mislukt.';
   }
@@ -900,12 +845,26 @@ const selectedLaw = shallowRef(null);
 const selectedLawLoading = ref(false);
 const lawError = ref(null);
 
-// Hier en niet bij isEnriching hierboven: watch() leest zijn bron meteen om de
-// dependency te leggen, en die computed gebruikt selectedLawId - dat staat een
-// paar regels hierboven pas. Eerder aanroepen gooit een ReferenceError in setup
-// en dan rendert de hele view niets.
-usePollWhile(isEnriching);
 const selectedArticleNumber = ref(null);
+
+// De verrijk-/beoordeel-staat van de geselecteerde wet, gedeeld met EditorView:
+// wat de lege Machine-/YAML-pane meldt en waar zijn knoppen heen gaan. Hier en
+// niet bovenaan het bestand: de composable legt meteen een watch op zijn bron,
+// dus selectedLawId/selectedArticleNumber moeten al bestaan - eerder aanroepen
+// gooit een ReferenceError in setup en dan rendert de hele view niets.
+const {
+  isEnriching,
+  reviewReady,
+  reviewArticleForPane,
+  openReviewForLaw,
+  openTasksForLaw,
+  requestEnrich,
+  refreshTasks,
+} = useEnrichState({
+  trajectRef: activeTrajectRef,
+  lawId: selectedLawId,
+  articleNumber: selectedArticleNumber,
+});
 
 // Recently-viewed laws (most-recent-first), persisted across sessions. Stored
 // as { law_id, name } so a law that fails to load in the active traject - and

--- a/frontend/src/composables/useEnrichState.js
+++ b/frontend/src/composables/useEnrichState.js
@@ -1,0 +1,125 @@
+/**
+ * useEnrichState - de verrijk-/beoordeel-staat van één wet, zoals de lege
+ * Machine- en YAML-panes die tonen: loopt er een verrijking, staat er een
+ * voorstel klaar, en waar moet je heen als je erop klikt.
+ *
+ * Bestaat omdat Bibliotheek en Editor allebei dezelfde wet in dezelfde panes
+ * tonen en dus hetzelfde moeten melden. Die blokken stonden regel-voor-regel
+ * dubbel en liepen uit elkaar: de ene helft kreeg wél een refresh van de
+ * gedeelde takenlijst en de andere niet, waardoor de editor bij een deeplink
+ * "Genereer een voorstel" aanbood terwijl er al een voorstel klaarlag.
+ *
+ * Bewust op useTaskActions gebouwd en niet op useTasks: dit is de niet-pollende
+ * helft. Een view die een wet toont mag de 30s-poll van de takenlijst niet
+ * ongevraagd starten (die draait ook voor anonieme bezoekers), dus verversen we
+ * gericht: één keer bij mount, na elke eigen verrijk-aanvraag, en zolang je naar
+ * de bezig-staat kijkt (usePollWhile).
+ */
+import { computed, onMounted, toValue } from 'vue';
+import { useRouter } from 'vue-router';
+import { useAuth } from './useAuth.js';
+import { useTaskActions, usePollWhile } from './useTasks.js';
+import { reviewTarget } from '../lib/taskReview.js';
+
+/**
+ * @param {object} sources - refs/getters van de view.
+ * @param {import('vue').Ref<string|null>} sources.trajectRef - actief traject.
+ * @param {import('vue').Ref<string|null>} sources.lawId - de getoonde wet.
+ * @param {import('vue').Ref<string|number|null>} sources.articleNumber - het geopende artikel.
+ * @param {import('vue').Ref<boolean>} [sources.reviewActive] - beoordeel je die
+ *   taak op dit moment al? Dan hoeft de pane 'er ligt een voorstel klaar' niet
+ *   te melden. Alleen de editor kent die modus.
+ */
+export function useEnrichState({ trajectRef, lawId, articleNumber, reviewActive }) {
+  const router = useRouter();
+  const { authenticated } = useAuth();
+  const {
+    refresh: refreshTasks,
+    requestEnrich: requestEnrichRaw,
+    running: runningJobs,
+    tasks: openTasks,
+  } = useTaskActions();
+
+  // Loopt er al een verrijking voor deze wet? Dan meldt de lege pane dat in
+  // plaats van opnieuw de knoppen aan te bieden; een tweede aanvraag zou toch
+  // op een 409 stuiten.
+  const isEnriching = computed(() =>
+    runningJobs.value.some(
+      (job) => job.job_type === 'enrich' && job.law_id === toValue(lawId),
+    ),
+  );
+  // Alleen pollen zolang je naar de bezig-staat kijkt; zie usePollWhile. Staat
+  // hier ná isEnriching en achter de argumenten van deze composable: de watch
+  // leest zijn bron meteen om de dependency te leggen, dus alles wat hij
+  // aanraakt moet al bestaan. Doordat de view zijn refs als argument meegeeft,
+  // is die volgorde hier structureel goed in plaats van een valkuil die elke
+  // aanroeper zelf moet onthouden.
+  usePollWhile(isEnriching);
+
+  // Staat er al een beoordeelbaar voorstel klaar voor deze wet? Eén verrijking
+  // levert een taak per gewijzigd artikel, dus meestal staan er meerdere open
+  // voor deze wet. Je kijkt naar één artikel, dus de taak van dát artikel gaat
+  // voor; is die er niet, dan de eerste van de wet - beter naar een naburig
+  // voorstel wijzen dan naar niets.
+  const pendingReviewTask = computed(() => {
+    const forLaw = openTasks.value.filter(
+      (t) => t.task_type === 'job_review' && t.payload?.law_id === toValue(lawId),
+    );
+    if (!forLaw.length) return null;
+    const here = String(toValue(articleNumber) ?? '');
+    return forLaw.find((t) => String(t.payload?.article ?? '') === here) ?? forLaw[0];
+  });
+  const reviewReady = computed(
+    () => !!pendingReviewTask.value && !toValue(reviewActive),
+  );
+  const reviewArticleForPane = computed(() =>
+    pendingReviewTask.value?.payload?.article == null
+      ? ''
+      : String(pendingReviewTask.value.payload.article),
+  );
+
+  function openReviewForLaw() {
+    const target = reviewTarget(pendingReviewTask.value);
+    if (target) router.push(target);
+  }
+
+  // Naar de takenlijst, gefilterd op deze wet: daar staat de lopende aanvraag
+  // als rij met activity-indicator.
+  function openTasksForLaw() {
+    const ref_ = toValue(trajectRef);
+    const id = toValue(lawId);
+    if (!ref_ || !id) return;
+    router.push({
+      name: 'taken-traject',
+      params: { trajectRef: ref_, categorie: 'wet', contextLawId: id },
+    });
+  }
+
+  // `running`/`tasks` worden alleen door een refresh gevuld; deze composable
+  // pollt niet uit zichzelf. Eén keer bij mount is genoeg om na een herlaad of
+  // een deeplink te weten wat er voor deze wet loopt of klaarstaat.
+  onMounted(() => {
+    if (authenticated.value) refreshTasks();
+  });
+
+  // Verrijken aanvragen mét de refresh erachteraan: zonder die refresh blijft
+  // `isEnriching` false, slaat de bezig-staat niet om en begint usePollWhile
+  // nooit te pollen. Die koppeling hoort hier en niet bij elke aanroeper - daar
+  // is hij één keer vergeten.
+  async function requestEnrich() {
+    const result = await requestEnrichRaw(toValue(trajectRef), toValue(lawId));
+    await refreshTasks();
+    return result;
+  }
+
+  return {
+    isEnriching,
+    pendingReviewTask,
+    reviewReady,
+    reviewArticleForPane,
+    openReviewForLaw,
+    openTasksForLaw,
+    requestEnrich,
+    refreshTasks,
+  };
+}

--- a/frontend/src/composables/useEnrichState.test.js
+++ b/frontend/src/composables/useEnrichState.test.js
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+// Zelfde mock-patroon als useTasks.test.js/TasksSidebarItem.test.js: de
+// netwerk-leg van useTasks.js loopt via één bestuurbare spy. useAuth komt uit
+// hetzelfde gedeelde pakket, dus die hangt in dezelfde mock.
+const apiFetch = vi.fn();
+const authenticated = ref(true);
+vi.mock('@regelrecht/frontend-shared', () => ({
+  apiFetch: (...a) => apiFetch(...a),
+  useAuth: () => ({ authenticated }),
+}));
+
+const push = vi.fn();
+vi.mock('vue-router', () => ({ useRouter: () => ({ push: (...a) => push(...a) }) }));
+
+const TRAJECT = 'mijn-traject-1a2b3c4d';
+const LAW = 'test_wet';
+
+function reviewTask(article, overrides = {}) {
+  return {
+    id: `t-${article}`,
+    task_type: 'job_review',
+    status: 'open',
+    payload: { traject_ref: TRAJECT, law_id: LAW, article },
+    ...overrides,
+  };
+}
+
+function tasksResponse({ tasks = [], running = [] } = {}) {
+  return { status: 200, json: async () => ({ tasks, open_count: tasks.length, running }) };
+}
+
+describe('useEnrichState', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    apiFetch.mockReset();
+    push.mockReset();
+    authenticated.value = true;
+  });
+
+  // Mount de composable in een echte component: de mount-refresh en
+  // usePollWhile hangen aan een component-instance.
+  async function mountState({ articleNumber = null, reviewActive = false, lawId = LAW } = {}) {
+    const { useEnrichState } = await import('./useEnrichState.js');
+    let state;
+    const wrapper = mount({
+      setup() {
+        state = useEnrichState({
+          trajectRef: ref(TRAJECT),
+          lawId: ref(lawId),
+          articleNumber: ref(articleNumber),
+          reviewActive: ref(reviewActive),
+        });
+        return () => null;
+      },
+    });
+    await wrapper.vm.$nextTick();
+    await Promise.resolve();
+    await wrapper.vm.$nextTick();
+    return { ...state, wrapper };
+  }
+
+  it('ververst de gedeelde takenlijst bij mount, zodat een deeplink de staat kent', async () => {
+    apiFetch.mockResolvedValue(tasksResponse({ tasks: [reviewTask('2')] }));
+    const { reviewReady, reviewArticleForPane } = await mountState({ articleNumber: '2' });
+    expect(apiFetch).toHaveBeenCalledWith('/api/tasks', expect.anything());
+    expect(reviewReady.value).toBe(true);
+    expect(reviewArticleForPane.value).toBe('2');
+  });
+
+  it('haalt de takenlijst niet op voor een anonieme bezoeker', async () => {
+    authenticated.value = false;
+    apiFetch.mockResolvedValue(tasksResponse());
+    await mountState();
+    expect(apiFetch).not.toHaveBeenCalled();
+  });
+
+  it('kiest de taak van het geopende artikel, anders de eerste van de wet', async () => {
+    apiFetch.mockResolvedValue(
+      tasksResponse({ tasks: [reviewTask('1'), reviewTask('3')] }),
+    );
+    const here = await mountState({ articleNumber: '3' });
+    expect(here.pendingReviewTask.value.id).toBe('t-3');
+
+    vi.resetModules();
+    const elsewhere = await mountState({ articleNumber: '7' });
+    expect(elsewhere.pendingReviewTask.value.id).toBe('t-1');
+  });
+
+  it('meldt geen klaarstaand voorstel terwijl je die taak al beoordeelt', async () => {
+    apiFetch.mockResolvedValue(tasksResponse({ tasks: [reviewTask('2')] }));
+    const { pendingReviewTask, reviewReady } = await mountState({
+      articleNumber: '2',
+      reviewActive: true,
+    });
+    expect(pendingReviewTask.value).not.toBeNull();
+    expect(reviewReady.value).toBe(false);
+  });
+
+  it('negeert taken van een andere wet', async () => {
+    apiFetch.mockResolvedValue(
+      tasksResponse({ tasks: [reviewTask('2', { payload: { law_id: 'andere_wet' } })] }),
+    );
+    const { reviewReady } = await mountState();
+    expect(reviewReady.value).toBe(false);
+  });
+
+  it('staat in de bezig-staat zolang er een enrich-job voor deze wet loopt', async () => {
+    apiFetch.mockResolvedValue(
+      tasksResponse({ running: [{ job_id: 'j1', job_type: 'enrich', law_id: LAW }] }),
+    );
+    const { isEnriching } = await mountState();
+    expect(isEnriching.value).toBe(true);
+  });
+
+  // De bug die deze composable opheft: zonder refresh na de aanvraag blijft
+  // isEnriching false en begint de gerichte poll nooit.
+  it('ververst de takenlijst na een verrijk-aanvraag, zodat de bezig-staat omslaat', async () => {
+    apiFetch.mockResolvedValue(tasksResponse());
+    const { isEnriching, requestEnrich } = await mountState();
+    expect(isEnriching.value).toBe(false);
+
+    apiFetch.mockReset();
+    apiFetch.mockImplementation(async (url) =>
+      url.endsWith('/enrich')
+        ? { status: 200 }
+        : tasksResponse({ running: [{ job_id: 'j1', job_type: 'enrich', law_id: LAW }] }),
+    );
+    const result = await requestEnrich();
+    expect(result).toEqual({ alreadyRunning: false, tooMany: false });
+    expect(apiFetch).toHaveBeenCalledWith(
+      `/api/trajects/${TRAJECT}/corpus/laws/${LAW}/enrich`,
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(apiFetch).toHaveBeenCalledWith('/api/tasks', expect.anything());
+    expect(isEnriching.value).toBe(true);
+  });
+
+  it('opent de takenlijst gefilterd op deze wet', async () => {
+    apiFetch.mockResolvedValue(tasksResponse());
+    const { openTasksForLaw } = await mountState();
+    openTasksForLaw();
+    expect(push).toHaveBeenCalledWith({
+      name: 'taken-traject',
+      params: { trajectRef: TRAJECT, categorie: 'wet', contextLawId: LAW },
+    });
+  });
+
+  it('doet niets zonder wet of traject', async () => {
+    apiFetch.mockResolvedValue(tasksResponse());
+    const { openTasksForLaw, openReviewForLaw } = await mountState({ lawId: null });
+    openTasksForLaw();
+    openReviewForLaw();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it('navigeert naar de beoordeling van het klaarstaande voorstel', async () => {
+    apiFetch.mockResolvedValue(tasksResponse({ tasks: [reviewTask('2')] }));
+    const { openReviewForLaw } = await mountState({ articleNumber: '2' });
+    openReviewForLaw();
+    expect(push).toHaveBeenCalledWith(
+      expect.objectContaining({ params: expect.objectContaining({ lawId: LAW }) }),
+    );
+  });
+});

--- a/frontend/src/composables/useTasks.js
+++ b/frontend/src/composables/useTasks.js
@@ -52,6 +52,12 @@ async function resolveTask(taskId, action) {
   await refresh();
 }
 
+// Kaal: vraagt de verrijking aan en raakt de gedeelde takenlijst niet. Zonder
+// een refresh erachteraan blijft `running` leeg, slaat de bezig-staat van de
+// lege Machine-/YAML-pane niet om en begint usePollWhile nooit te pollen. Een
+// view die een wet toont neemt daarom useEnrichState, dat die refresh eraan
+// vastknoopt; wie deze rechtstreeks aanroept (TasksListPane, dat zelf al pollt)
+// zet er zelf een refresh() achter.
 async function requestEnrich(trajectRef, lawId) {
   const res = await apiFetch(
     `/api/trajects/${encodeURIComponent(trajectRef)}/corpus/laws/${encodeURIComponent(lawId)}/enrich`,
@@ -131,11 +137,17 @@ export function usePollWhile(active, intervalMs = 10000) {
     if (pollTimer) clearInterval(pollTimer);
     pollTimer = null;
   };
-  // Bewust NIET immediate: dat evalueert `active` tijdens setup, en een
-  // caller die zijn computed bovenaan definieert leest dan state die verderop
-  // in het bestand pas gedeclareerd wordt (temporal dead zone). Setup gooit
-  // dan en de hele view rendert niets. Kost ook niets: `running` is bij setup
-  // nog leeg, dus er valt op dat moment nooit iets te starten.
+  // Bewust NIET immediate: `running` is bij setup nog leeg, dus er valt op dat
+  // moment nooit iets te starten - de eerste refresh laat de watch alsnog
+  // afgaan.
+  //
+  // Wat het weglaten van immediate NIET wegneemt: een watch leest zijn bron
+  // hoe dan ook meteen bij aanmaak, om de dependency te leggen. Alles wat
+  // `active` aanraakt moet dus al gedeclareerd zijn - een computed die state
+  // leest die verderop in het bestand pas komt, gooit hier een ReferenceError
+  // (temporal dead zone) en dan rendert de hele view niets. useEnrichState
+  // ontloopt dat door zijn bronnen als argument binnen te krijgen: die bestaan
+  // per definitie al op de aanroepregel.
   watch(active, (on) => {
     stop();
     if (on) pollTimer = setInterval(refresh, intervalMs);

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -1901,15 +1901,31 @@ pub(crate) fn produced_reviewable_law(
 /// A parse failure yields None, and the caller then falls back to one task for
 /// the whole law — a proposal we cannot read is still reviewable by hand.
 pub(crate) fn changed_articles(source_yaml: &str, proposal_yaml: &str) -> Option<Vec<String>> {
+    /// `number:` als string, of de YAML hem nu quootte of niet.
+    ///
+    /// Een ongequote `number: 2` parset als YAML-integer. Alleen `as_str()`
+    /// lezen liet zo'n artikel stil uit beide lijsten vallen: geen review-taak
+    /// voor een wél gewijzigd artikel, en ook geen parse-fout die de
+    /// hele-wet-fallback aanzet. De frontend normaliseert hetzelfde veld op
+    /// dezelfde manier (`String(a.number)` in `proposalDivergence`), en de
+    /// taak-payload draagt het nummer als string, dus dat is hier de eenheid.
+    fn article_number(article: &serde_yaml_ng::Value) -> Option<String> {
+        match article.get("number")? {
+            serde_yaml_ng::Value::String(s) => Some(s.clone()),
+            serde_yaml_ng::Value::Number(n) => Some(n.to_string()),
+            // Alles anders (ontbrekend, null, een lijst) is geen artikelnummer
+            // waar een reviewer iets aan heeft; die artikelen blijven buiten
+            // de diff.
+            _ => None,
+        }
+    }
+
     fn articles(yaml: &str) -> Option<Vec<(String, serde_yaml_ng::Value)>> {
         let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(yaml).ok()?;
         let list = doc.get("articles")?.as_sequence()?;
         Some(
             list.iter()
-                .filter_map(|a| {
-                    let number = a.get("number")?.as_str()?.to_string();
-                    Some((number, a.clone()))
-                })
+                .filter_map(|a| Some((article_number(a)?, a.clone())))
                 .collect(),
         )
     }
@@ -3349,6 +3365,39 @@ articles:
             changed_articles(SOURCE, proposal),
             Some(vec!["3".to_string()])
         );
+    }
+
+    // Een ongequote `number: 2` is geldige YAML en komt in de praktijk voor.
+    // Vroeger viel zo'n artikel stil uit de diff (as_str() op een integer), dus
+    // kreeg een wél gewijzigd artikel geen review-taak - en zonder parse-fout
+    // sloeg de hele-wet-fallback ook niet aan: het voorstel verdween geruisloos.
+    #[test]
+    fn reports_a_changed_article_with_an_unquoted_number() {
+        let source = r#"
+$id: wet_x
+articles:
+  - number: 1
+    text: Eerste artikel
+  - number: 2
+    text: Tweede artikel
+"#;
+        let proposal = r#"
+$id: wet_x
+articles:
+  - number: 1
+    text: Eerste artikel
+  - number: 2
+    text: Tweede artikel
+    machine_readable:
+      execution:
+        output:
+          - name: bedrag
+"#;
+        assert_eq!(
+            changed_articles(source, proposal),
+            Some(vec!["2".to_string()])
+        );
+        assert_eq!(changed_articles(source, source), Some(Vec::new()));
     }
 
     #[test]


### PR DESCRIPTION
Drie losse eindjes uit de review van #1118 (review-taken per artikel + de gedeelde lege staat van de Machine-/YAML-panes).

## 1. De editor kende de takenstatus niet

`EditorView` las `running`/`tasks` uit het niet-pollende `useTaskActions()`, maar niets vulde die gedeelde refs op de editor-route: geen refresh bij mount, en `enrichLaw` deed er ook geen na `requestEnrich`. Gevolg: bij een deeplink of herlaad in de editor bleven `reviewReady` en `isEnriching` altijd false — de lege pane bood "Genereer een voorstel" aan terwijl er al een voorstel klaarstond of een run liep — en na een verrijk-aanvraag vanuit de editor begon `usePollWhile` nooit te pollen. De 30s-poll van `useTasks()` start alleen via `TasksSidebarItem`, en die mount alleen in Home.

## 2. Die staat stond dubbel in EditorView en LibraryView

`pendingReviewTask`, `reviewArticleForPane`, `openReviewForLaw`, `openTasksForLaw` en `isEnriching` stonden vrijwel regel-voor-regel identiek in beide views. Dat de ene helft de mount-refresh wél kreeg en de andere niet, is precies waar die duplicatie op uitliep. Nieuw: `frontend/src/composables/useEnrichState.js`, gebruikt door beide views. De composable:

- ververst de gedeelde takenlijst bij mount (achter `authenticated`, dus anonieme bezoekers halen niets op en pollen nog steeds nooit);
- koppelt de refresh structureel aan de verrijk-aanvraag, zodat de bezig-staat omslaat en de gerichte poll begint;
- legt zijn `usePollWhile`-watch pas als zijn bronnen als argument binnen zijn — de TDZ-valkuil die LibraryView eerder met een comment moest omzeilen.

Het view-specifieke deel blijft in de views: de editor kent een beoordeel-modus (`reviewActive`, waarin de pane niets hoeft te melden), en de bibliotheek heeft een eigen foutmelding plus login/traject-redirect.

## 3. Ongequoot `number:` viel uit de per-artikel-diff

`changed_articles` in de pipeline las `number` met `as_str()`. Een ongequote `number: 2` parset als YAML-integer en viel daardoor stil uit *beide* kanten van de diff: een gewijzigd artikel met numeriek nummer kreeg geen review-taak, en de fallback van één taak voor de hele wet sloeg ook niet aan — die hangt aan een parse-fout, en die was er niet. Nummers worden nu genormaliseerd naar string, net zoals de frontend het veld al bewust afhandelt (`String(a.number)` in `proposalDivergence`).

## Buiten scope

De review-gaten rond toegevoegde/verwijderde artikelen in het per-artikel-diffen, `.yml`-support in `produced_reviewable_law` en de blob-cleanup in de "geen wijziging"-tak van `finish_enrich_task_job` blijven staan; die verdienen een eigen afweging.

## Checks

- `npx vitest run` in `frontend/`: 746 tests groen, waaronder 10 nieuwe voor `useEnrichState` (twee suites draaien lokaal niet door een ontbrekende `jsdom`/design-system-installatie, niet door deze wijziging).
- `just pipeline-test`: unit tests groen, inclusief de nieuwe test met een ongequoot artikelnummer (de DB-tests hebben lokaal geen Postgres).
- `just format` en `just lint` groen.