### PR TITLE
perf(editor): zet cache-headers op de editor-assets

### DIFF
--- a/packages/editor-api/Cargo.toml
+++ b/packages/editor-api/Cargo.toml
@@ -23,6 +23,7 @@ regelrecht-corpus = { path = "../corpus", features = ["github", "annotation-vali
 regelrecht-github = { path = "../github" }
 regelrecht-pipeline = { path = "../pipeline" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tower = { workspace = true, features = ["util"] }
 tower-http = { workspace = true, features = ["fs", "trace"] }
 tower-sessions.workspace = true
 tower-sessions-sqlx-store.workspace = true

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -5,11 +5,11 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use axum::middleware as axum_middleware;
-use axum::routing::get;
+use axum::routing::{get, MethodRouter};
 use axum::Router;
 use tokio::sync::{Mutex, RwLock};
+use tower::ServiceExt;
 use tower_http::services::{ServeDir, ServeFile};
-use tower_http::set_status::SetStatus;
 use tower_http::trace::TraceLayer;
 use tower_sessions::ExpiredDeletion;
 use tower_sessions::Expiry;
@@ -28,6 +28,7 @@ mod github_oauth;
 mod harvest_proxy;
 mod middleware;
 mod state;
+mod static_cache;
 mod task_requests;
 mod tasks_api;
 mod traject_corpus;
@@ -877,20 +878,41 @@ async fn init_backends(
 /// Compression stops at the static files on purpose: the JSON API keeps
 /// serving uncompressed bodies. See the SPA fallback below for why the
 /// index gets the same treatment.
-fn static_service(
-    static_dir: &str,
-    index_file: impl AsRef<std::path::Path>,
-) -> ServeDir<SetStatus<ServeFile>> {
+///
+/// Compression makes the bytes smaller; the `Cache-Control` added on the
+/// way out ([`static_cache`]) stops most of them being sent a second time
+/// at all. That header has to be set per request, because the policy
+/// depends on the URL — hence the wrapping handler rather than a plain
+/// `SetResponseHeaderLayer`. `ServeDir` sets no `Cache-Control` of its
+/// own, and the ETag and `Vary` it does set are left untouched: they are
+/// what makes the `no-cache` half cheap.
+fn static_service(static_dir: &str, index_file: impl AsRef<std::path::Path>) -> MethodRouter {
     // The SPA fallback (`/library/...`, `/editor/...` deep links) returns
     // index.html, which is itself precompressed — hence the same flags on the
     // not-found service.
     let index = ServeFile::new(index_file)
         .precompressed_br()
         .precompressed_gzip();
-    ServeDir::new(static_dir)
+    let files = ServeDir::new(static_dir)
         .precompressed_br()
         .precompressed_gzip()
-        .not_found_service(index)
+        .not_found_service(index);
+
+    get(move |request: axum::extract::Request| {
+        let files = files.clone();
+        async move {
+            let uri = request.uri().clone();
+            // `ServeDir`'s error type is `Infallible` once a not-found
+            // service is set, so this cannot fail.
+            let mut response = files
+                .oneshot(request)
+                .await
+                .unwrap_or_else(|e| match e {})
+                .map(axum::body::Body::new);
+            static_cache::apply(&uri, &mut response);
+            response
+        }
+    })
 }
 
 /// Read favorites.json from the static directory.
@@ -1141,7 +1163,7 @@ mod http_localhost_tests {
 /// the plain file.
 #[cfg(test)]
 mod static_service_tests {
-    use super::static_service;
+    use super::{static_cache, static_service};
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
     use http_body_util::BodyExt;
@@ -1151,17 +1173,25 @@ mod static_service_tests {
     const GZIPPED: &[u8] = b"pretend gzip bytes";
     const BROTLIED: &[u8] = b"pretend brotli bytes";
 
-    /// A static dir shaped like a real build: `app.js` with both variants
-    /// beside it, plus an `index.html` for the SPA fallback.
+    /// A static dir shaped like a real build: a content-hashed
+    /// `assets/app-DkX9a2Bc.js` with both variants beside it, plus the
+    /// `index.html` that sits at a fixed name and doubles as the SPA
+    /// fallback. Both halves are present on purpose — the caching tests
+    /// below are only meaningful if the fixture can tell them apart.
     fn fixture() -> tempfile::TempDir {
         let dir = tempfile::tempdir().expect("tempdir");
-        std::fs::write(dir.path().join("app.js"), PLAIN).expect("write");
-        std::fs::write(dir.path().join("app.js.gz"), GZIPPED).expect("write");
-        std::fs::write(dir.path().join("app.js.br"), BROTLIED).expect("write");
+        std::fs::create_dir(dir.path().join("assets")).expect("mkdir");
+        let asset = dir.path().join("assets").join("app-DkX9a2Bc.js");
+        std::fs::write(&asset, PLAIN).expect("write");
+        std::fs::write(asset.with_extension("js.gz"), GZIPPED).expect("write");
+        std::fs::write(asset.with_extension("js.br"), BROTLIED).expect("write");
         std::fs::write(dir.path().join("index.html"), PLAIN).expect("write");
         std::fs::write(dir.path().join("index.html.br"), BROTLIED).expect("write");
         dir
     }
+
+    /// Path of the hashed asset in [`fixture`].
+    const ASSET: &str = "/assets/app-DkX9a2Bc.js";
 
     async fn get(dir: &tempfile::TempDir, path: &str, accept_encoding: Option<&str>) -> Response {
         let static_dir = dir.path().to_string_lossy().to_string();
@@ -1174,7 +1204,6 @@ mod static_service_tests {
             .oneshot(request.body(Body::empty()).expect("request"))
             .await
             .expect("response")
-            .map(Body::new)
     }
 
     type Response = axum::http::Response<Body>;
@@ -1194,7 +1223,7 @@ mod static_service_tests {
     #[tokio::test]
     async fn brotli_wins_when_the_client_accepts_both() {
         let dir = fixture();
-        let response = get(&dir, "/app.js", Some("gzip, deflate, br")).await;
+        let response = get(&dir, ASSET, Some("gzip, deflate, br")).await;
 
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response.headers()["content-encoding"], "br");
@@ -1207,7 +1236,7 @@ mod static_service_tests {
     #[tokio::test]
     async fn client_q_values_decide_over_our_preference() {
         let dir = fixture();
-        let response = get(&dir, "/app.js", Some("br;q=0.5, gzip;q=1.0")).await;
+        let response = get(&dir, ASSET, Some("br;q=0.5, gzip;q=1.0")).await;
 
         assert_eq!(response.headers()["content-encoding"], "gzip");
         assert_eq!(body(response).await, GZIPPED);
@@ -1216,7 +1245,7 @@ mod static_service_tests {
     #[tokio::test]
     async fn gzip_is_served_when_brotli_is_not_accepted() {
         let dir = fixture();
-        let response = get(&dir, "/app.js", Some("gzip")).await;
+        let response = get(&dir, ASSET, Some("gzip")).await;
 
         assert_eq!(response.headers()["content-encoding"], "gzip");
         assert_eq!(body(response).await, GZIPPED);
@@ -1228,8 +1257,8 @@ mod static_service_tests {
     #[tokio::test]
     async fn etag_differs_per_encoding() {
         let dir = fixture();
-        let br = get(&dir, "/app.js", Some("br")).await;
-        let gz = get(&dir, "/app.js", Some("gzip")).await;
+        let br = get(&dir, ASSET, Some("br")).await;
+        let gz = get(&dir, ASSET, Some("gzip")).await;
 
         assert_ne!(
             br.headers().get("etag").expect("etag on br"),
@@ -1246,7 +1275,7 @@ mod static_service_tests {
         let index = dir.path().join("index.html");
         let request = Request::builder()
             .method("HEAD")
-            .uri("/app.js")
+            .uri(ASSET)
             .header("accept-encoding", "br")
             .body(Body::empty())
             .expect("request");
@@ -1267,7 +1296,7 @@ mod static_service_tests {
     #[tokio::test]
     async fn plain_file_is_served_without_accept_encoding() {
         let dir = fixture();
-        let response = get(&dir, "/app.js", None).await;
+        let response = get(&dir, ASSET, None).await;
 
         assert_eq!(response.status(), StatusCode::OK);
         assert!(response.headers().get("content-encoding").is_none());
@@ -1280,7 +1309,7 @@ mod static_service_tests {
     #[tokio::test]
     async fn vary_is_set_on_the_uncompressed_answer_too() {
         let dir = fixture();
-        let response = get(&dir, "/app.js", None).await;
+        let response = get(&dir, ASSET, None).await;
 
         assert_eq!(response.headers()["vary"], "accept-encoding");
     }
@@ -1314,5 +1343,81 @@ mod static_service_tests {
         assert_eq!(response.status(), StatusCode::OK);
         assert!(response.headers().get("content-encoding").is_none());
         assert_eq!(body(response).await, PLAIN);
+    }
+
+    /// The caching half of the story, end to end through the real service.
+    ///
+    /// Both cases are asserted together because either one alone proves
+    /// nothing: "assets get a year" is satisfied by a blanket header on
+    /// everything, and "the index revalidates" is satisfied by no header
+    /// at all. It is the *difference* between the two that is the policy.
+    #[tokio::test]
+    async fn hashed_assets_are_immutable_and_the_index_is_not() {
+        let dir = fixture();
+
+        let asset = get(&dir, ASSET, Some("br")).await;
+        assert_eq!(asset.status(), StatusCode::OK);
+        assert_eq!(asset.headers()["cache-control"], static_cache::IMMUTABLE);
+
+        let index = get(&dir, "/index.html", Some("br")).await;
+        assert_eq!(index.status(), StatusCode::OK);
+        assert_eq!(index.headers()["cache-control"], static_cache::REVALIDATE);
+    }
+
+    /// The SPA fallback is the index under another URL, so it must carry
+    /// the index's policy — otherwise a visitor caches a deep link with
+    /// yesterday's HTML in it.
+    #[tokio::test]
+    async fn the_spa_fallback_revalidates() {
+        let dir = fixture();
+        let response = get(&dir, "/library/some-law", Some("br")).await;
+
+        assert_eq!(
+            response.headers()["cache-control"],
+            static_cache::REVALIDATE
+        );
+    }
+
+    /// A request for an asset that is not on disk is answered with the
+    /// index HTML. Marking that immutable would pin a broken page under
+    /// a bundle URL for a year.
+    #[tokio::test]
+    async fn a_missing_asset_is_not_cached_as_one() {
+        let dir = fixture();
+        let response = get(&dir, "/assets/gone-Zz9YxW01.js", Some("br")).await;
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert_eq!(
+            response.headers()["cache-control"],
+            static_cache::REVALIDATE
+        );
+    }
+
+    /// Caching sits beside compression, it does not replace it: the ETag
+    /// and `Vary` that make the `no-cache` half cheap must survive.
+    #[tokio::test]
+    async fn caching_leaves_the_compression_headers_alone() {
+        let dir = fixture();
+        let response = get(&dir, ASSET, Some("br")).await;
+
+        assert_eq!(response.headers()["content-encoding"], "br");
+        assert_eq!(response.headers()["vary"], "accept-encoding");
+        assert!(response.headers().get("etag").is_some());
+        assert_eq!(response.headers()["cache-control"], static_cache::IMMUTABLE);
+    }
+
+    /// Files at the root of `dist` that are not the index — the icon,
+    /// `favorites.json` — sit at fixed names too and must revalidate.
+    #[tokio::test]
+    async fn fixed_name_root_files_revalidate() {
+        let dir = fixture();
+        std::fs::write(dir.path().join("favorites.json"), PLAIN).expect("write");
+        let response = get(&dir, "/favorites.json", None).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers()["cache-control"],
+            static_cache::REVALIDATE
+        );
     }
 }

--- a/packages/editor-api/src/static_cache.rs
+++ b/packages/editor-api/src/static_cache.rs
@@ -1,0 +1,244 @@
+//! Cache-Control policy for the editor's static files.
+//!
+//! The editor image has no nginx in front of it: `editor-api` is the web
+//! server for `frontend/dist` as well as the API, so caching policy has to
+//! be decided here or not at all. Until now it was not decided at all —
+//! every response left without a `Cache-Control`, which makes a returning
+//! visitor re-fetch the whole bundle or, at best, revalidate every file
+//! one by one.
+//!
+//! Two classes, and the split is the whole point:
+//!
+//! * **Content-hashed bundle files** (`/assets/index-DkX9a2Bc.js`). The
+//!   hash is derived from the contents, so the URL can never denote
+//!   different bytes. These get a year plus `immutable`: no request at
+//!   all on a repeat visit, not even a conditional one.
+//! * **Everything else** — `index.html`, the SPA fallback for deep
+//!   links, `favorites.json`, `regelrecht-icon.svg`. These live at fixed
+//!   names and their contents do change, so they get `no-cache`:
+//!   *revalidate before use*, not "never store". The browser keeps the
+//!   body and a `304` confirms it, which is the cheap answer we want.
+//!
+//! Getting the split wrong in the immutable direction is expensive and
+//! unfixable from the server side: a visitor holding a stale `immutable`
+//! entry will not ask again for a year, and no deploy reaches them. So
+//! the predicate below errs toward `no-cache` whenever a name does not
+//! unambiguously carry a hash.
+
+use axum::http::header::{HeaderValue, CACHE_CONTROL};
+use axum::http::{Response, StatusCode, Uri};
+
+/// One year, the maximum `max-age` RFC 9111 recommends anyone bother
+/// with, plus `immutable` so browsers skip the revalidation they would
+/// otherwise still send on a reload.
+pub const IMMUTABLE: HeaderValue = HeaderValue::from_static("public, max-age=31536000, immutable");
+
+/// Store it, but check with us before using it. Not `no-store`: we want
+/// the body kept so revalidation can answer `304` off the ETag that
+/// `ServeDir` already sets.
+pub const REVALIDATE: HeaderValue = HeaderValue::from_static("no-cache");
+
+/// Directory Vite writes its hashed output to. Nothing else is emitted
+/// here: `public/` is copied to the root of `dist`, and the build has no
+/// `assetFileNames` override, so every file under this prefix carries a
+/// content hash.
+const HASHED_DIR: &str = "/assets/";
+
+/// Vite's default hash is 8 base64url characters. Shorter runs are
+/// ordinary words in a kebab-case filename.
+const MIN_HASH_LEN: usize = 8;
+
+/// Set the cache policy on a static-file response.
+///
+/// Takes the *request* URI rather than reading the response, because the
+/// decision is about the URL's stability, not about the bytes. The
+/// status is consulted for one reason: a request for a missing
+/// `/assets/…` file falls through to the SPA index, and that HTML must
+/// never be cached for a year under an asset URL. Only a response that
+/// actually delivered (or confirmed) the asset may be marked immutable.
+pub fn apply<B>(uri: &Uri, response: &mut Response<B>) {
+    let immutable = response_is_authoritative(response.status()) && is_hashed_asset(uri.path());
+    let value = if immutable { IMMUTABLE } else { REVALIDATE };
+    response.headers_mut().insert(CACHE_CONTROL, value);
+}
+
+/// `200`, `304` and `206` mean the URL resolved to the file it names.
+/// Anything else (notably the `404` the SPA fallback carries) is some
+/// other resource wearing this URL and must stay revalidated.
+fn response_is_authoritative(status: StatusCode) -> bool {
+    matches!(
+        status,
+        StatusCode::OK | StatusCode::NOT_MODIFIED | StatusCode::PARTIAL_CONTENT
+    )
+}
+
+/// Whether a request path denotes a content-hashed bundle file.
+///
+/// Two gates. The path must sit under [`HASHED_DIR`], and the filename
+/// must carry a hash: a `-` followed by at least [`MIN_HASH_LEN`]
+/// base64url characters, up to the first `.`, containing a digit or an
+/// uppercase letter.
+///
+/// That last condition is what separates `index-DkX9a2Bc.js` from a
+/// hand-placed `some-long-name.css`, whose tail is equally long and
+/// equally base64url but reads as words. It costs us the ~1-in-1000 hash
+/// that happens to be all-lowercase — that file merely revalidates,
+/// which is the direction to be wrong in.
+pub fn is_hashed_asset(path: &str) -> bool {
+    let Some(rest) = path.strip_prefix(HASHED_DIR) else {
+        return false;
+    };
+    // Nested chunk directories are still Vite output; take the leaf.
+    let name = rest.rsplit('/').next().unwrap_or("");
+    let stem = strip_extensions(name);
+
+    stem.char_indices()
+        .filter(|(_, c)| *c == '-')
+        .any(|(i, _)| looks_like_hash(&stem[i + 1..]))
+}
+
+/// Drop the file extension(s), leaving the part the hash lives in.
+///
+/// Not "everything before the first dot": Vite happily emits dots inside
+/// the name it derives from a source module, as in
+/// `runtime-core.esm-bundler-yi8_EWx1.js`. Instead, strip from the right
+/// while the trailing segment reads as an extension — short and purely
+/// alphanumeric. Twice at most, which covers `.js.map` and stops well
+/// short of eating a dotted name.
+fn strip_extensions(name: &str) -> &str {
+    let mut stem = name;
+    for _ in 0..2 {
+        let Some((head, ext)) = stem.rsplit_once('.') else {
+            break;
+        };
+        let is_extension = (1..=5).contains(&ext.len())
+            && !ext.is_empty()
+            && ext.chars().all(|c| c.is_ascii_alphanumeric());
+        if !is_extension {
+            break;
+        }
+        stem = head;
+    }
+    stem
+}
+
+fn looks_like_hash(tail: &str) -> bool {
+    tail.len() >= MIN_HASH_LEN
+        && tail
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        && tail.chars().any(|c| c.is_ascii_digit() || c.is_uppercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hashed(path: &str) -> bool {
+        is_hashed_asset(path)
+    }
+
+    /// The shapes Vite actually emits, including a hash that contains the
+    /// base64url specials — those must not be mistaken for a word break.
+    #[test]
+    fn vite_output_is_hashed() {
+        assert!(hashed("/assets/index-DkX9a2Bc.js"));
+        assert!(hashed("/assets/index-DkX9a2Bc.css"));
+        assert!(hashed("/assets/index-DkX9a2Bc.js.map"));
+        assert!(hashed("/assets/vendor-router-B7f_2a-x.js"));
+        assert!(hashed("/assets/RegelrechtSans-a1B2c3D4.woff2"));
+        assert!(hashed("/assets/chunks/deep-Qq8XmZ01.js"));
+        // Vite derives chunk names from the source module, dots and all —
+        // these two are verbatim from a real `frontend/dist`.
+        assert!(hashed("/assets/runtime-core.esm-bundler-yi8_EWx1.js"));
+        assert!(hashed("/assets/JetBrainsMono-Italic_wght_-Ljgv2psh.woff2"));
+    }
+
+    /// Fixed names are the whole risk. None of these may ever be handed a
+    /// year, wherever they sit.
+    #[test]
+    fn fixed_names_are_not_hashed() {
+        assert!(!hashed("/index.html"));
+        assert!(!hashed("/favorites.json"));
+        assert!(!hashed("/regelrecht-icon.svg"));
+        assert!(!hashed("/favicon.ico"));
+        assert!(!hashed("/manifest.webmanifest"));
+        assert!(!hashed("/assets/style.css"));
+        assert!(!hashed("/assets/logo.svg"));
+        assert!(!hashed("/assets/some-long-name.css"));
+        assert!(!hashed("/assets/fonts/regelrecht-sans.woff2"));
+    }
+
+    /// A hash-shaped name outside `/assets/` is still a fixed URL as far
+    /// as we know; only the build directory carries the guarantee.
+    #[test]
+    fn the_prefix_is_required() {
+        assert!(!hashed("/index-DkX9a2Bc.js"));
+        assert!(!hashed("/static/assets/index-DkX9a2Bc.js"));
+    }
+
+    /// Too short to be a Vite hash — `-min`, `-v2`, `-nl` and friends.
+    #[test]
+    fn short_suffixes_are_not_hashes() {
+        assert!(!hashed("/assets/app-v2.js"));
+        assert!(!hashed("/assets/bundle-min.js"));
+    }
+
+    fn apply_to(path: &str, status: StatusCode) -> HeaderValue {
+        let mut response = Response::builder()
+            .status(status)
+            .body(())
+            .expect("response");
+        apply(&path.parse::<Uri>().expect("uri"), &mut response);
+        response.headers()[CACHE_CONTROL].clone()
+    }
+
+    #[test]
+    fn hashed_assets_get_a_year() {
+        assert_eq!(
+            apply_to("/assets/index-DkX9a2Bc.js", StatusCode::OK),
+            IMMUTABLE
+        );
+        assert_eq!(
+            apply_to("/assets/index-DkX9a2Bc.js", StatusCode::NOT_MODIFIED),
+            IMMUTABLE
+        );
+    }
+
+    #[test]
+    fn the_index_revalidates() {
+        assert_eq!(apply_to("/index.html", StatusCode::OK), REVALIDATE);
+        assert_eq!(apply_to("/", StatusCode::OK), REVALIDATE);
+    }
+
+    /// A missing asset is answered with the SPA index. Caching that HTML
+    /// for a year under a `.js` URL would break the app for exactly as
+    /// long, so the status gate has to hold.
+    #[test]
+    fn a_missing_asset_never_gets_a_year() {
+        assert_eq!(
+            apply_to("/assets/gone-DkX9a2Bc.js", StatusCode::NOT_FOUND),
+            REVALIDATE
+        );
+    }
+
+    /// Whatever a previous layer put there, ours is the policy that ships.
+    #[test]
+    fn an_existing_header_is_replaced() {
+        let mut response = Response::builder()
+            .status(StatusCode::OK)
+            .header(CACHE_CONTROL, "private")
+            .body(())
+            .expect("response");
+        apply(
+            &"/assets/index-DkX9a2Bc.js".parse::<Uri>().expect("uri"),
+            &mut response,
+        );
+        assert_eq!(
+            response.headers().get_all(CACHE_CONTROL).iter().count(),
+            1,
+            "the old value must be replaced, not appended"
+        );
+        assert_eq!(response.headers()[CACHE_CONTROL], IMMUTABLE);
+    }
+}


### PR DESCRIPTION
De tweede helft van #1121. De editor draait geen nginx, `editor-api` is zelf de webserver voor `frontend/dist`, en er stond geen `Cache-Control` op wat daaruit kwam, dus wat een terugkerende bezoeker deed hing af van browserheuristiek. Vite hasht de namen onder `/assets/` op de inhoud, dus die URL's kunnen nooit andere bytes betekenen en krijgen `public, max-age=31536000, immutable`; alles op een vaste naam krijgt `no-cache`, wat bewaren en vóór gebruik navragen betekent, en de ETag die `ServeDir` al zet maakt daar een 304 van.

Fout gaan in de immutable-richting is niet te repareren vanaf de server, dus er zitten twee poorten voor. De naam moet aantoonbaar een hash dragen, een `-` gevolgd door minstens acht base64url-tekens met een cijfer of hoofdletter erin, zodat een naam die niet overtuigt gewoon revalideert. En de status moet `200`, `304` of `206` zijn, zodat een ontbrekend asset dat naar de index doorvalt niet een jaar HTML onder een bundel-URL laat hangen.

De test asserteert beide kanten in één geval, want de eerste helft wordt ook gehaald door een blinde header op alles en de tweede door helemaal geen header; het verschil tussen die twee is het beleid.