### PR TITLE
refactor(pipeline): schrap het kaderwet-begrip uit de sluitingsplanner

### DIFF
--- a/docs/src/content/rfcs/rfc-026.md
+++ b/docs/src/content/rfcs/rfc-026.md
@@ -111,23 +111,15 @@ een losse vergelijking.
 | type-only import | definitorische verwijzing |
 | runtime-import | uitvoerende verwijzing |
 | optionele dependency, niet ingeschakeld | delegatie naar een beleidsregel |
-| prelude | kaderwet |
 | lockfile met hashes | sidecar met een hash per fragment |
 | resolve tegenover build | traversal tegenover verrijking |
 | feature die een optionele dependency uitschakelt | artikel buiten de hot path |
 | trait-impl elders in de crate | artikel dat een ander artikel wijzigt |
 | entry point en tree shaking | scenario als wortel |
 
-De analogie breekt op twee punten, en allebei kosten ze iets.
-
-Cycli zijn hier normaal. Een package manager weigert ze en bouwt in topologische
-volgorde; wetten verwijzen over en weer en er is geen volgorde die dat oplost.
-Zie de sectie over cycli.
-
-Er is geen equivalent van de prelude die je moet aanwijzen. In software staat de
-prelude in de taaldefinitie en klopt hij per constructie. Hier is het een
-handgeschreven lijst die kan verouderen, en dat is de enige plek in het ontwerp
-waar een stil gat kan ontstaan.
+De analogie breekt op de cycli, en dat kost iets. Cycli zijn hier normaal. Een
+package manager weigert ze en bouwt in topologische volgorde; wetten verwijzen
+over en weer en er is geen volgorde die dat oplost. Zie de sectie over cycli.
 
 ## Knopen en kanten
 
@@ -285,16 +277,18 @@ Advisering", zoals de bronpoort hem al vastlegt.
 
 **Bepalingen die op de hele wet werken.** Overgangsrecht, een hardheidsclausule,
 slotbepalingen, delegatiegrondslagen. Die noemen geen artikelnummers en zijn dus
-met verwijzingen niet te vinden. Dit is de lokale variant van de kaderwet, en het
-antwoord is hetzelfde: aanwijzen. Per wet is dat een handvol artikelen, en omdat
-de wet toch in zijn geheel verrijkt wordt, is de enige beslissing die overblijft
-of hun kanten gevolgd worden.
+met verwijzingen niet te vinden. Dit is de lokale variant van de algemene wet
+(zie de sectie hieronder). Per wet is dat een handvol artikelen, en omdat de wet
+toch in zijn geheel verrijkt wordt, is de enige beslissing die overblijft of hun
+kanten gevolgd worden.
 
 Hetzelfde patroon staat daarmee op drie schalen. Het hele artikel gaat mee omdat
 leden niet zelfstandig leesbaar zijn. De omhullende bepalingen van de wet gaan mee
-omdat ze zonder verwijzing werken. En de kaderwetten gaan mee omdat ze zichzelf
-van toepassing verklaren. Het gaat elke keer om wat op een artikel inwerkt zonder
-dat er een verwijzing naartoe staat.
+omdat ze zonder verwijzing werken. En de algemene wetten werken door omdat ze
+zichzelf van toepassing verklaren. Het gaat elke keer om wat op een artikel
+inwerkt zonder dat er een verwijzing naartoe staat, en elke keer staat het
+antwoord in het document zelf: de structuur (`placement`) en de zelfverklaarde
+reikwijdte (`applies-to`).
 
 Kanten zijn getypeerd, omdat de traversalregel per type verschilt.
 
@@ -309,7 +303,9 @@ het halve belastingrecht om te weten wat "partner" betekent.
 `delegates-to` verbindt een open norm met het document dat hem invult, en wordt
 niet gevolgd. Zie de volgende sectie.
 
-`applies-to` loopt tegen de leesrichting in: van de kaderwet naar de materiewet.
+`applies-to` loopt tegen de leesrichting in: van de algemene wet naar de
+materiewet. De bron van die kant is de reikwijdtebepaling van de algemene wet
+zelf; zie de sectie over algemene wetten.
 
 `amends` verbindt een wijzigingswet met wat hij wijzigt, en is vooral relevant
 voor invalidatie.
@@ -344,50 +340,45 @@ volledig. Er is geen omgekeerde index over het hele corpus nodig om te weten
 welke beleidsregels bestaan. Je verrijkt, je krijgt open termen met een adres
 erbij, en dan zoek je gericht.
 
-## Kaderwetten
+## Algemene wetten
 
-Blijft over de klasse die je niet met een markering kunt afvangen: de kaderwet
-die zichzelf van toepassing verklaart terwijl de materiewet daar niets over zegt.
-De Awb is op vrijwel elk besluit van toepassing zonder dat de Wet op de
-zorgtoeslag dat vermeldt. Wie vanuit de materiewet zoekt, vindt hem nooit. Dit is
-het stille gat uit requirement 5.
+Blijft over de klasse die je niet met een markering kunt afvangen: de wet die
+zichzelf van toepassing verklaart terwijl de materiewet daar niets over zegt. De
+Awb is op vrijwel elk besluit van een bestuursorgaan van toepassing zonder dat
+de Wet op de zorgtoeslag dat vermeldt. Wie vanuit de materiewet zoekt, vindt hem
+nooit. Dit is het stille gat uit requirement 5.
 
