### PR TITLE
chore: negeer ook de hernoemde mutants-uitvoer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,8 +45,9 @@ __pycache__/
 *.py[cod]
 .ruff_cache/
 
-# Mutation testing
-mutants.out/
+# Mutation testing. cargo-mutants hernoemt de vorige uitvoer bij een herrun
+# naar mutants.out.old/, en die naam matcht het patroon hierboven niet.
+mutants.out*/
 
 # BDD trace output
 trace_output/


### PR DESCRIPTION
`cargo-mutants` hernoemt bij een tweede run de vorige uitvoer naar `mutants.out.old/`, en die naam matcht `mutants.out/` niet. Wie de mutatiepoort twee keer draait en daarna `git add -A` doet, stageert die map dus. Dat is vandaag één keer gebeurd en op tijd opgemerkt tijdens een review.

Het patroon dekt nu beide namen. Er komt meer druk op deze poort te staan, want #1119 stelt voor hem naar pre-push te halen en zijn scope te verbreden voorbij `packages/engine`, dus de kans dat iemand hierin loopt neemt toe.