### PR TITLE
fix(engine): begrens de fuzzy annotatiescan

### DIFF
--- a/frontend/src/components/NoteCreator.test.js
+++ b/frontend/src/components/NoteCreator.test.js
@@ -219,6 +219,42 @@ describe('NoteCreator', () => {
     expect(skipped.find('[data-testid="note-save"]').exists()).toBe(false);
   });
 
+  it('does not blame the selection length when the law text drained the budget', async () => {
+    // 'search_budget' means the law was too large or too repetitive to scan,
+    // which shortening the selection cannot fix. Telling the author to shorten
+    // sends them into the same skip again with no clue why.
+    const budget = mountCreator({
+      engine: {
+        resolveNote: () => ({
+          status: 'skipped',
+          matches: [],
+          skip_reason: 'search_budget',
+        }),
+      },
+    });
+    const tooLong = mountCreator({
+      engine: {
+        resolveNote: () => ({
+          status: 'skipped',
+          matches: [],
+          skip_reason: 'quote_too_long',
+        }),
+      },
+    });
+    await nextTick();
+
+    const budgetBanner = budget.find('[data-testid="note-creator-status"]');
+    const tooLongBanner = tooLong.find('[data-testid="note-creator-status"]');
+    expect(budgetBanner.attributes('text')).toBe('Niet naar gezocht');
+    expect(budgetBanner.attributes('supporting-text')).not.toBe(
+      tooLongBanner.attributes('supporting-text'),
+    );
+    expect(budgetBanner.attributes('supporting-text')).not.toContain(
+      'te lang',
+    );
+    expect(tooLongBanner.attributes('supporting-text')).toContain('te lang');
+  });
+
   it('shows the full form once the selection resolves uniquely', async () => {
     const w = mountCreator(); // engine returns a matching unique result
     await nextTick();

--- a/frontend/src/components/NoteCreator.test.js
+++ b/frontend/src/components/NoteCreator.test.js
@@ -183,6 +183,42 @@ describe('NoteCreator', () => {
     expect(w.find('[data-testid="note-cancel"]').exists()).toBe(false);
   });
 
+  it('tells the user a skipped search was not searched, unlike an orphaned one', async () => {
+    // The resolver refused the scan (quote over the fuzzy budget). The user
+    // must see something different from "Niet teruggevonden": nothing was
+    // established about the text, and the lidnummer advice that belongs to
+    // a failed search would be misdirected here.
+    const skipped = mountCreator({
+      engine: {
+        resolveNote: () => ({
+          status: 'skipped',
+          matches: [],
+          skip_reason: 'quote_too_long',
+        }),
+      },
+    });
+    const orphaned = mountCreator({
+      engine: {
+        resolveNote: () => ({ status: 'orphaned', matches: [] }),
+      },
+    });
+    await nextTick();
+
+    const skippedBanner = skipped.find('[data-testid="note-creator-status"]');
+    const orphanedBanner = orphaned.find('[data-testid="note-creator-status"]');
+    expect(skippedBanner.exists()).toBe(true);
+    expect(skippedBanner.attributes('text')).toBe('Niet naar gezocht');
+    expect(orphanedBanner.attributes('text')).toBe('Niet teruggevonden');
+    expect(skippedBanner.attributes('text')).not.toBe(
+      orphanedBanner.attributes('text'),
+    );
+    expect(skippedBanner.attributes('supporting-text')).not.toContain(
+      'lidnummer',
+    );
+    // Still no save path: a skipped selection anchors nothing.
+    expect(skipped.find('[data-testid="note-save"]').exists()).toBe(false);
+  });
+
   it('shows the full form once the selection resolves uniquely', async () => {
     const w = mountCreator(); // engine returns a matching unique result
     await nextTick();

--- a/frontend/src/components/NoteCreator.vue
+++ b/frontend/src/components/NoteCreator.vue
@@ -378,6 +378,14 @@ const statusInfo = computed(() => {
         title: 'Niet eenduidig',
         lead: 'Dit fragment is hier niet uniek. Breid de selectie uit met de omringende woorden.',
       };
+    case 'not-searched':
+      // status 'skipped': the resolver hit its scan budget and never
+      // searched. Saying "niet teruggevonden" here would be untrue (nothing
+      // was established) and the lidnummer advice would be misdirected.
+      return {
+        title: 'Niet naar gezocht',
+        lead: 'De selectie is te lang om terug te zoeken. Maak de selectie korter.',
+      };
     default: // 'not-found'
       return {
         title: 'Niet teruggevonden',

--- a/frontend/src/components/NoteCreator.vue
+++ b/frontend/src/components/NoteCreator.vue
@@ -177,6 +177,7 @@ const referencedFragment = computed(() => {
 });
 const selectorStatus = computed(() => selectorResult.value?.status ?? null);
 const selectorReason = computed(() => selectorResult.value?.reason ?? null);
+const selectorSkipReason = computed(() => selectorResult.value?.skipReason ?? null);
 
 // Individual "is this part filled?" checks, shared by canSave and the body /
 // motivation builders. A link only counts once its target is actually chosen.
@@ -379,13 +380,20 @@ const statusInfo = computed(() => {
         lead: 'Dit fragment is hier niet uniek. Breid de selectie uit met de omringende woorden.',
       };
     case 'not-searched':
-      // status 'skipped': the resolver hit its scan budget and never
+      // status 'skipped': the resolver hit one of its bounds and never
       // searched. Saying "niet teruggevonden" here would be untrue (nothing
       // was established) and the lidnummer advice would be misdirected.
-      return {
-        title: 'Niet naar gezocht',
-        lead: 'De selectie is te lang om terug te zoeken. Maak de selectie korter.',
-      };
+      // Which bound was hit decides the advice: only 'quote_too_long' is
+      // something the author fixes by shortening the selection.
+      return selectorSkipReason.value === 'search_budget'
+        ? {
+            title: 'Niet naar gezocht',
+            lead: 'De wettekst is te groot om deze selectie in terug te zoeken. Korter selecteren helpt hier niet.',
+          }
+        : {
+            title: 'Niet naar gezocht',
+            lead: 'De selectie is te lang om terug te zoeken. Maak de selectie korter.',
+          };
     default: // 'not-found'
       return {
         title: 'Niet teruggevonden',

--- a/frontend/src/composables/useNotes.js
+++ b/frontend/src/composables/useNotes.js
@@ -181,7 +181,7 @@ export function useNotes(lawId, selectedArticle, trajectRef, lawValidFrom) {
     return out;
   });
 
-  /** Orphaned / ambiguous / parse-failed notes, for a status list. */
+  /** Orphaned / ambiguous / skipped / parse-failed notes, for a status list. */
   const issues = computed(() =>
     resolved.value
       .filter(
@@ -193,7 +193,12 @@ export function useNotes(lawId, selectedArticle, trajectRef, lawValidFrom) {
           ? `parsefout: ${e.error}`
           : e.match.status === 'orphaned'
             ? 'niet gevonden in de wettekst (orphaned)'
-            : 'meerdere matches (ambigu) - voeg context toe',
+            : e.match.status === 'skipped'
+              ? // The resolver hit its scan budget (config.rs) before finding
+                // anything: the law was not (fully) searched. Distinct from
+                // orphaned, which asserts the text is absent.
+                'niet naar gezocht: citaat te lang voor de zoekbegrenzing - kort het citaat in'
+              : 'meerdere matches (ambigu) - voeg context toe',
       })),
   );
 

--- a/frontend/src/composables/useNotes.js
+++ b/frontend/src/composables/useNotes.js
@@ -194,10 +194,14 @@ export function useNotes(lawId, selectedArticle, trajectRef, lawValidFrom) {
           : e.match.status === 'orphaned'
             ? 'niet gevonden in de wettekst (orphaned)'
             : e.match.status === 'skipped'
-              ? // The resolver hit its scan budget (config.rs) before finding
-                // anything: the law was not (fully) searched. Distinct from
-                // orphaned, which asserts the text is absent.
-                'niet naar gezocht: citaat te lang voor de zoekbegrenzing - kort het citaat in'
+              ? // The resolver hit a scan bound (config.rs): the law was not
+                // (fully) searched. Distinct from orphaned, which asserts
+                // the text is absent. skip_reason names the bound that was
+                // hit, so the advice matches the cause instead of always
+                // blaming the quote length.
+                e.match.skip_reason === 'quote_too_long'
+                ? 'niet naar gezocht: citaat te lang voor de zoekbegrenzing - kort het citaat in'
+                : 'niet volledig doorzocht: de wettekst overschrijdt de zoekbegrenzing'
               : 'meerdere matches (ambigu) - voeg context toe',
       })),
   );

--- a/frontend/src/composables/useNotes.test.js
+++ b/frontend/src/composables/useNotes.test.js
@@ -1,10 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
 import { ref } from 'vue';
-import { useResolvedDraftNotes } from './useNotes.js';
+import { useNotes, useResolvedDraftNotes } from './useNotes.js';
 
 // Capture what useResolvedDraftNotes hands the WASM engine. The mock replaces
 // the singleton engine bootstrap.
 const engineCalls = vi.hoisted(() => []);
+// What the mocked engine returns from resolveNotes; per-test.
+const resolveNotesResult = vi.hoisted(() => ({ value: [] }));
 vi.mock('./useEngine.js', () => ({
   useEngine: () => ({
     initEngine: async () => ({
@@ -15,10 +17,59 @@ vi.mock('./useEngine.js', () => ({
           matches: [{ article_number: '1', start: 0, end: 3 }],
         };
       },
+      resolveNotes: () => resolveNotesResult.value,
     }),
     loadDependency: async () => {},
   }),
 }));
+
+vi.mock('../lib/apiFetch.js', () => ({
+  apiFetch: async () => ({ status: 200, text: async () => 'annotations: []' }),
+}));
+
+describe('useNotes issues', () => {
+  async function issuesFor(lawId, match) {
+    resolveNotesResult.value = [{ note: { id: 'n1' }, match }];
+    const { issues } = useNotes(
+      ref(lawId),
+      ref({ number: '1' }),
+      ref(null),
+      ref('2024-01-01'),
+    );
+    await vi.waitFor(() => expect(issues.value).toHaveLength(1));
+    return issues.value[0].reason;
+  }
+
+  it('blames the quote length only when the quote length caused the skip', async () => {
+    // 'skipped' has three causes; "kort het citaat in" fixes exactly one of
+    // them. On a drained scan budget that advice is wrong: the author
+    // shortens the quote, nothing changes, and the real cause stays hidden.
+    const quote = await issuesFor('wet_skip_quote', {
+      status: 'skipped',
+      matches: [],
+      skip_reason: 'quote_too_long',
+    });
+    expect(quote).toContain('citaat te lang');
+    expect(quote).toContain('kort het citaat in');
+
+    const budget = await issuesFor('wet_skip_budget', {
+      status: 'skipped',
+      matches: [],
+      skip_reason: 'search_budget',
+    });
+    expect(budget).not.toContain('kort het citaat in');
+    expect(budget).toContain('niet volledig doorzocht');
+  });
+
+  it('keeps a skipped note distinguishable from an orphaned one', async () => {
+    const orphaned = await issuesFor('wet_orphaned', {
+      status: 'orphaned',
+      matches: [],
+    });
+    expect(orphaned).toContain('orphaned');
+    expect(orphaned).not.toContain('niet naar gezocht');
+  });
+});
 
 describe('useResolvedDraftNotes', () => {
   it('resolves drafts against the viewed law version, not the newest', async () => {

--- a/frontend/src/composables/useTextSelection.js
+++ b/frontend/src/composables/useTextSelection.js
@@ -72,14 +72,17 @@ export function utf16ToCp(text, u16Offset) {
  * @returns {{
  *   selector: object,
  *   exact: string,
- *   status: 'found'|'ambiguous'|'orphaned',
- *   reason: 'ok'|'too-common'|'not-found'|'mis-anchor',
+ *   status: 'found'|'ambiguous'|'orphaned'|'skipped',
+ *   reason: 'ok'|'too-common'|'not-found'|'mis-anchor'|'not-searched',
  * }}
  *   `reason` is for the UI message only; it does not change accept/reject.
  *   'too-common' = the bare quote already matched several places (RFC-018
  *   §5.4 "common word without context") even if widening context later
  *   degrades to orphaned; 'not-found' = genuinely not locatable; 'mis-anchor'
- *   = a unique match landed off the selection.
+ *   = a unique match landed off the selection; 'not-searched' = the resolver
+ *   refused the scan (status 'skipped': the quote exceeds the fuzzy budget
+ *   in config.rs), which is a different message than "not found" — nothing
+ *   was established about the text at all.
  */
 export function buildSelector(rawText, range, lawId, engine, articleNumber, validFrom) {
   const chars = Array.from(rawText);
@@ -147,9 +150,12 @@ export function buildSelector(rawText, range, lawId, engine, articleNumber, vali
     // 'skipped': the resolver refused the fuzzy scan (quote over the budget
     // in config.rs). Growing context cannot fix a too-long quote, and the
     // exact pass (which is unbudgeted) already failed, so stop here rather
-    // than looping two more widths to the same answer.
+    // than looping two more widths to the same answer. The status stays
+    // 'skipped': the UI must say "this was not searched", not "not found" —
+    // flattening it to orphaned here would hand the user the wrong message
+    // and the wrong advice.
     if (result?.status === 'skipped') {
-      return { selector, exact, status: 'orphaned', reason: 'not-found' };
+      return { selector, exact, status: 'skipped', reason: 'not-searched' };
     }
     if ((result?.matches?.length ?? 0) > 1) sawMultiple = true;
     // A unique `found` that is NOT our selection is a mis-anchor: treat it as

--- a/frontend/src/composables/useTextSelection.js
+++ b/frontend/src/composables/useTextSelection.js
@@ -144,6 +144,13 @@ export function buildSelector(rawText, range, lawId, engine, articleNumber, vali
     if (isExactlyOurSelection(result)) {
       return { selector, exact, status: 'found', reason: 'ok' };
     }
+    // 'skipped': the resolver refused the fuzzy scan (quote over the budget
+    // in config.rs). Growing context cannot fix a too-long quote, and the
+    // exact pass (which is unbudgeted) already failed, so stop here rather
+    // than looping two more widths to the same answer.
+    if (result?.status === 'skipped') {
+      return { selector, exact, status: 'orphaned', reason: 'not-found' };
+    }
     if ((result?.matches?.length ?? 0) > 1) sawMultiple = true;
     // A unique `found` that is NOT our selection is a mis-anchor: treat it as
     // ambiguous (more context may still pin the right one) rather than

--- a/frontend/src/composables/useTextSelection.js
+++ b/frontend/src/composables/useTextSelection.js
@@ -155,7 +155,15 @@ export function buildSelector(rawText, range, lawId, engine, articleNumber, vali
     // flattening it to orphaned here would hand the user the wrong message
     // and the wrong advice.
     if (result?.status === 'skipped') {
-      return { selector, exact, status: 'skipped', reason: 'not-searched' };
+      // skip_reason travels along: 'quote_too_long' and 'search_budget' need
+      // different advice, and the caller cannot recover it from 'not-searched'.
+      return {
+        selector,
+        exact,
+        status: 'skipped',
+        reason: 'not-searched',
+        skipReason: result.skip_reason ?? null,
+      };
     }
     if ((result?.matches?.length ?? 0) > 1) sawMultiple = true;
     // A unique `found` that is NOT our selection is a mis-anchor: treat it as

--- a/frontend/src/composables/useTextSelection.test.js
+++ b/frontend/src/composables/useTextSelection.test.js
@@ -170,19 +170,21 @@ describe('buildSelector', () => {
     expect(calls).toBe(1);
   });
 
-  it('stops immediately when the resolver skipped the search', () => {
+  it('passes a skipped search through as its own status, not as orphaned', () => {
     // 'skipped' = the resolver's fuzzy budget refused the quote (RFC-018
     // scan bounds). Growing prefix/suffix cannot shorten the quote, so
     // retrying the two wider widths would just burn the same budget again.
+    // The status must survive to the caller: "not searched" and "not found"
+    // are different messages to the user, with different advice.
     const range = { start: 10, end: 20 };
     let calls = 0;
     const engine = engineReturning(() => {
       calls++;
-      return { status: 'skipped', matches: [] };
+      return { status: 'skipped', matches: [], skip_reason: 'quote_too_long' };
     });
     const out = buildSelector(raw, range, 'w', engine, '1');
-    expect(out.status).toBe('orphaned');
-    expect(out.reason).toBe('not-found');
+    expect(out.status).toBe('skipped');
+    expect(out.reason).toBe('not-searched');
     expect(calls).toBe(1);
   });
 });

--- a/frontend/src/composables/useTextSelection.test.js
+++ b/frontend/src/composables/useTextSelection.test.js
@@ -169,4 +169,20 @@ describe('buildSelector', () => {
     expect(out.status).toBe('orphaned');
     expect(calls).toBe(1);
   });
+
+  it('stops immediately when the resolver skipped the search', () => {
+    // 'skipped' = the resolver's fuzzy budget refused the quote (RFC-018
+    // scan bounds). Growing prefix/suffix cannot shorten the quote, so
+    // retrying the two wider widths would just burn the same budget again.
+    const range = { start: 10, end: 20 };
+    let calls = 0;
+    const engine = engineReturning(() => {
+      calls++;
+      return { status: 'skipped', matches: [] };
+    });
+    const out = buildSelector(raw, range, 'w', engine, '1');
+    expect(out.status).toBe('orphaned');
+    expect(out.reason).toBe('not-found');
+    expect(calls).toBe(1);
+  });
 });

--- a/packages/engine/src/annotation/mod.rs
+++ b/packages/engine/src/annotation/mod.rs
@@ -11,7 +11,7 @@ pub mod resolver;
 pub mod types;
 
 pub use resolver::resolve;
-pub use types::{MatchResult, MatchStatus, SelectorHint, TextMatch, TextQuoteSelector};
+pub use types::{MatchResult, MatchStatus, SelectorHint, SkipReason, TextMatch, TextQuoteSelector};
 
 /// Extract the law `$id` from a note's `target.source` URI.
 ///

--- a/packages/engine/src/annotation/resolver.rs
+++ b/packages/engine/src/annotation/resolver.rs
@@ -9,6 +9,18 @@
 //! 3. One match (or a clear winner) is [`MatchStatus::Found`], several
 //!    equally-good are [`MatchStatus::Ambiguous`], none is
 //!    [`MatchStatus::Orphaned`].
+//! 4. The fuzzy scan is budgeted (see [`FuzzyBudget`] and the
+//!    `MAX_FUZZY_*` limits in [`crate::config`]): it is cubic in the quote
+//!    length and runs synchronously on the browser main thread via WASM, so
+//!    an unbounded scan freezes the editor for minutes. When a bound cuts the
+//!    search short before anything was found the result is
+//!    [`MatchStatus::Skipped`] — "this was not searched" — never a silent
+//!    `Orphaned`.
+//!
+//! [`MatchStatus::Found`]: crate::annotation::MatchStatus::Found
+//! [`MatchStatus::Ambiguous`]: crate::annotation::MatchStatus::Ambiguous
+//! [`MatchStatus::Orphaned`]: crate::annotation::MatchStatus::Orphaned
+//! [`MatchStatus::Skipped`]: crate::annotation::MatchStatus::Skipped
 //!
 //! A `regelrecht:hint` on the selector does not participate in resolution.
 //! RFC-018 is explicit that article numbers are non-authoritative and that
@@ -21,7 +33,8 @@
 //!
 //! Structurally ported from the Python proof-of-concept on the
 //! `feature/annotation-resolver` branch (resolution order, dedup, tiebreak
-//! margin; the PoC's hint fast path was dropped, see above). The scoring function differs deliberately: the
+//! margin; the PoC's hint fast path was dropped, see above). The scoring
+//! function differs deliberately: the
 //! PoC used `difflib.SequenceMatcher.ratio()` (Ratcliff-Obershelp); this uses
 //! normalised Levenshtein per RFC-018, which is harsher on block moves. The
 //! two disagree near the 0.7 threshold, so a boundary BDD scenario guards the
@@ -35,6 +48,8 @@
 
 use crate::annotation::types::{MatchResult, TextMatch, TextQuoteSelector};
 use crate::article::Article;
+use crate::config::{MAX_FUZZY_QUOTE_CHARS, MAX_FUZZY_SCAN_CHARS, MAX_FUZZY_SCORED_WINDOWS};
+use std::collections::HashSet;
 
 /// Default minimum weighted score for a fuzzy match to count.
 pub const DEFAULT_FUZZY_THRESHOLD: f64 = 0.7;
@@ -46,6 +61,40 @@ const WINDOW_TOLERANCE: f64 = 0.3;
 /// Margin by which the best fuzzy match must beat the second-best to be
 /// treated as unambiguous.
 const TIEBREAK_MARGIN: f64 = 0.1;
+
+/// Work budget for one resolve call's fuzzy scanning.
+///
+/// The sliding-window scan is cubic in the quote length and runs
+/// synchronously on the browser main thread via WASM, so it needs a hard
+/// upper bound like every other scan in this engine. The limits live in
+/// [`crate::config`] next to the YAML/array/recursion budgets; the exact-match
+/// pass is linear and stays unbudgeted. Tests construct smaller budgets to
+/// exercise the truncation paths.
+#[derive(Debug, Clone, Copy)]
+struct FuzzyBudget {
+    /// Quote length (chars) above which fuzzy matching does not run at all.
+    max_quote_chars: usize,
+    /// Law text (chars) this resolve may still fuzzily scan.
+    scan_chars_left: usize,
+    /// Candidate windows this resolve may still score (three Levenshtein
+    /// computations each).
+    scored_windows_left: usize,
+    /// Set when any part of the search was skipped for budget reasons; turns
+    /// an empty outcome into [`MatchResult::skipped`] instead of orphaned, so
+    /// "not searched" stays distinguishable from "searched and absent".
+    truncated: bool,
+}
+
+impl Default for FuzzyBudget {
+    fn default() -> Self {
+        Self {
+            max_quote_chars: MAX_FUZZY_QUOTE_CHARS,
+            scan_chars_left: MAX_FUZZY_SCAN_CHARS,
+            scored_windows_left: MAX_FUZZY_SCORED_WINDOWS,
+            truncated: false,
+        }
+    }
+}
 
 /// Resolve `selector` against the articles of a law.
 ///
@@ -78,15 +127,16 @@ pub fn resolve_with_threshold(
         };
     }
 
-    // Fuzzy match across all articles.
+    // Fuzzy match across all articles, within one shared work budget.
+    let mut budget = FuzzyBudget::default();
     let mut fuzzy: Vec<TextMatch> = Vec::new();
     for article in articles {
-        for mut m in find_fuzzy_matches(&article.text, selector, threshold) {
+        for mut m in find_fuzzy_matches(&article.text, selector, threshold, &mut budget) {
             m.article_number = article.number.clone();
             fuzzy.push(m);
         }
     }
-    finalize_fuzzy(fuzzy)
+    finalize_fuzzy(fuzzy, budget.truncated)
 }
 
 /// Resolve a selector against a single raw text body (no article context).
@@ -99,17 +149,27 @@ pub fn resolve_in_text(selector: &TextQuoteSelector, text: &str, threshold: f64)
             MatchResult::ambiguous(exact)
         };
     }
-    finalize_fuzzy(find_fuzzy_matches(text, selector, threshold))
+    let mut budget = FuzzyBudget::default();
+    let fuzzy = find_fuzzy_matches(text, selector, threshold, &mut budget);
+    finalize_fuzzy(fuzzy, budget.truncated)
 }
 
 /// Collapse fuzzy candidates into a final [`MatchResult`].
 ///
 /// Overlapping spans are deduplicated keeping the highest confidence. A single
 /// surviving match, or a clear winner (more than [`TIEBREAK_MARGIN`] ahead of
-/// the runner-up), is `Found`; otherwise `Ambiguous`; empty is `Orphaned`.
-fn finalize_fuzzy(matches: Vec<TextMatch>) -> MatchResult {
+/// the runner-up), is `Found`; otherwise `Ambiguous`. Empty is `Orphaned` —
+/// unless the scan was `truncated`, because then "nothing found" was never
+/// established: the outcome is `Skipped`, so the caller can tell the user the
+/// text was not (fully) searched. Candidates found before truncation are
+/// genuine matches and are reported normally.
+fn finalize_fuzzy(matches: Vec<TextMatch>, truncated: bool) -> MatchResult {
     if matches.is_empty() {
-        return MatchResult::orphaned();
+        return if truncated {
+            MatchResult::skipped()
+        } else {
+            MatchResult::orphaned()
+        };
     }
     let deduped = deduplicate_overlapping(matches);
     match clear_winner(&deduped) {
@@ -186,36 +246,60 @@ fn find_exact_matches(text: &str, selector: &TextQuoteSelector) -> Vec<TextMatch
 
 /// Fuzzy candidates at or above `threshold`, sorted by confidence descending.
 ///
-/// Mirrors the Python proof-of-concept: collect exact occurrences plus
-/// sliding windows of `len(exact) ± 30%` that share a significant word with
-/// `exact`, then score each by weighted Levenshtein similarity.
-fn find_fuzzy_matches(text: &str, selector: &TextQuoteSelector, threshold: f64) -> Vec<TextMatch> {
+/// Mirrors the Python proof-of-concept: collect sliding windows of
+/// `len(exact) ± 30%` that share a significant word with `exact`, then score
+/// each by weighted Levenshtein similarity. The scan draws on `budget`: a
+/// quote over the length cap, an article that no longer fits the scan budget,
+/// or running out of scoring budget all mark the budget truncated (and the
+/// last one stops the scan), so the caller reports the search as skipped
+/// rather than silently incomplete.
+fn find_fuzzy_matches(
+    text: &str,
+    selector: &TextQuoteSelector,
+    threshold: f64,
+    budget: &mut FuzzyBudget,
+) -> Vec<TextMatch> {
     let chars: Vec<char> = text.chars().collect();
     let exact_len = selector.exact.chars().count();
     if exact_len == 0 || chars.is_empty() {
         return Vec::new();
     }
+    if exact_len > budget.max_quote_chars {
+        budget.truncated = true;
+        return Vec::new();
+    }
+    if chars.len() > budget.scan_chars_left {
+        budget.truncated = true;
+        return Vec::new();
+    }
+    budget.scan_chars_left -= chars.len();
 
     let tolerance = ((exact_len as f64) * WINDOW_TOLERANCE) as usize;
     let min_w = exact_len.saturating_sub(tolerance).max(1);
     let max_w = exact_len + tolerance;
 
     // Constant for the whole scan: compute once, not per window position.
-    let exact_words = significant_words(&selector.exact);
+    let index = WordIndex::new(&chars, &selector.exact);
     let prefix_len = selector.prefix.chars().count();
     let suffix_len = selector.suffix.chars().count();
 
     let mut matches: Vec<TextMatch> = Vec::new();
-    for window in min_w..=max_w {
+    'scan: for window in min_w..=max_w {
         if window > chars.len() {
             break;
         }
+        let mut cursor = index.cursor(window);
         for i in 0..=(chars.len() - window) {
-            let candidate: String = chars[i..i + window].iter().collect();
-            if !shares_significant_content(&exact_words, &candidate) {
+            if !cursor.shares_significant_content(i) {
                 continue;
             }
+            if budget.scored_windows_left == 0 {
+                budget.truncated = true;
+                break 'scan;
+            }
+            budget.scored_windows_left -= 1;
 
+            let candidate: String = chars[i..i + window].iter().collect();
             let p_start = i.saturating_sub(prefix_len);
             let actual_prefix: String = chars[p_start..i].iter().collect();
             let s_end = (i + window + suffix_len).min(chars.len());
@@ -269,26 +353,153 @@ fn similarity(a: &str, b: &str) -> f64 {
 ///
 /// Computed once for `exact` before the sliding-window scan; "significant"
 /// excludes short function words (articles, prepositions) so the pre-filter
-/// keys on content words.
-fn significant_words(s: &str) -> std::collections::HashSet<String> {
-    s.to_lowercase()
-        .split_whitespace()
+/// keys on content words. Words are kept as `Vec<char>` so the scan can look
+/// up text slices without allocating.
+fn significant_words(s: &str) -> HashSet<Vec<char>> {
+    s.split_whitespace()
         .filter(|w| w.chars().count() > 3)
-        .map(String::from)
+        .map(|w| w.chars().map(lower_char).collect())
         .collect()
 }
 
-/// Cheap pre-filter: does the candidate share a significant word with `exact`?
-/// Avoids scoring obviously unrelated windows. `exact_words` is precomputed by
-/// the caller so this allocates nothing per window.
-fn shares_significant_content(
-    exact_words: &std::collections::HashSet<String>,
-    candidate: &str,
-) -> bool {
-    candidate
-        .to_lowercase()
-        .split_whitespace()
-        .any(|w| w.chars().count() > 3 && exact_words.contains(w))
+/// Per-`char` lowercase (first scalar of the mapping), keeping offsets
+/// aligned with the original text. Differs from `str::to_lowercase` only for
+/// exotic expanding mappings (e.g. 'İ' → "i̇"), which do not occur in Dutch
+/// legal text and would merely make the pre-filter slightly stricter there.
+fn lower_char(c: char) -> char {
+    c.to_lowercase().next().unwrap_or(c)
+}
+
+/// Pre-computed word index over one article's text for the fuzzy pre-filter:
+/// does a window share a significant word with the quote?
+///
+/// Replaces a per-window `String` build plus `to_lowercase()`, whose
+/// allocation floor alone was seconds per article even with every window
+/// rejected. This lowercases the text once, records the non-whitespace runs
+/// (words) with a per-run flag "this whole word is a significant quote word",
+/// and then answers each window in O(1) amortised: interior words via prefix
+/// sums over that flag, plus at most two hash lookups for the words truncated
+/// at the window edges — the same tokens the old
+/// `candidate.split_whitespace()` produced, so the filter's semantics are
+/// unchanged.
+struct WordIndex {
+    /// The text, lowercased per char (offset-aligned with the original).
+    lower: Vec<char>,
+    /// Non-whitespace runs as `(start, end)`; sorted, non-overlapping.
+    runs: Vec<(usize, usize)>,
+    /// `match_prefix[k]` = number of runs in `runs[..k]` that are themselves
+    /// a significant quote word.
+    match_prefix: Vec<usize>,
+    /// Significant (>3 chars, lowercased) words of the quote.
+    exact_words: HashSet<Vec<char>>,
+}
+
+impl WordIndex {
+    fn new(chars: &[char], exact: &str) -> Self {
+        let lower: Vec<char> = chars.iter().map(|&c| lower_char(c)).collect();
+        let exact_words = significant_words(exact);
+
+        let mut runs: Vec<(usize, usize)> = Vec::new();
+        let mut start: Option<usize> = None;
+        for (i, &c) in chars.iter().enumerate() {
+            match (c.is_whitespace(), start) {
+                (false, None) => start = Some(i),
+                (true, Some(s)) => {
+                    runs.push((s, i));
+                    start = None;
+                }
+                _ => {}
+            }
+        }
+        if let Some(s) = start {
+            runs.push((s, chars.len()));
+        }
+
+        let mut match_prefix = Vec::with_capacity(runs.len() + 1);
+        let mut total = 0usize;
+        match_prefix.push(total);
+        for &(s, e) in &runs {
+            let hit = e - s > 3 && exact_words.contains(&lower[s..e]);
+            total += usize::from(hit);
+            match_prefix.push(total);
+        }
+
+        Self {
+            lower,
+            runs,
+            match_prefix,
+            exact_words,
+        }
+    }
+
+    /// A cursor for scanning windows of one fixed size at non-decreasing
+    /// positions (the shape of the sliding-window loop).
+    fn cursor(&self, window: usize) -> WindowCursor<'_> {
+        WindowCursor {
+            index: self,
+            window,
+            a: 0,
+            b: 0,
+        }
+    }
+
+    /// Does the (possibly truncated) word at `lower[ts..te]` count as shared
+    /// significant content? Same rule as the old per-window tokenisation: the
+    /// token must be longer than 3 chars and equal a significant quote word.
+    fn edge_token_matches(&self, ts: usize, te: usize) -> bool {
+        te - ts > 3 && self.exact_words.contains(&self.lower[ts..te])
+    }
+}
+
+/// Sliding-window view over a [`WordIndex`] for one window size.
+///
+/// `a` is the first run starting at or after the window start, `b` the first
+/// run ending past the window end; both only ever move forward, so a whole
+/// pass over the text costs O(text + runs), not O(text × words-per-window).
+struct WindowCursor<'a> {
+    index: &'a WordIndex,
+    window: usize,
+    a: usize,
+    b: usize,
+}
+
+impl WindowCursor<'_> {
+    /// Cheap pre-filter: does the window starting at `i` share a significant
+    /// word with the quote? Positions must be queried in non-decreasing
+    /// order. Allocates nothing.
+    fn shares_significant_content(&mut self, i: usize) -> bool {
+        let j = i + self.window;
+        let runs = &self.index.runs;
+        while self.a < runs.len() && runs[self.a].0 < i {
+            self.a += 1;
+        }
+        while self.b < runs.len() && runs[self.b].1 <= j {
+            self.b += 1;
+        }
+
+        // Words lying entirely inside the window: counted via prefix sums.
+        if self.b > self.a && self.index.match_prefix[self.b] > self.index.match_prefix[self.a] {
+            return true;
+        }
+
+        // Word truncated at the left window edge (the run containing `i`, if
+        // it starts before the window does).
+        if self.a > 0 {
+            let (s, e) = runs[self.a - 1];
+            if e > i && self.index.edge_token_matches(s.max(i), e.min(j)) {
+                return true;
+            }
+        }
+        // Word truncated at the right window edge. When one run spans the
+        // whole window it is the same run as above; don't test it twice.
+        if self.b < runs.len() && (self.a == 0 || self.b != self.a - 1) {
+            let (s, e) = runs[self.b];
+            if s < j && self.index.edge_token_matches(s.max(i), e.min(j)) {
+                return true;
+            }
+        }
+        false
+    }
 }
 
 /// Keep only the highest-confidence match for each overlapping region.
@@ -706,7 +917,12 @@ mod tests {
         // only invites the resolver to anchor on the wrong text.
         let sel = selector("zorgtoeslag", "", "");
         let text = "de zorgtoeslag wordt jaarlijks vastgesteld door de Belastingdienst";
-        let matches = find_fuzzy_matches(text, &sel, DEFAULT_FUZZY_THRESHOLD);
+        let matches = find_fuzzy_matches(
+            text,
+            &sel,
+            DEFAULT_FUZZY_THRESHOLD,
+            &mut FuzzyBudget::default(),
+        );
         assert!(!matches.is_empty());
         for m in &matches {
             let len = m.end - m.start;
@@ -757,6 +973,165 @@ mod tests {
         assert!(r.is_orphaned(), "got {:?} at {:?}", r.status, r.matches);
     }
 
+    // === Budgets: the scan has a ceiling, and hitting it is visible ===
+
+    /// An article of ~230 chars whose text a long quote can be sliced from.
+    fn long_sentence() -> &'static str {
+        "De verzekerde heeft tegenover de zorgverzekeraar aanspraak op vergoeding van de kosten \
+         van zorg zoals verzekerd krachtens de zorgverzekering, voor zover de verzekerde daarop \
+         naar inhoud en omvang redelijkerwijs is aangewezen."
+    }
+
+    #[test]
+    fn a_quote_over_the_length_cap_is_skipped_not_orphaned() {
+        let text = long_sentence();
+        let arts = vec![article("2", text)];
+        // The quote is the article with one word changed: fuzzy matching
+        // would find it, but only by scanning windows around a >120-char
+        // quote — exactly the cubic blow-up the cap exists for.
+        let quote = text.replace("aanspraak", "recht");
+        let sel = selector(&quote, "", "");
+
+        // Premises: the quote really is over the cap, has no exact
+        // occurrence, and would fuzzily match were the cap not there.
+        assert!(quote.chars().count() > MAX_FUZZY_QUOTE_CHARS);
+        assert!(!text.contains(&quote));
+        let mut roomy = FuzzyBudget {
+            max_quote_chars: usize::MAX,
+            ..FuzzyBudget::default()
+        };
+        assert!(
+            !find_fuzzy_matches(text, &sel, DEFAULT_FUZZY_THRESHOLD, &mut roomy).is_empty(),
+            "without the cap this quote fuzzily matches; otherwise this test proves nothing"
+        );
+
+        let r = resolve(&sel, &arts);
+        assert!(
+            r.is_skipped(),
+            "a quote too long to search must say so, not report 'not found': {:?}",
+            r.status
+        );
+        assert!(r.matches.is_empty());
+    }
+
+    #[test]
+    fn a_long_quote_that_still_occurs_verbatim_resolves_exactly() {
+        // The length cap bounds only the fuzzy scan; the linear exact match
+        // keeps resolving quotes of any length.
+        let text = long_sentence();
+        let quote: String = text.chars().skip(3).take(150).collect();
+        assert!(quote.chars().count() > MAX_FUZZY_QUOTE_CHARS);
+        let arts = vec![article("2", text)];
+        let r = resolve(&selector(&quote, "", ""), &arts);
+        assert!(r.is_found(), "got {:?}", r.status);
+        assert_eq!(r.single().unwrap().confidence, 1.0);
+    }
+
+    #[test]
+    fn a_hinted_long_quote_is_also_skipped() {
+        // A hint does not participate in resolution, so it must not become a
+        // side door around the quote-length cap either.
+        let text = long_sentence();
+        let quote = text.replace("aanspraak", "recht");
+        assert!(quote.chars().count() > MAX_FUZZY_QUOTE_CHARS);
+        let arts = vec![article("1", "Onbelangrijke tekst."), article("2", text)];
+        let sel = hinted(&quote, "", "", "2", None);
+        let r = resolve(&sel, &arts);
+        assert!(r.is_skipped(), "got {:?}", r.status);
+    }
+
+    #[test]
+    fn text_beyond_the_scan_budget_is_skipped_not_orphaned() {
+        // Two articles that together exceed the scan budget; the changed
+        // quote sits in the second one, past the cut-off. Reporting
+        // "orphaned" would claim the whole law was searched — it was not.
+        let filler = "vulwoord ".repeat(MAX_FUZZY_SCAN_CHARS / 9 / 2 + 100);
+        let target = format!("{filler}en voorts recht op een zorgtoeslag van rechtswege");
+        let sel = selector(
+            "aanspraak op een zorgtoeslag",
+            "en voorts ",
+            " van rechtswege",
+        );
+
+        // Premises: the two articles together bust the budget, and the
+        // second article on its own (which does fit) fuzzily matches.
+        let total = filler.chars().count() + target.chars().count();
+        assert!(total > MAX_FUZZY_SCAN_CHARS);
+        let alone = resolve(&sel, &[article("2", &target)]);
+        assert!(
+            alone.is_found(),
+            "the target must be fuzzily matchable on its own, got {:?}",
+            alone.status
+        );
+
+        let arts = vec![article("1", &filler), article("2", &target)];
+        let r = resolve(&sel, &arts);
+        assert!(r.is_skipped(), "got {:?}", r.status);
+    }
+
+    #[test]
+    fn exhausting_the_scoring_budget_is_skipped_not_orphaned() {
+        // Noise made of the quote's own key word: every window passes the
+        // pre-filter and gets scored (below threshold — the context words
+        // differ), draining the scoring budget before the real target at the
+        // end is ever reached.
+        // Enough noise positions that the budget runs dry within the first
+        // window size, long before any window reaches the target.
+        let noise = "zorgtoeslag ".repeat(MAX_FUZZY_SCORED_WINDOWS);
+        let target = "de verzekerde heeft recht op een aanvullende zorgtoeslag per jaar";
+        let text = format!("{noise}{target}");
+        let sel = selector(
+            "aanspraak op een aanvullende zorgtoeslag",
+            "verzekerde heeft ",
+            " per jaar",
+        );
+
+        // Premises: the target alone matches fuzzily, and the full text
+        // genuinely exhausts the scoring budget.
+        let alone = resolve(&sel, &[article("2", target)]);
+        assert!(alone.is_found(), "got {:?}", alone.status);
+        let mut budget = FuzzyBudget::default();
+        find_fuzzy_matches(&text, &sel, DEFAULT_FUZZY_THRESHOLD, &mut budget);
+        assert_eq!(
+            budget.scored_windows_left, 0,
+            "the noise must drain the scoring budget; otherwise this test proves nothing"
+        );
+
+        let r = resolve(&sel, &[article("2", &text)]);
+        assert!(r.is_skipped(), "got {:?}", r.status);
+    }
+
+    #[test]
+    fn truncation_only_turns_an_empty_result_into_skipped() {
+        assert!(finalize_fuzzy(Vec::new(), true).is_skipped());
+        assert!(finalize_fuzzy(Vec::new(), false).is_orphaned());
+        let r = finalize_fuzzy(vec![candidate("2", 0, 10, 0.9)], true);
+        assert!(
+            r.is_found(),
+            "a match found before the cut-off is still a match"
+        );
+    }
+
+    #[test]
+    fn the_scan_budget_is_spent_per_article_and_carries_across_articles() {
+        // First article fits and is scanned; the second no longer fits. The
+        // budget must be drawn down by the first scan — a per-article reset
+        // would defeat the bound.
+        let sel = selector("aanspraak op een zorgtoeslag", "", "");
+        let first = "tekst zonder relevante woorden hier";
+        let second = "en dan recht op een zorgtoeslag";
+        let mut budget = FuzzyBudget {
+            scan_chars_left: first.chars().count() + 1,
+            ..FuzzyBudget::default()
+        };
+        let m1 = find_fuzzy_matches(first, &sel, DEFAULT_FUZZY_THRESHOLD, &mut budget);
+        assert!(m1.is_empty());
+        assert!(!budget.truncated, "the first article fits the budget");
+        let m2 = find_fuzzy_matches(second, &sel, DEFAULT_FUZZY_THRESHOLD, &mut budget);
+        assert!(m2.is_empty(), "the second article no longer fits");
+        assert!(budget.truncated);
+    }
+
     // === Scoring and collapsing helpers ===
 
     #[test]
@@ -770,27 +1145,94 @@ mod tests {
         assert!(similarity("aanspraak", "aanzoek") > 0.0);
     }
 
+    /// Old-API shim: does the window `[i, i+window)` of `text` share a
+    /// significant word with `exact`? (One-off query through the cursor.)
+    fn window_shares(text: &str, exact: &str, i: usize, window: usize) -> bool {
+        let chars: Vec<char> = text.chars().collect();
+        let index = WordIndex::new(&chars, exact);
+        index.cursor(window).shares_significant_content(i)
+    }
+
     #[test]
     fn only_words_longer_than_three_characters_are_significant() {
         let words = significant_words("Recht op een zorgtoeslag van de wet");
-        assert!(words.contains("recht"), "lowercased: {words:?}");
-        assert!(words.contains("zorgtoeslag"));
+        let as_chars = |s: &str| s.chars().collect::<Vec<char>>();
+        assert!(words.contains(&as_chars("recht")), "lowercased: {words:?}");
+        assert!(words.contains(&as_chars("zorgtoeslag")));
         assert!(
-            !words.contains("wet"),
+            !words.contains(&as_chars("wet")),
             "three characters is too common to key on"
         );
-        assert!(!words.contains("op"));
+        assert!(!words.contains(&as_chars("op")));
     }
 
     #[test]
     fn the_prefilter_needs_a_word_shared_with_the_quote() {
-        let quote = significant_words("aanspraak op zorgtoeslag");
-        assert!(shares_significant_content(&quote, "recht op zorgtoeslag"));
+        let quote = "aanspraak op zorgtoeslag";
+        let shares = |text: &str| window_shares(text, quote, 0, text.chars().count());
+        assert!(shares("recht op zorgtoeslag"));
         assert!(
-            !shares_significant_content(&quote, "vastgesteld bij ministeriële regeling"),
+            !shares("vastgesteld bij ministeriële regeling"),
             "long words that the quote does not use are not shared content"
         );
-        assert!(!shares_significant_content(&quote, "op de wet"));
+        assert!(!shares("op de wet"));
+    }
+
+    #[test]
+    fn the_prefilter_matches_case_insensitively() {
+        assert!(window_shares(
+            "ZORGTOESLAG voor iedereen",
+            "de zorgtoeslag",
+            0,
+            11
+        ));
+    }
+
+    #[test]
+    fn the_prefilter_sees_a_word_truncated_at_a_window_edge() {
+        // The window cuts "zorgtoeslagen" down to "zorgtoeslag": the old
+        // per-window tokenisation counted that truncated token as shared
+        // content, and the indexed pre-filter must keep doing so.
+        let text = "de zorgtoeslagen";
+        assert!(window_shares(text, "zorgtoeslag", 0, 14));
+        // A cut that leaves only "zorg" (long enough, but not a quote word)
+        // or "zor" (too short to be significant) is not shared content.
+        assert!(!window_shares(text, "zorgtoeslag", 0, 7));
+        assert!(!window_shares(text, "zorgtoeslag", 0, 6));
+    }
+
+    #[test]
+    fn the_prefilter_sees_interior_and_left_truncated_words() {
+        let text = "aanspraak op een zorgtoeslag";
+        // Interior word: window over " op een zorgtoeslag" fully contains
+        // "zorgtoeslag".
+        assert!(window_shares(text, "de zorgtoeslag", 9, 19));
+        // Left-truncated: window starting inside "aanspraak" keeps "spraak",
+        // which is not a quote word.
+        assert!(!window_shares(text, "de aanspraak", 3, 10));
+        // But a left cut that still leaves a full quote word elsewhere is
+        // fine: "op een zorgtoeslag" contains "zorgtoeslag".
+        assert!(window_shares(text, "de zorgtoeslag", 3, 25));
+    }
+
+    #[test]
+    fn a_cursor_answers_the_same_as_a_fresh_query_at_every_position() {
+        // The cursor's two pointers only move forward; sliding it over the
+        // text must give the same answers as querying each window cold.
+        let text = "de verzekerde heeft aanspraak op een zorgtoeslag van de wet";
+        let quote = "aanspraak op zorgtoeslag";
+        let chars: Vec<char> = text.chars().collect();
+        let index = WordIndex::new(&chars, quote);
+        for window in [5, 11, 24] {
+            let mut cursor = index.cursor(window);
+            for i in 0..=(chars.len() - window) {
+                assert_eq!(
+                    cursor.shares_significant_content(i),
+                    window_shares(text, quote, i, window),
+                    "window {window} at {i}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/packages/engine/src/annotation/resolver.rs
+++ b/packages/engine/src/annotation/resolver.rs
@@ -444,10 +444,13 @@ impl WordIndex {
     }
 
     /// Does the (possibly truncated) word at `lower[ts..te]` count as shared
-    /// significant content? Same rule as the old per-window tokenisation: the
-    /// token must be longer than 3 chars and equal a significant quote word.
+    /// significant content? Same rule as the old per-window tokenisation.
+    /// The >3-chars significance threshold needs no separate check here:
+    /// `exact_words` only holds words longer than 3 chars, so a shorter
+    /// token can never be contained in it.
     fn edge_token_matches(&self, ts: usize, te: usize) -> bool {
-        te - ts > 3 && self.exact_words.contains(&self.lower[ts..te])
+        debug_assert!(te > ts, "callers only pass non-empty edge tokens");
+        self.exact_words.contains(&self.lower[ts..te])
     }
 }
 
@@ -477,16 +480,21 @@ impl WindowCursor<'_> {
             self.b += 1;
         }
 
-        // Words lying entirely inside the window: counted via prefix sums.
-        if self.b > self.a && self.index.match_prefix[self.b] > self.index.match_prefix[self.a] {
+        // Words lying entirely inside the window (`runs[a..b]`), counted via
+        // prefix sums. When one run spans the whole window `b` sits before
+        // `a`; the sums are monotone, so the comparison is false on its own
+        // and needs no separate `b > a` guard.
+        if self.index.match_prefix[self.b] > self.index.match_prefix[self.a] {
             return true;
         }
 
-        // Word truncated at the left window edge (the run containing `i`, if
-        // it starts before the window does).
+        // Word truncated at the left window edge: the run containing `i`. At
+        // most one run can contain `i`, and by the pointer invariant it is
+        // `runs[a-1]` (every run at or after `a` starts inside the window).
         if self.a > 0 {
             let (s, e) = runs[self.a - 1];
-            if e > i && self.index.edge_token_matches(s.max(i), e.min(j)) {
+            debug_assert!(s < i, "runs[a-1] starts before the window");
+            if e > i && self.index.edge_token_matches(i, e.min(j)) {
                 return true;
             }
         }
@@ -494,7 +502,8 @@ impl WindowCursor<'_> {
         // whole window it is the same run as above; don't test it twice.
         if self.b < runs.len() && (self.a == 0 || self.b != self.a - 1) {
             let (s, e) = runs[self.b];
-            if s < j && self.index.edge_token_matches(s.max(i), e.min(j)) {
+            debug_assert!(e > j, "runs[b] ends past the window");
+            if s < j && self.index.edge_token_matches(s.max(i), j) {
                 return true;
             }
         }
@@ -1287,6 +1296,40 @@ mod tests {
         // But a left cut that still leaves a full quote word elsewhere is
         // fine: "op een zorgtoeslag" contains "zorgtoeslag".
         assert!(window_shares(text, "de zorgtoeslag", 3, 25));
+    }
+
+    #[test]
+    fn a_word_truncated_only_at_the_left_edge_is_seen() {
+        // The window starts four chars into "zorgtoeslagen"; the remaining
+        // "toeslagen" is a quote word. Only the left-edge check can see this.
+        let text = "zorgtoeslagen x";
+        assert!(window_shares(text, "de toeslagen", 4, 9));
+        // Same left cut, but now the window also ends inside the run: the
+        // token is clipped on both sides to "toeslag".
+        assert!(window_shares(text, "de toeslag", 4, 7));
+        // A window ending exactly where a run ends, and one starting exactly
+        // where a run starts: adjacent runs are no edge tokens at all.
+        assert!(!window_shares("de zorgtoeslag", "de zorgtoeslag", 2, 11));
+        assert!(!window_shares("zorgtoeslag de", "zorgtoeslag x", 1, 11));
+    }
+
+    #[test]
+    fn a_right_truncated_word_is_seen_from_any_window_start() {
+        let text = "de zorgtoeslagen";
+        // Window starting exactly at the run start (the pointer boundary):
+        // token [3, 14) = "zorgtoeslag".
+        assert!(window_shares(text, "zorgtoeslag", 3, 11));
+        // Window starting inside the run: token [3, 10) = "zorgtoe".
+        assert!(window_shares("de zorgtoeslagen mooi", "de zorgtoe", 3, 7));
+        // A full run inside the window before the right-truncated word: the
+        // truncated "zorgtoeslag" must still be found past the non-matching
+        // "flop".
+        assert!(window_shares(
+            "de flop zorgtoeslagen",
+            "de zorgtoeslag",
+            3,
+            16
+        ));
     }
 
     #[test]

--- a/packages/engine/src/annotation/resolver.rs
+++ b/packages/engine/src/annotation/resolver.rs
@@ -1127,6 +1127,50 @@ mod tests {
     }
 
     #[test]
+    fn a_better_candidate_past_the_cut_off_is_not_lost_behind_a_found() {
+        // A weak-but-scoring candidate in the first article, then an article
+        // whose noise drains the scoring budget before the better candidate
+        // at its end is ever scored. Reporting the early candidate as `Found`
+        // would anchor the note on the worse place and hide that the search
+        // never got to the better one.
+        let sel = selector(
+            "aanspraak op een aanvullende zorgtoeslag",
+            "verzekerde heeft ",
+            " per jaar",
+        );
+        let weak = "de verzekerde heeft aanspraak op enige aanvullende toeslag per jaar";
+        let better = "de verzekerde heeft aanspraak op een aanvullende zorgtoeslaag per jaar";
+        let noise = "zorgtoeslag ".repeat(MAX_FUZZY_SCORED_WINDOWS);
+
+        // Premises: both articles match on their own, the second one better.
+        let weak_alone = resolve(&sel, &[article("1", weak)]);
+        let better_alone = resolve(&sel, &[article("2", better)]);
+        assert!(weak_alone.is_found(), "got {:?}", weak_alone.status);
+        assert!(better_alone.is_found(), "got {:?}", better_alone.status);
+        assert!(
+            better_alone.single().unwrap().confidence > weak_alone.single().unwrap().confidence,
+            "the second article must be the better candidate"
+        );
+
+        let arts = vec![
+            article("1", weak),
+            article("2", &format!("{noise}{better}")),
+        ];
+        let r = resolve(&sel, &arts);
+        assert!(r.is_skipped(), "got {:?}", r.status);
+        assert_eq!(r.skip_reason, Some(SkipReason::SearchBudget));
+        assert!(
+            r.single().is_none(),
+            "the early candidate must not pass as the unique match"
+        );
+        assert_eq!(
+            r.matches.first().map(|m| m.article_number.as_str()),
+            Some("1"),
+            "the candidate found before the cut-off stays visible"
+        );
+    }
+
+    #[test]
     fn a_cut_short_search_never_claims_a_definitive_outcome() {
         let cut = Some(SkipReason::SearchBudget);
         assert!(finalize_fuzzy(Vec::new(), cut).is_skipped());

--- a/packages/engine/src/annotation/resolver.rs
+++ b/packages/engine/src/annotation/resolver.rs
@@ -1132,6 +1132,80 @@ mod tests {
         assert!(budget.truncated);
     }
 
+    #[test]
+    fn an_article_that_exactly_fits_the_scan_budget_is_scanned() {
+        // The bound is "does not fit", strictly: an article of exactly the
+        // remaining budget is still scanned, and the scan spends the budget
+        // down to zero (not up, not divided — the budget is a countdown).
+        let sel = selector("aanspraak op een zorgtoeslag", "", "");
+        let text = "en dan recht op een zorgtoeslag";
+        let mut budget = FuzzyBudget {
+            scan_chars_left: text.chars().count(),
+            ..FuzzyBudget::default()
+        };
+        let matches = find_fuzzy_matches(text, &sel, DEFAULT_FUZZY_THRESHOLD, &mut budget);
+        assert!(!budget.truncated, "an exact fit is within the budget");
+        assert!(!matches.is_empty(), "the exact-fit article was scanned");
+        assert_eq!(budget.scan_chars_left, 0);
+    }
+
+    #[test]
+    fn a_quote_exactly_at_the_length_cap_is_still_searched() {
+        // The cap is "longer than", strictly: a quote of exactly the maximum
+        // length still gets the fuzzy scan; one char less of headroom skips.
+        let sel = selector("aanspraak op een zorgtoeslag", "", "");
+        let quote_len = sel.exact.chars().count();
+        let text = "en dan recht op een zorgtoeslag";
+
+        let mut at_cap = FuzzyBudget {
+            max_quote_chars: quote_len,
+            ..FuzzyBudget::default()
+        };
+        let matches = find_fuzzy_matches(text, &sel, DEFAULT_FUZZY_THRESHOLD, &mut at_cap);
+        assert!(!at_cap.truncated, "exactly at the cap is still searched");
+        assert!(!matches.is_empty());
+
+        let mut over_cap = FuzzyBudget {
+            max_quote_chars: quote_len - 1,
+            ..FuzzyBudget::default()
+        };
+        let m2 = find_fuzzy_matches(text, &sel, DEFAULT_FUZZY_THRESHOLD, &mut over_cap);
+        assert!(m2.is_empty(), "one char over the cap skips the scan");
+        assert!(over_cap.truncated);
+    }
+
+    #[test]
+    fn the_scoring_budget_counts_each_scored_window_exactly_once() {
+        // Measure how many windows this scan scores, then rerun with a
+        // budget of exactly that number: it must complete untruncated with
+        // the budget spent to zero. One less must truncate. This pins the
+        // countdown itself (a budget that counts up or divides never hits
+        // zero at the right moment).
+        let sel = selector("aanspraak op een zorgtoeslag", "", "");
+        let text = "en dan recht op een zorgtoeslag";
+        let mut probe = FuzzyBudget::default();
+        let matches = find_fuzzy_matches(text, &sel, DEFAULT_FUZZY_THRESHOLD, &mut probe);
+        assert!(!matches.is_empty());
+        let scored = MAX_FUZZY_SCORED_WINDOWS - probe.scored_windows_left;
+        assert!(scored >= 1, "at least the matching window was scored");
+
+        let mut exact_fit = FuzzyBudget {
+            scored_windows_left: scored,
+            ..FuzzyBudget::default()
+        };
+        let m2 = find_fuzzy_matches(text, &sel, DEFAULT_FUZZY_THRESHOLD, &mut exact_fit);
+        assert_eq!(m2.len(), matches.len());
+        assert!(!exact_fit.truncated, "exactly enough budget is enough");
+        assert_eq!(exact_fit.scored_windows_left, 0);
+
+        let mut one_short = FuzzyBudget {
+            scored_windows_left: scored - 1,
+            ..FuzzyBudget::default()
+        };
+        find_fuzzy_matches(text, &sel, DEFAULT_FUZZY_THRESHOLD, &mut one_short);
+        assert!(one_short.truncated, "one window short truncates the scan");
+    }
+
     // === Scoring and collapsing helpers ===
 
     #[test]

--- a/packages/engine/src/annotation/resolver.rs
+++ b/packages/engine/src/annotation/resolver.rs
@@ -46,7 +46,7 @@
 //! offsets. JS consumers indexing the law text must account for this; see the
 //! WASM binding docs.
 
-use crate::annotation::types::{MatchResult, TextMatch, TextQuoteSelector};
+use crate::annotation::types::{MatchResult, SkipReason, TextMatch, TextQuoteSelector};
 use crate::article::Article;
 use crate::config::{MAX_FUZZY_QUOTE_CHARS, MAX_FUZZY_SCAN_CHARS, MAX_FUZZY_SCORED_WINDOWS};
 use std::collections::HashSet;
@@ -79,10 +79,12 @@ struct FuzzyBudget {
     /// Candidate windows this resolve may still score (three Levenshtein
     /// computations each).
     scored_windows_left: usize,
-    /// Set when any part of the search was skipped for budget reasons; turns
-    /// an empty outcome into [`MatchResult::skipped`] instead of orphaned, so
-    /// "not searched" stays distinguishable from "searched and absent".
-    truncated: bool,
+    /// Set (with the bound that was hit) when any part of the search was
+    /// skipped; turns the outcome into [`MatchResult::skipped`] so "not
+    /// (fully) searched" stays distinguishable from "searched and absent".
+    /// The first cause wins: a later, different bound does not rewrite why
+    /// the search degraded.
+    skipped: Option<SkipReason>,
 }
 
 impl Default for FuzzyBudget {
@@ -91,8 +93,15 @@ impl Default for FuzzyBudget {
             max_quote_chars: MAX_FUZZY_QUOTE_CHARS,
             scan_chars_left: MAX_FUZZY_SCAN_CHARS,
             scored_windows_left: MAX_FUZZY_SCORED_WINDOWS,
-            truncated: false,
+            skipped: None,
         }
+    }
+}
+
+impl FuzzyBudget {
+    /// Record that a bound was hit, keeping the first cause.
+    fn mark_skipped(&mut self, reason: SkipReason) {
+        self.skipped.get_or_insert(reason);
     }
 }
 
@@ -136,7 +145,7 @@ pub fn resolve_with_threshold(
             fuzzy.push(m);
         }
     }
-    finalize_fuzzy(fuzzy, budget.truncated)
+    finalize_fuzzy(fuzzy, budget.skipped)
 }
 
 /// Resolve a selector against a single raw text body (no article context).
@@ -151,25 +160,25 @@ pub fn resolve_in_text(selector: &TextQuoteSelector, text: &str, threshold: f64)
     }
     let mut budget = FuzzyBudget::default();
     let fuzzy = find_fuzzy_matches(text, selector, threshold, &mut budget);
-    finalize_fuzzy(fuzzy, budget.truncated)
+    finalize_fuzzy(fuzzy, budget.skipped)
 }
 
 /// Collapse fuzzy candidates into a final [`MatchResult`].
 ///
-/// Overlapping spans are deduplicated keeping the highest confidence. A single
-/// surviving match, or a clear winner (more than [`TIEBREAK_MARGIN`] ahead of
-/// the runner-up), is `Found`; otherwise `Ambiguous`. Empty is `Orphaned` —
-/// unless the scan was `truncated`, because then "nothing found" was never
-/// established: the outcome is `Skipped`, so the caller can tell the user the
-/// text was not (fully) searched. Candidates found before truncation are
-/// genuine matches and are reported normally.
-fn finalize_fuzzy(matches: Vec<TextMatch>, truncated: bool) -> MatchResult {
+/// A cut-short search (`skipped` is set) is always `Skipped`, whatever was
+/// found by then: `Found` would claim uniqueness over text that was never
+/// searched, and an empty `Orphaned` would claim absence that was never
+/// established. Candidates found before the cut-off ride along in the
+/// result's `matches`. A complete search collapses as before: overlapping
+/// spans deduplicated keeping the highest confidence; a single survivor, or
+/// a clear winner (more than [`TIEBREAK_MARGIN`] ahead of the runner-up), is
+/// `Found`; several equally-good are `Ambiguous`; none is `Orphaned`.
+fn finalize_fuzzy(matches: Vec<TextMatch>, skipped: Option<SkipReason>) -> MatchResult {
+    if let Some(reason) = skipped {
+        return MatchResult::skipped(reason, deduplicate_overlapping(matches));
+    }
     if matches.is_empty() {
-        return if truncated {
-            MatchResult::skipped()
-        } else {
-            MatchResult::orphaned()
-        };
+        return MatchResult::orphaned();
     }
     let deduped = deduplicate_overlapping(matches);
     match clear_winner(&deduped) {
@@ -250,9 +259,9 @@ fn find_exact_matches(text: &str, selector: &TextQuoteSelector) -> Vec<TextMatch
 /// `len(exact) ± 30%` that share a significant word with `exact`, then score
 /// each by weighted Levenshtein similarity. The scan draws on `budget`: a
 /// quote over the length cap, an article that no longer fits the scan budget,
-/// or running out of scoring budget all mark the budget truncated (and the
-/// last one stops the scan), so the caller reports the search as skipped
-/// rather than silently incomplete.
+/// or running out of scoring budget all mark the budget skipped with the
+/// bound that was hit (and the last one stops the scan), so the caller
+/// reports the search as skipped rather than silently incomplete.
 fn find_fuzzy_matches(
     text: &str,
     selector: &TextQuoteSelector,
@@ -265,11 +274,11 @@ fn find_fuzzy_matches(
         return Vec::new();
     }
     if exact_len > budget.max_quote_chars {
-        budget.truncated = true;
+        budget.mark_skipped(SkipReason::QuoteTooLong);
         return Vec::new();
     }
     if chars.len() > budget.scan_chars_left {
-        budget.truncated = true;
+        budget.mark_skipped(SkipReason::SearchBudget);
         return Vec::new();
     }
     budget.scan_chars_left -= chars.len();
@@ -294,7 +303,7 @@ fn find_fuzzy_matches(
                 continue;
             }
             if budget.scored_windows_left == 0 {
-                budget.truncated = true;
+                budget.mark_skipped(SkipReason::SearchBudget);
                 break 'scan;
             }
             budget.scored_windows_left -= 1;
@@ -1020,6 +1029,7 @@ mod tests {
             "a quote too long to search must say so, not report 'not found': {:?}",
             r.status
         );
+        assert_eq!(r.skip_reason, Some(SkipReason::QuoteTooLong));
         assert!(r.matches.is_empty());
     }
 
@@ -1076,6 +1086,11 @@ mod tests {
         let arts = vec![article("1", &filler), article("2", &target)];
         let r = resolve(&sel, &arts);
         assert!(r.is_skipped(), "got {:?}", r.status);
+        assert_eq!(
+            r.skip_reason,
+            Some(SkipReason::SearchBudget),
+            "the quote is fine; the law was too large to finish searching"
+        );
     }
 
     #[test]
@@ -1108,17 +1123,22 @@ mod tests {
 
         let r = resolve(&sel, &[article("2", &text)]);
         assert!(r.is_skipped(), "got {:?}", r.status);
+        assert_eq!(r.skip_reason, Some(SkipReason::SearchBudget));
     }
 
     #[test]
-    fn truncation_only_turns_an_empty_result_into_skipped() {
-        assert!(finalize_fuzzy(Vec::new(), true).is_skipped());
-        assert!(finalize_fuzzy(Vec::new(), false).is_orphaned());
-        let r = finalize_fuzzy(vec![candidate("2", 0, 10, 0.9)], true);
-        assert!(
-            r.is_found(),
-            "a match found before the cut-off is still a match"
-        );
+    fn a_cut_short_search_never_claims_a_definitive_outcome() {
+        let cut = Some(SkipReason::SearchBudget);
+        assert!(finalize_fuzzy(Vec::new(), cut).is_skipped());
+        assert!(finalize_fuzzy(Vec::new(), None).is_orphaned());
+
+        // A candidate found before the cut-off must not become `Found`: that
+        // would claim uniqueness over text that was never searched. It rides
+        // along in the skipped result instead.
+        let r = finalize_fuzzy(vec![candidate("2", 0, 10, 0.9)], cut);
+        assert!(r.is_skipped(), "got {:?}", r.status);
+        assert_eq!(r.matches.len(), 1, "the candidate stays visible");
+        assert_eq!(r.skip_reason, Some(SkipReason::SearchBudget));
     }
 
     #[test]
@@ -1135,10 +1155,13 @@ mod tests {
         };
         let m1 = find_fuzzy_matches(first, &sel, DEFAULT_FUZZY_THRESHOLD, &mut budget);
         assert!(m1.is_empty());
-        assert!(!budget.truncated, "the first article fits the budget");
+        assert!(
+            budget.skipped.is_none(),
+            "the first article fits the budget"
+        );
         let m2 = find_fuzzy_matches(second, &sel, DEFAULT_FUZZY_THRESHOLD, &mut budget);
         assert!(m2.is_empty(), "the second article no longer fits");
-        assert!(budget.truncated);
+        assert_eq!(budget.skipped, Some(SkipReason::SearchBudget));
     }
 
     #[test]
@@ -1153,7 +1176,10 @@ mod tests {
             ..FuzzyBudget::default()
         };
         let matches = find_fuzzy_matches(text, &sel, DEFAULT_FUZZY_THRESHOLD, &mut budget);
-        assert!(!budget.truncated, "an exact fit is within the budget");
+        assert!(
+            budget.skipped.is_none(),
+            "an exact fit is within the budget"
+        );
         assert!(!matches.is_empty(), "the exact-fit article was scanned");
         assert_eq!(budget.scan_chars_left, 0);
     }
@@ -1171,7 +1197,10 @@ mod tests {
             ..FuzzyBudget::default()
         };
         let matches = find_fuzzy_matches(text, &sel, DEFAULT_FUZZY_THRESHOLD, &mut at_cap);
-        assert!(!at_cap.truncated, "exactly at the cap is still searched");
+        assert!(
+            at_cap.skipped.is_none(),
+            "exactly at the cap is still searched"
+        );
         assert!(!matches.is_empty());
 
         let mut over_cap = FuzzyBudget {
@@ -1180,7 +1209,7 @@ mod tests {
         };
         let m2 = find_fuzzy_matches(text, &sel, DEFAULT_FUZZY_THRESHOLD, &mut over_cap);
         assert!(m2.is_empty(), "one char over the cap skips the scan");
-        assert!(over_cap.truncated);
+        assert_eq!(over_cap.skipped, Some(SkipReason::QuoteTooLong));
     }
 
     #[test]
@@ -1204,7 +1233,10 @@ mod tests {
         };
         let m2 = find_fuzzy_matches(text, &sel, DEFAULT_FUZZY_THRESHOLD, &mut exact_fit);
         assert_eq!(m2.len(), matches.len());
-        assert!(!exact_fit.truncated, "exactly enough budget is enough");
+        assert!(
+            exact_fit.skipped.is_none(),
+            "exactly enough budget is enough"
+        );
         assert_eq!(exact_fit.scored_windows_left, 0);
 
         let mut one_short = FuzzyBudget {
@@ -1212,7 +1244,10 @@ mod tests {
             ..FuzzyBudget::default()
         };
         find_fuzzy_matches(text, &sel, DEFAULT_FUZZY_THRESHOLD, &mut one_short);
-        assert!(one_short.truncated, "one window short truncates the scan");
+        assert!(
+            one_short.skipped.is_some(),
+            "one window short truncates the scan"
+        );
     }
 
     // === Scoring and collapsing helpers ===

--- a/packages/engine/src/annotation/types.rs
+++ b/packages/engine/src/annotation/types.rs
@@ -95,10 +95,26 @@ pub enum MatchStatus {
     /// Multiple equally-good matches; the note is ambiguous.
     Ambiguous,
     /// The fuzzy search was skipped or cut short by a resource bound
-    /// (quote too long, or the scan/scoring budget ran out) before any match
-    /// was found. Unlike [`Orphaned`](Self::Orphaned) this does **not**
-    /// assert the text is absent — it says "this was not (fully) searched".
+    /// (see [`SkipReason`]). Unlike [`Orphaned`](Self::Orphaned) this does
+    /// **not** assert the text is absent, and unlike
+    /// [`Found`](Self::Found) it claims no uniqueness: any candidates found
+    /// before the cut-off ride along in `matches`, but text beyond the
+    /// cut-off was never searched.
     Skipped,
+}
+
+/// Why a fuzzy search was skipped or cut short (the bounds live in
+/// [`crate::config`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SkipReason {
+    /// The quote exceeds `MAX_FUZZY_QUOTE_CHARS`; the fuzzy scan never ran.
+    /// Shortening the quote is the fix.
+    QuoteTooLong,
+    /// The scan or scoring budget ran out partway through the law; the text
+    /// beyond the cut-off was not searched. The quote length is not the
+    /// cause, so "shorten the quote" would be misdirected advice here.
+    SearchBudget,
 }
 
 /// A single located span in the law text.
@@ -130,8 +146,13 @@ pub struct MatchResult {
     /// Overall resolution status.
     pub status: MatchStatus,
     /// Located spans. One element when `Found`, several when `Ambiguous`,
-    /// empty when `Orphaned`.
+    /// empty when `Orphaned`. When `Skipped`: any candidates found before
+    /// the search was cut short — never a claim of uniqueness.
     pub matches: Vec<TextMatch>,
+    /// Why the search was skipped; present exactly when `status` is
+    /// `Skipped`. On the wire: `"quote_too_long"` or `"search_budget"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skip_reason: Option<SkipReason>,
 }
 
 impl MatchResult {
@@ -139,6 +160,7 @@ impl MatchResult {
         Self {
             status: MatchStatus::Found,
             matches,
+            skip_reason: None,
         }
     }
 
@@ -146,6 +168,7 @@ impl MatchResult {
         Self {
             status: MatchStatus::Orphaned,
             matches: Vec::new(),
+            skip_reason: None,
         }
     }
 
@@ -153,13 +176,17 @@ impl MatchResult {
         Self {
             status: MatchStatus::Ambiguous,
             matches,
+            skip_reason: None,
         }
     }
 
-    pub(crate) fn skipped() -> Self {
+    /// A search cut short by `reason`; `matches` carries whatever candidates
+    /// were found before the cut-off (possibly none).
+    pub(crate) fn skipped(reason: SkipReason, matches: Vec<TextMatch>) -> Self {
         Self {
             status: MatchStatus::Skipped,
-            matches: Vec::new(),
+            matches,
+            skip_reason: Some(reason),
         }
     }
 
@@ -264,7 +291,7 @@ regelrecht:hint:
         assert!(!ambiguous.is_orphaned());
         assert!(!ambiguous.is_skipped());
 
-        let skipped = MatchResult::skipped();
+        let skipped = MatchResult::skipped(SkipReason::QuoteTooLong, Vec::new());
         assert!(skipped.is_skipped());
         assert!(!skipped.is_found());
         assert!(
@@ -272,14 +299,40 @@ regelrecht:hint:
             "a skipped search must not present itself as 'searched and absent'"
         );
         assert!(!skipped.is_ambiguous());
-        assert!(skipped.matches.is_empty());
     }
 
-    /// The wire value the frontend branches on: `status: 'skipped'`.
+    /// The wire values the frontend branches on: `status: 'skipped'` plus a
+    /// `skip_reason` naming the bound that was hit.
     #[test]
-    fn skipped_serialises_lowercase() {
-        let json = serde_json::to_string(&MatchStatus::Skipped).unwrap();
-        assert_eq!(json, "\"skipped\"");
+    fn skipped_serialises_status_and_reason() {
+        let json =
+            serde_json::to_string(&MatchResult::skipped(SkipReason::QuoteTooLong, Vec::new()))
+                .unwrap();
+        assert!(json.contains("\"status\":\"skipped\""), "{json}");
+        assert!(
+            json.contains("\"skip_reason\":\"quote_too_long\""),
+            "{json}"
+        );
+
+        let json =
+            serde_json::to_string(&MatchResult::skipped(SkipReason::SearchBudget, Vec::new()))
+                .unwrap();
+        assert!(json.contains("\"skip_reason\":\"search_budget\""), "{json}");
+
+        // Other statuses carry no reason field at all: absence must mean
+        // "was not skipped", not "reason unknown".
+        let json = serde_json::to_string(&MatchResult::orphaned()).unwrap();
+        assert!(!json.contains("skip_reason"), "{json}");
+    }
+
+    /// A skipped search may carry the candidates found before the cut-off,
+    /// but a consumer asking for "the single match" must not get one: a
+    /// candidate is not a claim of uniqueness over text never searched.
+    #[test]
+    fn a_skipped_result_hands_out_no_single_match() {
+        let skipped = MatchResult::skipped(SkipReason::SearchBudget, vec![a_match()]);
+        assert_eq!(skipped.matches.len(), 1);
+        assert!(skipped.single().is_none());
     }
 
     /// `single()` is only meaningful for a `Found` result; an ambiguous result

--- a/packages/engine/src/annotation/types.rs
+++ b/packages/engine/src/annotation/types.rs
@@ -94,6 +94,11 @@ pub enum MatchStatus {
     Orphaned,
     /// Multiple equally-good matches; the note is ambiguous.
     Ambiguous,
+    /// The fuzzy search was skipped or cut short by a resource bound
+    /// (quote too long, or the scan/scoring budget ran out) before any match
+    /// was found. Unlike [`Orphaned`](Self::Orphaned) this does **not**
+    /// assert the text is absent — it says "this was not (fully) searched".
+    Skipped,
 }
 
 /// A single located span in the law text.
@@ -151,6 +156,13 @@ impl MatchResult {
         }
     }
 
+    pub(crate) fn skipped() -> Self {
+        Self {
+            status: MatchStatus::Skipped,
+            matches: Vec::new(),
+        }
+    }
+
     /// True when exactly one location was found.
     pub fn is_found(&self) -> bool {
         self.status == MatchStatus::Found
@@ -164,6 +176,12 @@ impl MatchResult {
     /// True when multiple equally-good locations were found.
     pub fn is_ambiguous(&self) -> bool {
         self.status == MatchStatus::Ambiguous
+    }
+
+    /// True when the fuzzy search was skipped or truncated by a resource
+    /// bound before any match was found.
+    pub fn is_skipped(&self) -> bool {
+        self.status == MatchStatus::Skipped
     }
 
     /// The single match, when [`is_found`](Self::is_found).
@@ -244,6 +262,24 @@ regelrecht:hint:
         assert!(ambiguous.is_ambiguous());
         assert!(!ambiguous.is_found());
         assert!(!ambiguous.is_orphaned());
+        assert!(!ambiguous.is_skipped());
+
+        let skipped = MatchResult::skipped();
+        assert!(skipped.is_skipped());
+        assert!(!skipped.is_found());
+        assert!(
+            !skipped.is_orphaned(),
+            "a skipped search must not present itself as 'searched and absent'"
+        );
+        assert!(!skipped.is_ambiguous());
+        assert!(skipped.matches.is_empty());
+    }
+
+    /// The wire value the frontend branches on: `status: 'skipped'`.
+    #[test]
+    fn skipped_serialises_lowercase() {
+        let json = serde_json::to_string(&MatchStatus::Skipped).unwrap();
+        assert_eq!(json, "\"skipped\"");
     }
 
     /// `single()` is only meaningful for a `Found` result; an ambiguous result

--- a/packages/engine/src/bin/validate_annotations.rs
+++ b/packages/engine/src/bin/validate_annotations.rs
@@ -173,6 +173,16 @@ fn check_notes(
                         path.display()
                     );
                     warnings += 1;
+                } else if result.is_skipped() {
+                    // Not the same as orphaned: the resolver never (fully)
+                    // searched, so absence was not established.
+                    eprintln!(
+                        "  WARN: {} note[{i}]: not searched (quote of {} chars exceeds the \
+                         fuzzy scan budget; shorten the quote)",
+                        path.display(),
+                        selector.exact.chars().count()
+                    );
+                    warnings += 1;
                 }
             }
         }
@@ -492,6 +502,20 @@ mod tests {
         let doc = json!({"annotations": [zorgtoeslag_note("motorrijtuigenbelasting")]});
         assert_eq!(
             check_notes(Path::new("notes.yaml"), &doc, &vocabulary_of(&[]), &repo()),
+            1
+        );
+    }
+
+    /// A quote too long for the bounded fuzzy scan: the resolver reports the
+    /// search as skipped, and the validator must warn "not searched" rather
+    /// than stay silent (silence would read as "resolves fine").
+    #[test]
+    fn a_selector_too_long_to_search_warns_as_not_searched() {
+        let quote = "motorrijtuigenbelasting ".repeat(6);
+        assert!(quote.chars().count() > regelrecht_engine::config::MAX_FUZZY_QUOTE_CHARS);
+        let doc = json!({"annotations": [zorgtoeslag_note(&quote)]});
+        assert_eq!(
+            check_notes(Path::new("notes.yaml"), &doc, &vocabulary_of(&[])),
             1
         );
     }

--- a/packages/engine/src/bin/validate_annotations.rs
+++ b/packages/engine/src/bin/validate_annotations.rs
@@ -111,6 +111,22 @@ fn main() {
     }
 }
 
+/// Why a resolve was skipped, in the words the author needs.
+///
+/// Skipped is not the same as orphaned: the resolver never (fully) searched,
+/// so absence was not established. Only a quote-length skip is fixed by
+/// shortening the quote; a scan or scoring budget that ran out has nothing to
+/// do with this quote, and saying otherwise sends the author after a change
+/// that cannot help.
+fn skip_cause(reason: Option<SkipReason>, quote_chars: usize) -> String {
+    match reason {
+        Some(SkipReason::QuoteTooLong) => {
+            format!("quote of {quote_chars} chars exceeds the fuzzy quote cap; shorten the quote")
+        }
+        _ => "the law exceeds the fuzzy scan budget; the text was not fully searched".to_string(),
+    }
+}
+
 /// Resolve each note and check tag values; return the warning count.
 fn check_notes(
     path: &Path,
@@ -156,6 +172,14 @@ fn check_notes(
                                 selector.exact
                             );
                             warnings += 1;
+                        } else if result.is_skipped() {
+                            let cause =
+                                skip_cause(result.skip_reason, selector.exact.chars().count());
+                            eprintln!(
+                                "  WARN: {} note[{i}]: not searched ({cause})",
+                                path.display()
+                            );
+                            warnings += 1;
                         }
                     }
                 }
@@ -170,25 +194,6 @@ fn check_notes(
                     };
                     eprintln!(
                         "  WARN: {} note[{i}]: selector not checked ({detail})",
-                        path.display()
-                    );
-                    warnings += 1;
-                } else if result.is_skipped() {
-                    // Not the same as orphaned: the resolver never (fully)
-                    // searched, so absence was not established. Name the
-                    // bound that was hit — "shorten the quote" is only the
-                    // fix when the quote length was the cause.
-                    let cause = match result.skip_reason {
-                        Some(SkipReason::QuoteTooLong) => format!(
-                            "quote of {} chars exceeds the fuzzy quote cap; shorten the quote",
-                            selector.exact.chars().count()
-                        ),
-                        _ => "the law exceeds the fuzzy scan budget; \
-                              the text was not fully searched"
-                            .to_string(),
-                    };
-                    eprintln!(
-                        "  WARN: {} note[{i}]: not searched ({cause})",
                         path.display()
                     );
                     warnings += 1;
@@ -524,9 +529,24 @@ mod tests {
         assert!(quote.chars().count() > regelrecht_engine::config::MAX_FUZZY_QUOTE_CHARS);
         let doc = json!({"annotations": [zorgtoeslag_note(&quote)]});
         assert_eq!(
-            check_notes(Path::new("notes.yaml"), &doc, &vocabulary_of(&[])),
+            check_notes(Path::new("notes.yaml"), &doc, &vocabulary_of(&[]), &repo()),
             1
         );
+    }
+
+    /// The warning must name the bound that was actually hit. "Shorten the
+    /// quote" is advice for one of the three causes only; on the other two it
+    /// sends the author after a change that cannot help.
+    #[test]
+    fn the_skip_warning_only_blames_the_quote_when_the_quote_was_the_cause() {
+        let long = skip_cause(Some(SkipReason::QuoteTooLong), 240);
+        assert!(long.contains("240 chars"), "{long}");
+        assert!(long.contains("shorten the quote"), "{long}");
+
+        let budget = skip_cause(Some(SkipReason::SearchBudget), 40);
+        assert!(!budget.contains("shorten the quote"), "{budget}");
+        assert!(!budget.contains("40"), "{budget}");
+        assert!(budget.contains("not fully searched"), "{budget}");
     }
 
     #[test]

--- a/packages/engine/src/bin/validate_annotations.rs
+++ b/packages/engine/src/bin/validate_annotations.rs
@@ -19,7 +19,7 @@ use std::path::{Path, PathBuf};
 use std::process;
 
 use jsonschema::Validator;
-use regelrecht_engine::annotation::{law_id_from_source, resolve, TextQuoteSelector};
+use regelrecht_engine::annotation::{law_id_from_source, resolve, SkipReason, TextQuoteSelector};
 use regelrecht_engine::article::{ArticleBasedLaw, LawLoad};
 
 const ANNOTATION_SCHEMA: &str = include_str!("../../../../schema/v0.5.3/annotation-schema.json");
@@ -175,12 +175,21 @@ fn check_notes(
                     warnings += 1;
                 } else if result.is_skipped() {
                     // Not the same as orphaned: the resolver never (fully)
-                    // searched, so absence was not established.
+                    // searched, so absence was not established. Name the
+                    // bound that was hit — "shorten the quote" is only the
+                    // fix when the quote length was the cause.
+                    let cause = match result.skip_reason {
+                        Some(SkipReason::QuoteTooLong) => format!(
+                            "quote of {} chars exceeds the fuzzy quote cap; shorten the quote",
+                            selector.exact.chars().count()
+                        ),
+                        _ => "the law exceeds the fuzzy scan budget; \
+                              the text was not fully searched"
+                            .to_string(),
+                    };
                     eprintln!(
-                        "  WARN: {} note[{i}]: not searched (quote of {} chars exceeds the \
-                         fuzzy scan budget; shorten the quote)",
-                        path.display(),
-                        selector.exact.chars().count()
+                        "  WARN: {} note[{i}]: not searched ({cause})",
+                        path.display()
                     );
                     warnings += 1;
                 }

--- a/packages/engine/src/config.rs
+++ b/packages/engine/src/config.rs
@@ -65,6 +65,35 @@ pub const SUPPORTED_SCHEMAS: &[&str] = &[
     "v0.5.4", "v0.5.5", "v0.5.6",
 ];
 
+/// Maximum quote length (in `char`s) for the fuzzy annotation scan.
+///
+/// The sliding-window fuzzy match in `annotation::resolver` is cubic in the
+/// quote length; unbounded it freezes the browser main thread for minutes on
+/// a long quote (the resolver also runs synchronously via WASM). Above this
+/// length only the exact match runs and the result is reported as
+/// [`crate::annotation::MatchStatus::Skipped`], so a user can tell "not
+/// searched" apart from "not found". 120 chars is well past the RFC-018
+/// write-path context (40) and covers any quote a note reasonably anchors on.
+pub const MAX_FUZZY_QUOTE_CHARS: usize = 120;
+
+/// Maximum law text (in `char`s) one fuzzy resolve may scan.
+///
+/// Bounds the sliding-window scan across articles: articles that no longer
+/// fit in the budget are not fuzzily searched and the result reports
+/// `Skipped` instead of pretending the whole law was searched. 250k chars is
+/// roughly twice the Zorgverzekeringswet (~120k), so ordinary laws are fully
+/// scanned.
+pub const MAX_FUZZY_SCAN_CHARS: usize = 250_000;
+
+/// Maximum number of candidate windows one fuzzy resolve may score.
+///
+/// Scoring a window costs three Levenshtein computations (quadratic in the
+/// quote length). The pre-filter is cheap, but on a law that repeats the
+/// quote's words everywhere it passes almost every window; this cap bounds
+/// the total work regardless. Exceeding it truncates the scan and reports
+/// `Skipped` when nothing was found by then.
+pub const MAX_FUZZY_SCORED_WINDOWS: usize = 10_000;
+
 /// Maximum recursion depth for dot notation property access.
 ///
 /// Prevents stack overflow on malicious input like "a.a.a.a.a...".
@@ -95,5 +124,27 @@ mod tests {
 
         assert!(MAX_PROPERTY_DEPTH >= 10, "Should allow nested objects");
         assert!(MAX_PROPERTY_DEPTH <= 100, "Should limit extreme depth");
+
+        assert!(
+            MAX_FUZZY_QUOTE_CHARS >= 100,
+            "Should allow a sentence-length quote"
+        );
+        assert!(
+            MAX_FUZZY_QUOTE_CHARS <= 500,
+            "Should keep the cubic scan bounded"
+        );
+        assert!(
+            MAX_FUZZY_SCAN_CHARS >= 119_763,
+            "Should cover the Zorgverzekeringswet in one scan"
+        );
+        assert!(MAX_FUZZY_SCAN_CHARS <= 1_000_000, "Should bound the scan");
+        assert!(
+            MAX_FUZZY_SCORED_WINDOWS >= 1_000,
+            "Should score enough windows to find real fuzzy matches"
+        );
+        assert!(
+            MAX_FUZZY_SCORED_WINDOWS <= 100_000,
+            "Should bound the Levenshtein work"
+        );
     }
 }

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -57,8 +57,8 @@ pub mod telemetry;
 
 // Re-export commonly used items
 pub use annotation::{
-    law_id_from_source, resolve as resolve_note, MatchResult, MatchStatus, SelectorHint, TextMatch,
-    TextQuoteSelector,
+    law_id_from_source, resolve as resolve_note, MatchResult, MatchStatus, SelectorHint,
+    SkipReason, TextMatch, TextQuoteSelector,
 };
 pub use article::{
     Action, ActionOperation, ActionValue, Article, ArticleBasedLaw, Case, Execution,

--- a/packages/engine/src/wasm.rs
+++ b/packages/engine/src/wasm.rs
@@ -544,13 +544,16 @@ impl WasmEngine {
     ///
     /// # Returns
     /// * `Ok(JsValue)` - `MatchResult`: `{ status, matches: [{ article_number,
-    ///   start, end, confidence, matched_text }] }`. `status` is `"found"`,
-    ///   `"orphaned"`, `"ambiguous"`, or `"skipped"` — the last means the
-    ///   fuzzy scan hit a resource bound (quote too long, or the scan/scoring
-    ///   budget in `config.rs`) before finding anything, so "not searched" is
-    ///   distinguishable from "not found". `start`/`end` are **`char`
-    ///   offsets** (Unicode scalar values), not UTF-16 code units: JS code
-    ///   slicing the article text must convert accordingly.
+    ///   start, end, confidence, matched_text }], skip_reason? }`. `status`
+    ///   is `"found"`, `"orphaned"`, `"ambiguous"`, or `"skipped"` — the last
+    ///   means the fuzzy scan hit a resource bound (`config.rs`) and the law
+    ///   was not (fully) searched, so "not searched" is distinguishable from
+    ///   "not found"; `skip_reason` (`"quote_too_long"` or `"search_budget"`,
+    ///   present only then) names the bound, and `matches` carries any
+    ///   candidates found before the cut-off without a uniqueness claim.
+    ///   `start`/`end` are **`char` offsets** (Unicode scalar values), not
+    ///   UTF-16 code units: JS code slicing the article text must convert
+    ///   accordingly.
     /// * `Err(JsValue)` - Error if the law is not loaded, no version matches
     ///   `valid_from`, or the selector/date is invalid
     #[wasm_bindgen(js_name = resolveNote)]

--- a/packages/engine/src/wasm.rs
+++ b/packages/engine/src/wasm.rs
@@ -544,7 +544,11 @@ impl WasmEngine {
     ///
     /// # Returns
     /// * `Ok(JsValue)` - `MatchResult`: `{ status, matches: [{ article_number,
-    ///   start, end, confidence, matched_text }] }`. `start`/`end` are **`char`
+    ///   start, end, confidence, matched_text }] }`. `status` is `"found"`,
+    ///   `"orphaned"`, `"ambiguous"`, or `"skipped"` — the last means the
+    ///   fuzzy scan hit a resource bound (quote too long, or the scan/scoring
+    ///   budget in `config.rs`) before finding anything, so "not searched" is
+    ///   distinguishable from "not found". `start`/`end` are **`char`
     ///   offsets** (Unicode scalar values), not UTF-16 code units: JS code
     ///   slicing the article text must convert accordingly.
     /// * `Err(JsValue)` - Error if the law is not loaded, no version matches


### PR DESCRIPTION
`find_fuzzy_matches` in de annotatieresolver is kubisch in de citaatlengte en had geen enkele bovengrens, terwijl hij via WASM synchroon op de hoofddraad van de browser draait. Eén notitie met een citaat van anderhalve zin bevroor de editor daardoor een kwartier of langer, en Safari liep er twee keer volledig op vast. De scan krijgt nu drie grenzen in `config.rs`: 120 tekens citaat, 250k tekens afgezochte wettekst en 10k gescoorde vensters per resolve. Het voorfilter beantwoordt zijn vraag daarnaast via een woordindex met meelopende pointers, in plaats van per vensterpositie een `String` te bouwen.

Een grens raken is een zichtbare uitkomst. De status `skipped` betekent "hier is niet naar gezocht" en staat naast `orphaned`, en het resultaat draagt een `skip_reason`, zodat de melding de grens noemt die geraakt is in plaats van de auteur achter een inkorting aan te sturen die niets oplost. Een afgekapte zoekactie is altijd `skipped`, ook als er al een treffer lag: `Found` zou uniciteit claimen over tekst die nooit doorzocht is, en dan ankert de notitie op de zwakkere plek.

Buiten deze PR gelaten: de resolver naar een web worker, een conformance-stap voor `skipped` in de BDD-grammatica, en de statusopsomming in RFC-018.