### PR TITLE
perf(frontend): houd echarts uit de eerste lading van de editor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,6 +317,10 @@ jobs:
       - name: Check security headers
         run: just security-headers-test
 
+      - name: Check first-load guard
+        if: needs.changes.outputs.ci == 'true'
+        run: just first-load-test
+
       # Leak-guard laag 2: voorzie het git-ignored aanvulbestand met de casus-/
       # sector-specifieke patronen uit een secret, zodat de skills-no-casus hook in
       # CI op volle sterkte draait zonder die patronen in de publieke repo te zetten.

--- a/Justfile
+++ b/Justfile
@@ -93,11 +93,18 @@ precompress-test:
 security-headers-test:
     node --test script/security-headers.test.mjs
 
+# Pins the first-load guard against fixture dists. The guard itself only runs
+# inside `npm run build`, so without this a broken chunk match surfaces as a
+# failing image build — or worse, as a green one that ships echarts eagerly.
+[doc("Check the editor's first-load guard")]
+first-load-test:
+    node --test frontend/scripts/check-first-load.test.mjs
+
 # Run all quality checks, exactly what CI runs. Needs Docker for the
 # container-backed suites; on a machine without a daemon, swap `test` for
 # `test-no-docker`.
 [doc("Run all quality checks, exactly what CI runs (needs Docker)")]
-check: format lint build-check validate validate-annotations deploy-filters-test precompress-test security-headers-test test
+check: format lint build-check validate validate-annotations deploy-filters-test precompress-test security-headers-test first-load-test test
 
 # --- Tests ---
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "prebuild": "node scripts/copy-laws.js",
     "predev": "node ../bdd/codegen/gen-js.mjs && node scripts/copy-laws.js",
     "dev": "vite",
-    "build": "vite build && node scripts/precompress.mjs dist",
+    "build": "vite build && node scripts/check-first-load.mjs dist && node scripts/precompress.mjs dist",
     "preview": "vite preview",
     "pretest": "node ../bdd/codegen/gen-js.mjs",
     "test": "vitest run",

--- a/frontend/scripts/check-first-load.mjs
+++ b/frontend/scripts/check-first-load.mjs
@@ -16,40 +16,74 @@
  *    (echarts rejoined the static entry graph some other way).
  *
  * Runs as part of `npm run build`, so every path that produces the artifact
- * (local build, CI, the Docker image) gets the check.
+ * (local build, CI, the Docker image) gets the check. `just first-load-test`
+ * pins the guard itself against a fixture dist, without a build.
  */
-import { readdirSync, readFileSync } from 'node:fs';
+import { readdirSync, readFileSync, realpathSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const dist = process.argv[2] || 'dist';
+/** Chunk names that belong to the lazy overview route, never to the entry. */
+const LAZY_ROUTE_CHUNK = /\/(echarts|OverviewView)-[^/]*\.js$/;
 
-const assets = readdirSync(join(dist, 'assets'));
-const echartsChunks = assets.filter((f) => /^echarts-.*\.js$/.test(f));
-if (echartsChunks.length === 0) {
-  console.error(
-    'check-first-load: no echarts-*.js chunk in dist/assets. The ' +
-      "codeSplitting group in vite.config.js no longer applies, so echarts " +
-      'is back in a route chunk (and likely in the first load).',
-  );
-  process.exit(1);
+/**
+ * Everything index.html makes the browser fetch before it can render: the
+ * entry script plus every modulepreload. Both forms matter — a preload is a
+ * request the browser fires immediately, so it counts as first load even
+ * though nothing imports it yet.
+ */
+function firstLoadRequests(html) {
+  return [
+    ...html.matchAll(/<link[^>]*rel="modulepreload"[^>]*href="([^"]+)"/g),
+    ...html.matchAll(/<script[^>]*src="([^"]+)"/g),
+  ].map((m) => m[1]);
 }
 