-Kaderwetten worden aangewezen en niet opgespoord. Kaderwet zijn is een juridische
-kwalificatie en geen eigenschap van de graaf, dus er valt niets aan te detecteren.
-Een heuristiek op ingaande graad zou bovendien het omgekeerde vinden van wat we
-zoeken: die vindt de wetten waar veel naar verwezen wordt, zoals de Awir en de Wet
-inkomstenbelasting, en dat zijn juist de wetten die al gewone kanten hebben. De
-Awb heeft die kanten niet, en dat is waarom hij een probleem is.
+In het staats- en bestuursrecht heet die klasse de algemene wet. Aanwijzing 2.46
+van de Aanwijzingen voor de regelgeving geeft de lijst en de werking: afwijking
+van de Awb, Boek 1 van het Burgerlijk Wetboek, de Algemene termijnenwet en de
+AWR vergt een zwaarwichtig belang. Een eerdere versie van dit ontwerp noemde ze
+"kaderwetten" en hield er een handgeschreven lijst naast; aangewezen wetten
+gingen als kaart naast de diepte mee, zonder dieptepunt te kosten en zonder dat
+erin of eruit gelopen werd. Dat is geschrapt, om drie redenen. De term botst met
+het vak en met het corpus: een kaderwet is een wet die de invulling aan lagere
+regels delegeert, en daarvan staan er vijftien echte in het corpus. De lijst
+gooide twee tegengestelde gevallen op één hoop: de Awir stond erop terwijl de
+materiewetten er dik naar verwijzen en de traversal hem gewoon vindt, zodat de
+uitzondering daar alleen de producent buiten het plan hield die eerder vertaald
+moest worden dan zijn lezer. En het kaartmechanisme loste het Awb-geval niet op:
+een kaart ontstond alleen op een verwijzing die de traversal tegenkwam, en het
+probleem met de Awb is nu net dat die verwijzingen er niet zijn.
 