-const html = readFileSync(join(dist, 'index.html'), 'utf8');
-const loaded = [
-  ...html.matchAll(/<link[^>]*rel="modulepreload"[^>]*href="([^"]+)"/g),
-  ...html.matchAll(/<script[^>]*src="([^"]+)"/g),
-].map((m) => m[1]);
+/**
+ * @returns {{problems: string[], echartsChunk: string|undefined, loaded: string[]}}
+ */
+export function checkFirstLoad(dist) {
+  const problems = [];
 
-const offenders = loaded.filter((href) => /\/(echarts|OverviewView)-[^/]*\.js$/.test(href));
-if (offenders.length > 0) {
-  console.error(
-    'check-first-load: index.html pulls lazy-route payload into the first ' +
-      `load: ${offenders.join(', ')}. See the codeSplitting comment in ` +
-      'vite.config.js.',
-  );
-  process.exit(1);
+  const assets = readdirSync(join(dist, 'assets'));
+  const echartsChunks = assets.filter((f) => /^echarts-.*\.js$/.test(f));
+  if (echartsChunks.length === 0) {
+    problems.push(
+      'no echarts-*.js chunk in dist/assets. The codeSplitting group in ' +
+        'vite.config.js no longer applies, so echarts is back in a route ' +
+        'chunk (and likely in the first load).',
+    );
+  }
+
+  const loaded = firstLoadRequests(readFileSync(join(dist, 'index.html'), 'utf8'));
+  const offenders = loaded.filter((href) => LAZY_ROUTE_CHUNK.test(href));
+  if (offenders.length > 0) {
+    problems.push(
+      `index.html pulls lazy-route payload into the first load: ${offenders.join(', ')}. ` +
+        'See the codeSplitting comment in vite.config.js.',
+    );
+  }
+
+  return { problems, echartsChunk: echartsChunks[0], loaded };
 }
 
-console.log(
-  `check-first-load: ok (${loaded.length} static JS requests, echarts stays in ${echartsChunks[0]})`,
-);
+function main() {
+  const dist = process.argv[2] || 'dist';
+  const { problems, echartsChunk, loaded } = checkFirstLoad(dist);
+
+  if (problems.length > 0) {
+    for (const problem of problems) console.error(`check-first-load: ${problem}`);
+    process.exit(1);
+  }
+
+  console.log(
+    `check-first-load: ok (${loaded.length} static JS requests, echarts stays in ${echartsChunk})`,
+  );
+}
+
+// Run only when invoked directly, so the test can import the check without
+// exiting the test process on a fixture that is meant to fail.
+const invokedDirectly =
+  process.argv[1] && realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1]);
+
+if (invokedDirectly) main();

--- a/frontend/scripts/check-first-load.mjs
+++ b/frontend/scripts/check-first-load.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * Postbuild guard for the editor's first load.
+ *
+ * The `codeSplitting` group in vite.config.js keeps echarts (~550 KB) out of
+ * the static entry graph; without it, rolldown parks its shared runtime
+ * helper inside the OverviewView chunk and index.html modulepreloads the
+ * whole echarts payload on every page. That regression is silent: the build
+ * still succeeds, the app still works, the first load just doubles.
+ *
+ * This script makes it loud. It fails the build when:
+ *  - the dedicated echarts chunk is missing from dist/assets (the
+ *    codeSplitting group no longer applies, e.g. the option was renamed or
+ *    removed in a Vite/rolldown upgrade), or
+ *  - index.html preloads or directly loads an echarts or OverviewView chunk
+ *    (echarts rejoined the static entry graph some other way).
+ *
+ * Runs as part of `npm run build`, so every path that produces the artifact
+ * (local build, CI, the Docker image) gets the check.
+ */
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const dist = process.argv[2] || 'dist';
+
+const assets = readdirSync(join(dist, 'assets'));
+const echartsChunks = assets.filter((f) => /^echarts-.*\.js$/.test(f));
+if (echartsChunks.length === 0) {
+  console.error(
+    'check-first-load: no echarts-*.js chunk in dist/assets. The ' +
+      "codeSplitting group in vite.config.js no longer applies, so echarts " +
+      'is back in a route chunk (and likely in the first load).',
+  );
+  process.exit(1);
+}
+
+const html = readFileSync(join(dist, 'index.html'), 'utf8');
+const loaded = [
+  ...html.matchAll(/<link[^>]*rel="modulepreload"[^>]*href="([^"]+)"/g),
+  ...html.matchAll(/<script[^>]*src="([^"]+)"/g),
+].map((m) => m[1]);
+
+const offenders = loaded.filter((href) => /\/(echarts|OverviewView)-[^/]*\.js$/.test(href));
+if (offenders.length > 0) {
+  console.error(
+    'check-first-load: index.html pulls lazy-route payload into the first ' +
+      `load: ${offenders.join(', ')}. See the codeSplitting comment in ` +
+      'vite.config.js.',
+  );
+  process.exit(1);
+}
+
+console.log(
+  `check-first-load: ok (${loaded.length} static JS requests, echarts stays in ${echartsChunks[0]})`,
+);