-De aanwijzing is een prelude. Zoals een taal een handvol namen impliciet
-beschikbaar stelt zonder dat een module ze importeert, verklaart een kaderwet zich
-van toepassing zonder dat de materiewet ernaar verwijst. Een prelude wordt niet
-gevonden door de resolver, hij wordt gedeclareerd, en wie hem niet declareert
-compileert code waarin de helft van de namen ontbreekt zonder dat er een import
-mist.
+Er blijft een relatie over, met een bron in de wettekst. Elke algemene wet
+bevat zijn eigen reikwijdtebepaling ("Deze wet geldt voor inkomensafhankelijke
+regelingen", Awir artikel 1). Dat is de `applies-to`-kant hierboven: zodra de
+algemene wet geoogst en verrijkt is, komen die kanten uit de reikwijdtebepaling
+zelf. Een lijst ernaast die kan verouderen is dan niet meer nodig.
 
-Het zijn er weinig. Awb, Awir, Algemene termijnenwet, Wet inkomstenbelasting voor
-de inkomensbegrippen, en nog een handvol. Ze worden vooraf uitgewerkt en
-vastgelegd als data: per kaderwet het toepassingsbereik, het patroon waaraan je
-herkent dat het aan de orde is, en wat er dan meegenomen moet worden. Een
-verrijkingsopdracht krijgt die kaarten mee als extra invoer, en de poort na de
-verrijking controleert dat de vermelde werking ook echt is meegenomen. Een besluit
-dat verrijkt is zonder dat de Awb-termijnen erin zitten, faalt.
+De garantie die de kaart moest geven hangt aan een output. Een output met
+`legal_character` BESCHIKKING valt per definitie onder het Awb-regime, en de
+toetsbare formulering ("een output die een besluit representeert heeft een
+beslistermijn en een bezwaarpad") sleutelt daarop. Een besluit dat verrijkt is
+zonder dat de Awb-termijnen erin zitten, faalt op die poort, ook wanneer de
+traversal de Awb nooit heeft gezien.
 
-Het moet data zijn en geen prozaregel in een skill. Een regel in een
-skill veroudert stil en niemand merkt het. Een lijst met een eigenaar en een poort
-die erop controleert, veroudert zichtbaar.
-
-Het duurste eraan is dat de kaart machinaal toetsbaar moet zijn. "De Awb is van
-toepassing" zegt een poort niets. "Een output die een besluit representeert heeft
-een beslistermijn en een bezwaarpad" is toetsbaar, en zo'n formulering is
-juristenwerk per kaderwet. Voor de Awb en de Awir samen is dat de moeite waard,
-omdat die twee bijna elke materiewet in dit domein raken. Daarna weegt het per
-geval.
-
-De lijst zelf blijft een erkend risico: wat er niet op staat, mis je nog steeds
-stil. Dat is een aanvaarde beperking en geen opgelost probleem, en de lijst hoort
-dus periodiek tegen het licht.
+Tot de Awb verrijkt is en die poort bestaat, is de Awb-werking een bekend gat
+met een naam, en geen kaart die dekking suggereert.
 
 ## Scenario als wortel
 
@@ -501,19 +492,21 @@ verschillende afwegingen.
 
 De verwachting is dat de graaf uiteenvalt in gemeenschappen die met rechtsgebieden
 samenvallen: sociale zekerheid rond de Awir en de Wet inkomstenbelasting,
-omgevingsrecht rond de Omgevingswet, met de kaderwetten als kanten dwars door
-alles heen.
+omgevingsrecht rond de Omgevingswet, met de algemene wetten als kanten dwars
+door alles heen.
 
 Als dat klopt, is het bruikbaar: de sluiting van een scenario ligt dan grotendeels
-binnen één cluster plus een paar kaderwetten, en dan is de werkvoorraad per
+binnen één cluster plus een paar algemene wetten, en dan is de werkvoorraad per
 gebied planbaar in plaats van per wet. Het is toetsbaar zodra de resolve-stap over
 genoeg corpus heeft gedraaid, door de modulariteit van de graaf te meten. Tot dan
 is het een vermoeden.
 
 ## Wat dit niet oplost
 
-De kaderwetlijst is handwerk en veroudert. Een werking die er niet op staat
-blijft een stil gat.
+De werking van een algemene wet die nog niet geoogst en verrijkt is, blijft een
+gat. De poort op `legal_character` vangt de vorm (een beschikking zonder
+termijnen faalt), maar de inhoud van het Awb-regime zit er pas in wanneer de
+`applies-to`-kanten er zijn.
 
 De resolve-stap moet verwijzingen herkennen die niet in de standaardvorm staan.
 Impliciete verwijzingen ("de daartoe bevoegde minister") vindt hij niet.
@@ -542,8 +535,8 @@ nodig voor al het andere.
 Daarna de resolve-stap over de wetten die nu in de ronde zitten, zodat de graaf
 bestaat voordat er iets op gebouwd wordt.
 
-Daarna de kaderwetkaarten voor Awb en Awir, omdat die twee de meeste materiewetten
-raken en de poort erop de gevaarlijkste faalvorm afdekt.
+Daarna de poort op `legal_character`, omdat die de gevaarlijkste faalvorm
+afdekt: een verrijkte beschikking zonder termijn- en bezwaarmodellering.
 
 Daarna de werkvoorraad met herkomst, en pas dan de sluitings-poort, want die heeft
 de werkvoorraad nodig om te weten wat nog open staat.
@@ -553,7 +546,9 @@ het bovenstaande.
 
 ## Open beslissingen
 
-Wie wijst de kaderwetten aan en beheert de lijst en met welk reviewritme.
+Hoe de verrijking de reikwijdtebepaling van een algemene wet omzet in
+`applies-to`-kanten, hoe breed zo'n kant mag zijn ("vrijwel elk besluit" is geen
+lijst BWB-nummers), en wie die kanten reviewt.
 
 Is de sidecar een bestand naast de wet of een map. Bij fijne fragmentatie wordt
 één bestand groot.

--- a/docs/src/content/rfcs/rfc-026.md
+++ b/docs/src/content/rfcs/rfc-026.md
@@ -360,9 +360,13 @@ regels delegeert, en daarvan staan er vijftien echte in het corpus. De lijst
 gooide twee tegengestelde gevallen op één hoop: de Awir stond erop terwijl de
 materiewetten er dik naar verwijzen en de traversal hem gewoon vindt, zodat de
 uitzondering daar alleen de producent buiten het plan hield die eerder vertaald
-moest worden dan zijn lezer. En het kaartmechanisme loste het Awb-geval niet op:
-een kaart ontstond alleen op een verwijzing die de traversal tegenkwam, en het
-probleem met de Awb is nu net dat die verwijzingen er niet zijn.
+moest worden dan zijn lezer. En het kaartmechanisme beantwoordde de vraag niet
+waarvoor het bestond: een kaart ontstond alleen op een verwijzing die de
+traversal tegenkwam, dus of de Awb-kaart verscheen hing af van toevallige
+citaten elders in de sluiting (vanaf de zorgtoeslag wel op diepte 1, via de
+Zvw, en niet op diepte 0) en zei niets over toepasselijkheid, terwijl de
+besluit-machinerie waar het om gaat op geen enkele diepte via verwijzingen
+binnenkomt.
 
 Er blijft een relatie over, met een bron in de wettekst. Elke algemene wet
 bevat zijn eigen reikwijdtebepaling ("Deze wet geldt voor inkomensafhankelijke

--- a/packages/pipeline/src/bin/enrich_once.rs
+++ b/packages/pipeline/src/bin/enrich_once.rs
@@ -66,9 +66,7 @@ use regelrecht_pipeline::enrich::{
     FeedbackRounds, LlmProvider, ProcessLlmRunner, RunSteps, SessionReuse,
 };
 use regelrecht_pipeline::enrich_v2::checks;
-use regelrecht_pipeline::enrich_v2::closure::{
-    plan_closure, Kaderwetten, LawIndex, Plan, StopRules, Task,
-};
+use regelrecht_pipeline::enrich_v2::closure::{plan_closure, LawIndex, Plan, StopRules, Task};
 
 struct Args {
     corpus: PathBuf,
@@ -81,7 +79,6 @@ struct Args {
     article: Vec<String>,
     depth: Option<usize>,
     max_plan_articles: usize,
-    kaderwetten: Option<PathBuf>,
     rounds: FeedbackRounds,
     session_reuse: SessionReuse,
     steps: RunSteps,
@@ -98,7 +95,6 @@ fn parse_args() -> Result<Args, String> {
     let mut article: Vec<String> = Vec::new();
     let mut depth = None;
     let mut max_plan_articles = 200usize;
-    let mut kaderwetten = None;
     let mut rounds = FeedbackRounds::default();
     let mut steps = RunSteps::all();
     let mut session_reuse = SessionReuse::default();
@@ -118,7 +114,6 @@ fn parse_args() -> Result<Args, String> {
             // the Zorgverzekeringswet, and planning them one at a time would
             // plan seven overlapping closures instead of the one they form.
             "--article" => article.push(value("--article")?),
-            "--kaderwetten" => kaderwetten = Some(PathBuf::from(value("--kaderwetten")?)),
             "--depth" => {
                 depth = Some(
                     value("--depth")?
@@ -149,7 +144,7 @@ fn parse_args() -> Result<Args, String> {
                     "usage: enrich-once --corpus <root> --law <path.yaml> [--provider claude] \
                      [--model opus] [--effort medium] [--timeout 900] [--articles 15] \
                      [--rounds 2|checks=2,marking=2] [--article 69]... [--depth 1] \
-                     [--max-plan-articles 200] [--kaderwetten <path>] [--steps window,reconcile] \
+                     [--max-plan-articles 200] [--steps window,reconcile] \
                      [--session-reuse window|repair|off]"
                         .to_string(),
                 )
@@ -169,7 +164,6 @@ fn parse_args() -> Result<Args, String> {
         article,
         depth,
         max_plan_articles,
-        kaderwetten,
         rounds,
         session_reuse,
         steps,
@@ -197,52 +191,11 @@ fn plan_from_args(args: &Args) -> Result<Option<Plan>, String> {
 
     let index = LawIndex::scan(&args.corpus)
         .map_err(|e| format!("cannot read the corpus at {}: {e}", args.corpus.display()))?;
-    // Three outcomes, and they may not read as one. A list that is not there
-    // designates nothing and says so; a list that is there and broken fails
-    // the run, because falling back to "no framework laws" is the silent gap
-    // RFC-026 requirement 5 names as the one form that may not occur. The
-    // message names the file that was actually read, which under
-    // `--kaderwetten` is not the one beside the corpus.
-    let kaderwetten_path = args
-        .kaderwetten
-        .clone()
-        .unwrap_or_else(|| args.corpus.join("kaderwetten.yaml"));
-    let kaderwetten = match &args.kaderwetten {
-        Some(path) => Some(
-            Kaderwetten::parse(
-                &std::fs::read_to_string(path)
-                    .map_err(|e| format!("cannot read {}: {e}", path.display()))?,
-            )
-            .map_err(|e| format!("{}: {e}", path.display()))?,
-        ),
-        None => Kaderwetten::load(&args.corpus)?,
-    };
-    let unfound =
-        "A law that declares itself applicable without being referenced will not be found";
-    let kaderwetten = match kaderwetten {
-        None => {
-            eprintln!(
-                "note: {} is absent, so no framework law is designated. {unfound}",
-                kaderwetten_path.display()
-            );
-            Kaderwetten::default()
-        }
-        Some(list) if list.bwb_ids.is_empty() => {
-            eprintln!(
-                "note: {} designates no framework law. {unfound}",
-                kaderwetten_path.display()
-            );
-            list
-        }
-        Some(list) => list,
-    };
-
     let plan = plan_closure(
         &args.corpus,
         &args.law,
         &args.article,
         depth,
-        &kaderwetten,
         &index,
         StopRules::default(),
     )?;
@@ -262,9 +215,8 @@ fn plan_from_args(args: &Args) -> Result<Option<Plan>, String> {
 /// Built as lines rather than printed straight out because this is the only
 /// account of a run that costs hours: it names every law, the totals it will
 /// work through, and the edges it decided not to follow. A gap count that
-/// silently drops an occurrence, or a "kaderwetten" line that appears when
-/// there are none, misstates what the run is about to do, and nobody re-reads
-/// the plan afterwards to catch it.
+/// silently drops an occurrence misstates what the run is about to do, and
+/// nobody re-reads the plan afterwards to catch it.
 fn plan_report(plan: &Plan, depth: usize, articles: &[String]) -> Vec<String> {
     let mut lines = vec![format!(
         "=== bouwplan op diepte {depth} vanaf artikel {}",
@@ -277,12 +229,6 @@ fn plan_report(plan: &Plan, depth: usize, articles: &[String]) -> Vec<String> {
         plan.articles(),
         plan.entries()
     ));
-    if !plan.cards.is_empty() {
-        lines.push(format!(
-            "  kaderwetten (naast de diepte): {}",
-            plan.cards.join(", ")
-        ));
-    }
     if !plan.gaps.is_empty() {
         // Per kind and summed over the laws: the same reason for not following
         // an edge occurs at many laws, and what the reader needs is how much of
@@ -754,7 +700,6 @@ articles:
             article: Vec::new(),
             depth: None,
             max_plan_articles: 200,
-            kaderwetten: None,
             rounds: FeedbackRounds::default(),
             session_reuse: SessionReuse::default(),
             steps: RunSteps::all(),
@@ -843,23 +788,18 @@ articles:
     }
 
     /// A line per thing the plan actually has. An empty list is not a finding,
-    /// and printing "kaderwetten:" or "bekende gaten:" with nothing behind it
-    /// reads as the opposite of what it means.
+    /// and printing "bekende gaten:" with nothing behind it reads as the
+    /// opposite of what it means.
     #[test]
     fn test_the_report_leaves_out_what_the_plan_does_not_have() {
         let plan = Plan {
             tasks: vec![task("wet_a", 2)],
-            cards: Vec::new(),
             gaps: Vec::new(),
         };
         let report = plan_report(&plan, 1, &["1".to_string()]).join("\n");
 
         assert!(report.contains("bouwplan op diepte 1 vanaf artikel 1"));
         assert!(report.contains("totaal: 1 wetten, 2 artikelen, 4 entries"));
-        assert!(
-            !report.contains("kaderwetten"),
-            "no framework law came along, so the line must not appear: {report}"
-        );
         assert!(
             !report.contains("bekende gaten"),
             "no edge was left unfollowed, so the line must not appear: {report}"
@@ -877,7 +817,6 @@ articles:
     fn test_the_gap_summary_sums_the_occurrences_per_reason() {
         let plan = Plan {
             tasks: vec![task("wet_a", 2)],
-            cards: vec!["awb".to_string(), "awr".to_string()],
             gaps: vec![
                 Gap {
                     kind: GapKind::OutsideCorpus,
@@ -899,7 +838,6 @@ articles:
         let report = plan_report(&plan, 2, &["1".to_string(), "2".to_string()]).join("\n");
 
         assert!(report.contains("vanaf artikel 1, 2"));
-        assert!(report.contains("kaderwetten (naast de diepte): awb, awr"));
         assert!(
             report.contains("bekende gaten: Delegated 2, OutsideCorpus 7"),
             "seven edges point outside the corpus, not four and not three: {report}"

--- a/packages/pipeline/src/enrich_v2/closure.rs
+++ b/packages/pipeline/src/enrich_v2/closure.rs
@@ -76,9 +76,13 @@
 //! de artikelen die op de handgeschreven kaart stonden, dus daar berekende de
 //! graaf al wat de lijst wilde afdwingen, en "niet inlopen" hield nog wel de
 //! producent buiten het plan die deepest-first eerder vertaald moest worden dan
-//! zijn lezer. De Awb heeft het omgekeerde probleem, geen inkomende kanten,
-//! maar daarvoor deed de kaart niets: hij ontstond alleen op een kant die de
-//! traversal tegenkwam, en die kanten zijn er voor de Awb niet. Een wet die
+//! zijn lezer. De Awb heeft het omgekeerde probleem: de zorgtoeslag citeert hem
+//! zelf nergens, en de besluit-machinerie (beslistermijnen, bezwaar) komt op
+//! geen enkele diepte via verwijzingen binnen; op diepte 2 is het enige
+//! Awb-artikel 4:3, als bijvangst. Een kaart verscheen wel, maar alleen omdat
+//! meegetrokken Zvw-artikelen toevallig een Awb-kant hebben; hij ontstond op
+//! een kant die de traversal tegenkwam, hing dus af van toevallige citaten
+//! elders in de sluiting, en zei niets over toepasselijkheid. Een wet die
 //! werkt zonder geciteerd te worden is een relatie met een bron in de wettekst
 //! (de reikwijdtebepaling, als `applies-to`-kant) en een trigger in het schema
 //! (`legal_character`), geen wetscategorie in de planner. Zie RFC-026.

--- a/packages/pipeline/src/enrich_v2/closure.rs
+++ b/packages/pipeline/src/enrich_v2/closure.rs
@@ -18,8 +18,10 @@
 //! ## De meting die de standaard bepaalt
 //!
 //! Gemeten met deze code op het corpus, vanaf `--article 69` van de
-//! Zorgverzekeringswet, met de stopregels hieronder aan en de Awb en de Awir
-//! aangewezen als kaderwet:
+//! Zorgverzekeringswet, met de stopregels hieronder aan. De meting is gedaan
+//! toen de Awb en de Awir nog als "kaderwet" naast de diepte stonden; zonder
+//! die uitzondering, die inmiddels geschrapt is, komt diepte 3 op 5 396 in
+//! plaats van 5 274 artikelen uit, ruim twee procent meer:
 //!
 //! | diepte | wetten | artikelen | entries |
 //! |-------:|-------:|----------:|--------:|
@@ -64,26 +66,22 @@
 //! - **Verwijzing zonder artikel.** "de Wet langdurige zorg" of "afdeling
 //!   3.3.1" noemt geen artikel, dus er is niets om naartoe te lopen. Op diepte 3
 //!   staan er ruim drieduizend van; ze volgen zou het wetboek oogsten.
-//! - **Kaderwetten.** Zie hieronder.
 //!
-//! ## Kaderwetten staan naast de diepte
+//! ## Algemene wetten zijn gewone wetten
 //!
-//! Een kaderwet is een probleem omdat je hem juist *niet* vindt door
-//! verwijzingen te volgen: de Awb verklaart zichzelf van toepassing op vrijwel
-//! elk besluit zonder dat de materiewet hem noemt. De kaart haalt hem er dus
-//! bij, buiten de graaf om, en de poort erna controleert dat de vermelde
-//! werking er echt in zit.
-//!
-//! Daarmee komt de vraag of die kaart een niveau kost. Hij kost er geen, en de
-//! meting zegt dat het cijfermatig nauwelijks uitmaakt: op diepte 3 scheelt het
-//! 5 274 tegen 5 396 artikelen, ruim twee procent. Omdat het zo weinig kost, is
-//! de keuze te maken op wat hij betekent, en dan is een niveau verbruiken aan
-//! iets dat overal geldt de verkeerde kant op. Elke wet zou meteen op diepte 1
-//! zitten zonder één materiële sprong te hebben gemaakt.
-//!
-//! Om dezelfde reden wordt er niet *vanuit* een kaderwet verder gelopen. Zou de
-//! Awb zijn eigen verwijzingen meelopen, dan is de sluiting de Awb en niet de
-//! wet waar je om vroeg.
+//! Er stond hier een vierde stopregel: een handgeschreven lijst "kaderwetten"
+//! (de Awb en de Awir) die als kaart naast de diepte meegingen en waar niet in
+//! of uit werd gelopen. Die uitzondering is geschrapt. Gemeten op het corpus
+//! komt de Awir vanaf de Wet op de zorgtoeslag op diepte 1 gewoon binnen met
+//! de artikelen die op de handgeschreven kaart stonden, dus daar berekende de
+//! graaf al wat de lijst wilde afdwingen, en "niet inlopen" hield nog wel de
+//! producent buiten het plan die deepest-first eerder vertaald moest worden dan
+//! zijn lezer. De Awb heeft het omgekeerde probleem, geen inkomende kanten,
+//! maar daarvoor deed de kaart niets: hij ontstond alleen op een kant die de
+//! traversal tegenkwam, en die kanten zijn er voor de Awb niet. Een wet die
+//! werkt zonder geciteerd te worden is een relatie met een bron in de wettekst
+//! (de reikwijdtebepaling, als `applies-to`-kant) en een trigger in het schema
+//! (`legal_character`), geen wetscategorie in de planner. Zie RFC-026.
 //!
 //! ## Definitie tegenover berekening
 //!
@@ -249,82 +247,6 @@ fn read_head(path: &Path, root: &Path) -> Option<LawEntry> {
     })
 }
 
-/// The designated framework laws: the ones a traversal never finds because
-/// they declare themselves applicable without being referenced.
-///
-/// Read from `<corpus>/kaderwetten.yaml`. An absent file means none are
-/// designated, which is the honest reading: this is a hand-written list and
-/// RFC-026 already names it as the one place a silent gap can arise.
-///
-/// Absent and broken are two different things and only the first is an honest
-/// empty list. A list with a YAML error used to fall back to no designations
-/// at all, and the caller then reported the file as *absent* — the silent gap
-/// requirement 5 calls the one failure form that may not occur, arrived at
-/// through the very line meant to prevent it. Both readers therefore return a
-/// `Result` and say which of the two happened.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct Kaderwetten {
-    /// BWB identifiers, in the order the file lists them.
-    pub bwb_ids: Vec<String>,
-}
-
-impl Kaderwetten {
-    /// Read the list beside the corpus.
-    ///
-    /// `Ok(None)` when the file is not there, which is a corpus that
-    /// designates no framework laws. An `Err` is a file that is there and
-    /// cannot be read as a list.
-    ///
-    /// # Errors
-    ///
-    /// When `kaderwetten.yaml` exists but is not readable as YAML.
-    pub fn load(root: &Path) -> Result<Option<Self>, String> {
-        let path = root.join("kaderwetten.yaml");
-        let Ok(raw) = std::fs::read_to_string(&path) else {
-            return Ok(None);
-        };
-        Self::parse(&raw)
-            .map(Some)
-            .map_err(|e| format!("{}: {e}", path.display()))
-    }
-
-    /// Parse the list. Accepts a bare sequence of BWB numbers and a sequence of
-    /// mappings with a `bwb_id`, because both shapes read as the same list and
-    /// refusing one of them would be pedantry over a hand-written file.
-    ///
-    /// # Errors
-    ///
-    /// When the text is not YAML at all. A list that parses and designates
-    /// nothing is not an error: an empty file says the same as an absent one.
-    pub fn parse(raw: &str) -> Result<Self, String> {
-        let doc = serde_yaml_ng::from_str::<Value>(raw)
-            .map_err(|e| format!("de kaderwetlijst is geen YAML: {e}"))?;
-        let seq = doc
-            .get("kaderwetten")
-            .and_then(Value::as_sequence)
-            .or_else(|| doc.as_sequence())
-            .cloned()
-            .unwrap_or_default();
-        let bwb_ids = seq
-            .iter()
-            .filter_map(|item| match item {
-                Value::String(s) => Some(s.clone()),
-                other => other
-                    .get("bwb_id")
-                    .and_then(Value::as_str)
-                    .map(str::to_string),
-            })
-            .collect();
-        Ok(Self { bwb_ids })
-    }
-
-    /// Whether this law is designated.
-    #[must_use]
-    pub fn contains(&self, bwb_id: &str) -> bool {
-        self.bwb_ids.iter().any(|b| b == bwb_id)
-    }
-}
-
 /// The bounds the traversal applies before the depth number does.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct StopRules {
@@ -387,8 +309,6 @@ pub struct Plan {
     /// Laws to enrich, deepest first: a producer is translated before the law
     /// that reads it, which is what makes the binding real instead of a guess.
     pub tasks: Vec<Task>,
-    /// Framework laws that come along beside the depth.
-    pub cards: Vec<String>,
     /// Edges recorded rather than followed.
     pub gaps: Vec<Gap>,
 }
@@ -455,7 +375,6 @@ pub fn plan_closure(
     start_path: &str,
     start_articles: &[String],
     depth: usize,
-    kaderwetten: &Kaderwetten,
     index: &LawIndex,
     rules: StopRules,
 ) -> std::result::Result<Plan, String> {
@@ -490,7 +409,6 @@ pub fn plan_closure(
     law_depth.insert(start_bwb.clone(), 0);
     let mut taken: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
     let mut gaps: BTreeMap<(GapKind, String), usize> = BTreeMap::new();
-    let mut cards: BTreeSet<String> = BTreeSet::new();
 
     // The queue holds (law, article, is_entry_point). An entry point is an
     // article the closure came in through; a definition article is a leaf only
@@ -549,12 +467,6 @@ pub fn plan_closure(
         }
 
         for (target_law, target_article) in outward {
-            // A framework law comes along beside the depth: it is added to the
-            // plan as a card and never walked into or out of.
-            if kaderwetten.contains(&target_law) {
-                cards.insert(target_law);
-                continue;
-            }
             let Some(entry) = index.get(&target_law) else {
                 *gaps
                     .entry((GapKind::OutsideCorpus, target_law.clone()))
@@ -635,7 +547,6 @@ pub fn plan_closure(
 
     Ok(Plan {
         tasks,
-        cards: cards.into_iter().collect(),
         gaps: gaps
             .into_iter()
             .map(|((kind, bwb_id), occurrences)| Gap {
@@ -750,14 +661,13 @@ articles:
         std::fs::write(path, body).unwrap();
     }
 
-    fn plan_of(dir: &tempfile::TempDir, depth: usize, kaderwetten: &Kaderwetten) -> Plan {
+    fn plan_of(dir: &tempfile::TempDir, depth: usize) -> Plan {
         let index = LawIndex::scan(dir.path()).unwrap();
         plan_closure(
             dir.path(),
             "regulation/nl/wet/wet_a/2026-01-01.yaml",
             &["1".to_string()],
             depth,
-            kaderwetten,
             &index,
             StopRules::default(),
         )
@@ -778,7 +688,7 @@ articles:
 
     #[test]
     fn depth_zero_stays_inside_the_starting_law() {
-        let plan = plan_of(&corpus(), 0, &Kaderwetten::default());
+        let plan = plan_of(&corpus(), 0);
         assert_eq!(plan.tasks.len(), 1);
         assert_eq!(plan.tasks[0].law_id, "wet_a");
         assert_eq!(plan.tasks[0].articles, vec!["1".to_string()]);
@@ -794,7 +704,7 @@ articles:
     /// costs one point, whatever the longer route through B would cost.
     #[test]
     fn a_law_reached_straight_from_the_start_costs_one_jump() {
-        let plan = plan_of(&corpus(), 1, &Kaderwetten::default());
+        let plan = plan_of(&corpus(), 1);
         let depth_of = |id: &str| {
             plan.tasks
                 .iter()
@@ -811,7 +721,7 @@ articles:
     /// because article 5 names it; article 2 of A stays out.
     #[test]
     fn a_step_inside_a_law_is_free_but_only_along_the_hot_path() {
-        let plan = plan_of(&corpus(), 1, &Kaderwetten::default());
+        let plan = plan_of(&corpus(), 1);
         let b = plan.tasks.iter().find(|t| t.law_id == "wet_b").unwrap();
         assert_eq!(b.articles, vec!["5".to_string(), "6".to_string()]);
         let a = plan.tasks.iter().find(|t| t.law_id == "wet_a").unwrap();
@@ -822,15 +732,18 @@ articles:
     /// binds to names that already exist.
     #[test]
     fn the_plan_puts_producers_before_their_readers() {
-        let plan = plan_of(&corpus(), 1, &Kaderwetten::default());
+        let plan = plan_of(&corpus(), 1);
         let depths: Vec<usize> = plan.tasks.iter().map(|t| t.depth).collect();
         assert_eq!(depths, vec![1, 1, 0]);
     }
 
-    /// A framework law comes along as a card and never spends a level, and the
-    /// closure does not walk out of it either.
+    /// A law that declares itself applicable is an ordinary law in the plan.
+    /// There used to be a designated list ("kaderwetten") whose members came
+    /// along as a card beside the depth and were never walked into; a
+    /// referenced producer must instead land in the plan as a task, deepest
+    /// first, like any other law.
     #[test]
-    fn a_framework_law_is_a_card_beside_the_depth() {
+    fn a_self_declaring_law_is_an_ordinary_task_in_the_plan() {
         let dir = corpus();
         write(
             &dir,
@@ -840,7 +753,7 @@ regulatory_layer: WET
 bwb_id: BWBR0000001
 articles:
   - number: '1'
-    text: Zie artikel 3 van de kaderwet.
+    text: Zie artikel 3 van de algemene wet.
     references:
       - id: ref1
         bwb_id: BWBR0000009
@@ -849,8 +762,8 @@ articles:
         );
         write(
             &dir,
-            "regulation/nl/wet/kaderwet/2026-01-01.yaml",
-            r"$id: kaderwet
+            "regulation/nl/wet/algemene_wet/2026-01-01.yaml",
+            r"$id: algemene_wet
 regulatory_layer: WET
 bwb_id: BWBR0000009
 articles:
@@ -858,16 +771,14 @@ articles:
     text: Deze wet is van toepassing op elk besluit.
 ",
         );
-        let kaderwetten = Kaderwetten {
-            bwb_ids: vec!["BWBR0000009".to_string()],
-        };
-        let plan = plan_of(&dir, 1, &kaderwetten);
-        assert_eq!(plan.cards, vec!["BWBR0000009".to_string()]);
-        assert!(
-            plan.tasks.iter().all(|t| t.law_id != "kaderwet"),
-            "een kaart is geen taak in de sluiting"
-        );
-        assert_eq!(plan.tasks.len(), 1, "de kaderwet verbruikt geen niveau");
+        let plan = plan_of(&dir, 1);
+        let task = plan
+            .tasks
+            .iter()
+            .find(|t| t.law_id == "algemene_wet")
+            .expect("de aangehaalde wet staat als taak in het plan");
+        assert_eq!(task.depth, 1, "een wetssprong kost een punt, ook hier");
+        assert_eq!(task.articles, vec!["3".to_string()]);
     }
 
     #[test]
@@ -899,7 +810,7 @@ articles:
     text: Het percentage is drie.
 ",
         );
-        let plan = plan_of(&dir, 3, &Kaderwetten::default());
+        let plan = plan_of(&dir, 3);
         assert_eq!(plan.tasks.len(), 1);
         assert_eq!(plan.gaps.len(), 1);
         assert_eq!(plan.gaps[0].kind, GapKind::Delegated);
@@ -923,7 +834,7 @@ articles:
         artikel: '2'
 ",
         );
-        let plan = plan_of(&dir, 3, &Kaderwetten::default());
+        let plan = plan_of(&dir, 3);
         assert_eq!(plan.gaps[0].kind, GapKind::OutsideCorpus);
         assert_eq!(plan.gaps[0].bwb_id, "BWBR9999999");
     }
@@ -947,7 +858,7 @@ articles:
         bwb_id: BWBR0000002
 ",
         );
-        let plan = plan_of(&dir, 3, &Kaderwetten::default());
+        let plan = plan_of(&dir, 3);
         assert_eq!(plan.gaps.len(), 1);
         assert_eq!(plan.gaps[0].kind, GapKind::NoArticle);
         assert_eq!(plan.tasks.len(), 1);
@@ -978,7 +889,6 @@ articles:
                 "regulation/nl/wet/wet_a/2026-01-01.yaml",
                 &["2".to_string()],
                 1,
-                &Kaderwetten::default(),
                 &index,
                 rules,
             )
@@ -1012,7 +922,6 @@ articles:
             "regulation/nl/wet/wet_a/2026-01-01.yaml",
             &["99".to_string()],
             1,
-            &Kaderwetten::default(),
             &index,
             StopRules::default(),
         )
@@ -1022,65 +931,9 @@ articles:
 
     #[test]
     fn a_plan_over_the_limit_refuses_with_its_own_size() {
-        let plan = plan_of(&corpus(), 1, &Kaderwetten::default());
+        let plan = plan_of(&corpus(), 1);
         assert!(plan.refuse_above(100).is_none());
         let refusal = plan.refuse_above(1).unwrap();
         assert!(refusal.contains("articles"), "{refusal}");
-    }
-
-    #[test]
-    fn kaderwetten_parse_both_shapes_and_an_absent_file() {
-        assert_eq!(
-            Kaderwetten::parse("- BWBR0005537\n- BWBR0016770\n")
-                .unwrap()
-                .bwb_ids,
-            vec!["BWBR0005537".to_string(), "BWBR0016770".to_string()]
-        );
-        assert_eq!(
-            Kaderwetten::parse(
-                "kaderwetten:\n  - bwb_id: BWBR0005537\n    naam: Awb\n  - bwb_id: BWBR0016770\n"
-            )
-            .unwrap()
-            .bwb_ids,
-            vec!["BWBR0005537".to_string(), "BWBR0016770".to_string()]
-        );
-        let dir = tempfile::tempdir().unwrap();
-        assert_eq!(
-            Kaderwetten::load(dir.path()),
-            Ok(None),
-            "afwezig is afwezig"
-        );
-    }
-
-    /// Absent and broken are not the same list. A YAML error used to read as
-    /// "no framework laws are designated", which the caller then reported as
-    /// an *absent* file: the silent gap RFC-026 requirement 5 calls the one
-    /// unacceptable failure form, arrived at through the line that exists to
-    /// prevent it.
-    #[test]
-    fn een_stukke_kaderwetlijst_is_geen_lege_kaderwetlijst() {
-        assert!(
-            Kaderwetten::parse("kaderwetten: [BWBR0005537\n").is_err(),
-            "een YAML-fout mag niet als lege lijst doorgaan"
-        );
-
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(
-            dir.path().join("kaderwetten.yaml"),
-            "kaderwetten: [BWBR0005537\n",
-        )
-        .unwrap();
-        let error = Kaderwetten::load(dir.path()).unwrap_err();
-        assert!(
-            error.contains("kaderwetten.yaml"),
-            "de melding noemt het bestand dat gelezen is: {error}"
-        );
-
-        // A list that parses and designates nothing is still an honest empty
-        // list, so the two cases stay apart in both directions.
-        assert_eq!(
-            Kaderwetten::parse("kaderwetten: []\n"),
-            Ok(Kaderwetten::default())
-        );
     }
 }


### PR DESCRIPTION
Schrapt het kaderwet-begrip uit de sluitingsplanner, zoals voorgesteld in #1122. De `Kaderwetten`-lijst, de kaart-logica en de vlag `--kaderwetten` zijn weg; een wet die eerst als kaart naast de diepte meeging is nu een gewone taak in het plan. RFC-026 is bijgewerkt: de sectie "Kaderwetten" heet nu "Algemene wetten", de garantie hangt aan een poort op `legal_character` en de vindbaarheid aan `applies-to`-kanten uit de reikwijdtebepalingen. De test die het kaartgedrag vastlegde is vervangen door een test op het nieuwe gedrag (een aangehaalde zelfverklarende wet is een gewone taak op diepte 1); de parse-tests van de lijst zijn mee verwijderd.

In de praktijk verandert er minder dan het lijkt: `kaderwetten.yaml` heeft nooit in het corpus gestaan, dus elke gewone run draaide al zonder de uitzondering, en een kaart leverde alleen een regel in het planrapport op.

Buiten deze PR: het ontwerp van `applies-to` (vervolg via #1122) en de visualisatiekant in de crate `packages/graph`. Voor wie daar later aan werkt: de draft-branch van #1132 verliest bij een rebase op deze wijziging zijn bron voor de cards; die kant moet daar apart worden opgelost. De mutatiepoort dekt alleen `packages/engine` en is hier niet van toepassing.