--- a/frontend/scripts/check-first-load.test.mjs
+++ b/frontend/scripts/check-first-load.test.mjs
@@ -1,0 +1,150 @@
+// Node's built-in test runner, so this costs no dependency. Run with
+// `just first-load-test` (part of `just check`).
+//
+// The guard itself is the only thing standing between a silent bundling
+// regression and a doubled first load, and it is wired into `npm run build` —
+// a bug in it would surface as a failing Docker image build, or not at all.
+// So the fixtures here are the shapes a real `dist/` takes: the current build,
+// and the two ways echarts gets back into the entry graph.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { checkFirstLoad } from './check-first-load.mjs';
+
+/**
+ * Shared chunks index.html preloads in a real build: the rolldown runtime, the
+ * vue runtime, a handful of composables. Named as vite hashes them.
+ */
+const SHARED_CHUNKS = [
+  'rolldown-runtime-DK3Fl9T5.js',
+  'runtime-core.esm-bundler-yi8_EWx1.js',
+  'useApi-CROJJdhE-DDjPdHJd.js',
+  'useLaw-BmNkokO3.js',
+];
+
+/** Lazy route chunks that exist on disk but are imported at navigation time. */
+const ROUTE_CHUNKS = ['AccountRequestView-DjPvsnLO.js', 'DataTable-CvK3xaic.js'];
+
+/**
+ * Write a dist that matches what vite emits: hashed files under assets/, an
+ * index.html with the entry as a module script and every eagerly-fetched chunk
+ * as a modulepreload.
+ */
+async function dist({ assets, entry = 'index-SWwzPvTN.js', preloads = SHARED_CHUNKS }) {
+  const dir = await mkdtemp(join(tmpdir(), 'check-first-load-'));
+  await mkdir(join(dir, 'assets'));
+  for (const name of assets) await writeFile(join(dir, 'assets', name), '/* chunk */\n');
+
+  const html = `<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8">
+  <title>RegelRecht</title>
+  <link rel="icon" type="image/svg+xml" href="/regelrecht-icon.svg">
+  <script type="module" crossorigin src="/assets/${entry}"></script>
+${preloads.map((p) => `  <link rel="modulepreload" crossorigin href="/assets/${p}">`).join('\n')}
+  <link rel="stylesheet" crossorigin href="/assets/index-aazph-g7.css">
+</head>
+<body>
+  <div id="app" style="height: 100%;"></div>
+</body>
+</html>
+`;
+  await writeFile(join(dir, 'index.html'), html);
+  return dir;
+}
+
+async function withDist(spec, assertions) {
+  const dir = await dist(spec);
+  try {
+    await assertions(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test('a build with echarts in its own chunk passes', async () => {
+  await withDist(
+    {
+      assets: [
+        'index-SWwzPvTN.js',
+        'echarts-B-2PdTzp.js',
+        'OverviewView-DGcaNwgn.js',
+        ...SHARED_CHUNKS,
+        ...ROUTE_CHUNKS,
+        'index-aazph-g7.css',
+      ],
+    },
+    (dir) => {
+      const { problems, echartsChunk, loaded } = checkFirstLoad(dir);
+      assert.deepEqual(problems, []);
+      assert.equal(echartsChunk, 'echarts-B-2PdTzp.js');
+      // The entry plus its preloads; the stylesheet is not a JS request.
+      assert.equal(loaded.length, SHARED_CHUNKS.length + 1);
+    },
+  );
+});
+
+test('a build without the codeSplitting group fails', async () => {
+  // What the build looks like when the group stops applying: echarts is folded
+  // into the route chunk, so there is no echarts-*.js left. index.html is
+  // unchanged, which is exactly why this is invisible without the guard.
+  await withDist(
+    {
+      assets: ['index-SWwzPvTN.js', 'OverviewView-DGcaNwgn.js', ...SHARED_CHUNKS],
+    },
+    (dir) => {
+      const { problems } = checkFirstLoad(dir);
+      assert.equal(problems.length, 1);
+      assert.match(problems[0], /no echarts-\*\.js chunk/);
+    },
+  );
+});
+
+test('an echarts chunk that index.html preloads fails', async () => {
+  await withDist(
+    {
+      assets: ['index-SWwzPvTN.js', 'echarts-B-2PdTzp.js', ...SHARED_CHUNKS],
+      preloads: [...SHARED_CHUNKS, 'echarts-B-2PdTzp.js'],
+    },
+    (dir) => {
+      const { problems } = checkFirstLoad(dir);
+      assert.equal(problems.length, 1);
+      assert.match(problems[0], /first load/);
+      // The build log has to name the chunk, or the failure is a riddle.
+      assert.match(problems[0], /echarts-B-2PdTzp\.js/);
+    },
+  );
+});
+
+test('an OverviewView chunk loaded by a script tag fails', async () => {
+  // A preload is not the only way in: an eager import of the route puts the
+  // chunk in the entry graph and vite emits it as a module script.
+  await withDist(
+    {
+      assets: ['index-SWwzPvTN.js', 'echarts-B-2PdTzp.js', 'OverviewView-DGcaNwgn.js'],
+      entry: 'OverviewView-DGcaNwgn.js',
+      preloads: SHARED_CHUNKS,
+    },
+    (dir) => {
+      const { problems } = checkFirstLoad(dir);
+      assert.equal(problems.length, 1);
+      assert.match(problems[0], /OverviewView-DGcaNwgn\.js/);
+    },
+  );
+});
+
+test('both failures are reported in one run', async () => {
+  await withDist(
+    {
+      assets: ['index-SWwzPvTN.js', 'OverviewView-DGcaNwgn.js'],
+      preloads: [...SHARED_CHUNKS, 'OverviewView-DGcaNwgn.js'],
+    },
+    (dir) => {
+      assert.equal(checkFirstLoad(dir).problems.length, 2);
+    },
+  );
+});

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -83,7 +83,11 @@ export default defineConfig({
         // (true) pulls the captured modules' dependencies (Vue's runtime-core,
         // reactivity, tslib) into the echarts chunk, which puts it right back
         // in the entry graph.
-        advancedChunks: {
+        //
+        // `scripts/check-first-load.mjs` (postbuild) guards this: if the
+        // option stops working the build fails instead of echarts silently
+        // rejoining the first load.
+        codeSplitting: {
           groups: [
             {
               name: 'echarts',

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -68,6 +68,32 @@ export default defineConfig({
   build: {
     cssTarget: ['chrome123', 'edge123', 'firefox120', 'safari18'],
     outDir: 'dist',
+    rolldownOptions: {
+      output: {
+        // Without this group, rolldown parks its shared module-namespace
+        // runtime helper inside the OverviewView chunk (the only chunk that
+        // needs CJS interop, via echarts). Several design-system chunks in the
+        // static entry graph import that helper, which drags the ~550 KB
+        // echarts payload into index.html's modulepreload list even though the
+        // route itself is lazy. Grouping echarts into its own chunk makes
+        // rolldown emit a separate tiny runtime chunk, and echarts is then
+        // only fetched when a harvester view actually opens.
+        //
+        // `includeDependenciesRecursively: false` is required: the default
+        // (true) pulls the captured modules' dependencies (Vue's runtime-core,
+        // reactivity, tslib) into the echarts chunk, which puts it right back
+        // in the entry graph.
+        advancedChunks: {
+          groups: [
+            {
+              name: 'echarts',
+              test: /node_modules[\\/](echarts|zrender|vue-echarts)[\\/]/,
+              includeDependenciesRecursively: false,
+            },
+          ],
+        },
+      },
+    },
   },
   server: {
     port: 3000,


### PR DESCRIPTION
Rolldown zette zijn gedeelde module-namespace-runtimehelper in de OverviewView-chunk, de enige chunk met CJS-interop (via echarts). Chunks van het design system in de statische entry-graaf importeren die helper, zodat de 550 KB echarts-chunk in de modulepreload-lijst van index.html belandde terwijl de route zelf al lui geladen werd. Een eigen codeSplitting-groep voor echarts geeft de helper een losse runtime-chunk; echarts wordt nu pas opgehaald wanneer een harvester-view opent, en de eerste lading gaat van 603 naar 445 KiB brotli. `includeDependenciesRecursively: false` is nodig, want de default trekt runtime-core, reactivity en tslib de echarts-chunk in en zet die daarmee terug in de entry-graaf.

Valt die optie ooit weg, dan slaagt de build gewoon en staat echarts stilzwijgend weer in de eerste lading. `scripts/check-first-load.mjs` draait daarom als onderdeel van `npm run build` en heeft een eigen test met fixtures in de vormen die een echte `dist/` aanneemt.