### PR TITLE
test(engine): veertien gemeten soundness-gaps als KNOWN_GAPS met fixtures

### DIFF
--- a/packages/engine/tests/conformance.rs
+++ b/packages/engine/tests/conformance.rs
@@ -53,6 +53,36 @@ const KNOWN_GAPS: &[&str] = &[
     // than skipping it, so the leniency stops at the model boundary; see
     // `engine.rs`, `execute_actions_traced`.
     "action_without_output.yaml",
+    // Measured 2026-08-06, closing the undercount found in the schema↔model
+    // review: probing every schema constraint the fixtures did not touch found
+    // these fourteen additional shapes the model accepts. Grouped by family.
+    //
+    // -- Enums the model reads as a free string. The schema gate is the only
+    // validation; past it, the label reaches whatever consumer reads it, or
+    // no one. Two more enum gaps (`delegation_type`, `type_spec.unit`) are
+    // deliberately NOT listed here: behaviour hangs off those labels, so they
+    // should become model enums rather than documented leniency — tracked as a
+    // design decision, not as a gap to accept.
+    "open_term_type_array.yaml", // schema allows 5 open-term types; the model reads the full 7-wide ParameterType
+    "hook_without_legal_character.yaml", // schema requires + enums `applies_to.legal_character`; model has Option<String>
+    "produces_unknown_legal_character.yaml", // schema pins 5 legal characters; model reads any string
+    "produces_unknown_decision_type.yaml",   // schema pins 9 decision types; model reads any string
+    "temporal_unknown_type.yaml", // schema pins period|point_in_time; model reads any string
+    "start_of_week_unit.yaml", // schema pins START_OF `in` to year|month; model reads any string, engine errors at runtime (same family as date_part_plural_unit)
+    //
+    // -- Required fields the model does not enforce. Metadata-completeness
+    // errors the schema gate catches as long as the file passes CI; the model
+    // stays lenient because it must also read pre-v0.6.0 files.
+    "input_without_source.yaml", // schema requires `source` on inputs (`source: {}` = registry lookup, so absence is a real difference); model Option — the engine then computes with Null, which counts as zero/not-met
+    "wet_without_bwb_id.yaml", // schema's per-layer conditional requireds (WET→bwb_id etc.); model has all identifiers as Option
+    "document_without_articles.yaml", // schema requires `articles`; model defaults to an empty list
+    "article_without_url.yaml", // schema requires `url` per article; model Option (per-article twin of missing_required_url)
+    "operand_dollar_with_space.yaml", // schema forbids strings that start with `$` but are no valid variableReference; model reads any string
+    //
+    // -- Compat and migration leniency, deliberate on the model side.
+    "comparison_alias_not_equals.yaml", // NOT_EQUALS (with IS_NULL/NOT_NULL/NOT_IN/SWITCH) is a compat alias outside the schema enum; kept for pre-canonicalization files (`value.rs`, operation deserializer)
+    "inline_round_without_precision.yaml", // schema's allOf requires `precision` on inline ROUND/CEIL/FLOOR; model Option
+    "untranslatables_on_v0_6_0.yaml", // v0.6.0 dropped the old channel for `markings`; the model still parses it (it must read v0.5.x) and the engine honours the flag — flag-keeping, the safe side of wrong (see `Marking` rustdoc)
 ];
 
 /// Repo root, derived from this crate's manifest dir (`packages/engine`).

--- a/packages/engine/tests/conformance.rs
+++ b/packages/engine/tests/conformance.rs
@@ -64,7 +64,7 @@ const KNOWN_GAPS: &[&str] = &[
     // should become model enums rather than documented leniency — tracked as a
     // design decision, not as a gap to accept.
     "open_term_type_array.yaml", // schema allows 5 open-term types; the model reads the full 7-wide ParameterType
-    "hook_without_legal_character.yaml", // schema requires + enums `applies_to.legal_character`; model has Option<String>
+    "hook_without_legal_character.yaml", // schema requires + enums `applies_to.legal_character`; model has Option<String>, and the resolver then refuses the law at load (`check_hook_filters`) — leniency stops at the model boundary
     "produces_unknown_legal_character.yaml", // schema pins 5 legal characters; model reads any string
     "produces_unknown_decision_type.yaml",   // schema pins 9 decision types; model reads any string
     "temporal_unknown_type.yaml", // schema pins period|point_in_time; model reads any string
@@ -73,15 +73,15 @@ const KNOWN_GAPS: &[&str] = &[
     // -- Required fields the model does not enforce. Metadata-completeness
     // errors the schema gate catches as long as the file passes CI; the model
     // stays lenient because it must also read pre-v0.6.0 files.
-    "input_without_source.yaml", // schema requires `source` on inputs (`source: {}` = registry lookup, so absence is a real difference); model Option — the engine then computes with Null, which counts as zero/not-met
+    "input_without_source.yaml", // schema requires `source` on inputs (`source: {}` = registry lookup, so absence is a real difference); model Option — resolution skips the sourceless input (`resolve_inputs_with_service`) and evaluation fails hard with "Variable not found", which does not name the missing `source` as the cause
     "wet_without_bwb_id.yaml", // schema's per-layer conditional requireds (WET→bwb_id etc.); model has all identifiers as Option
     "document_without_articles.yaml", // schema requires `articles`; model defaults to an empty list
     "article_without_url.yaml", // schema requires `url` per article; model Option (per-article twin of missing_required_url)
-    "operand_dollar_with_space.yaml", // schema forbids strings that start with `$` but are no valid variableReference; model reads any string
+    "operand_dollar_with_space.yaml", // schema forbids strings that start with `$` but are no valid variableReference; model reads any string — the engine treats everything after `$` as a variable name and fails loudly at evaluation ("Variable not found")
     //
     // -- Compat and migration leniency, deliberate on the model side.
     "comparison_alias_not_equals.yaml", // NOT_EQUALS (with IS_NULL/NOT_NULL/NOT_IN/SWITCH) is a compat alias outside the schema enum; kept for pre-canonicalization files (`value.rs`, operation deserializer)
-    "inline_round_without_precision.yaml", // schema's allOf requires `precision` on inline ROUND/CEIL/FLOOR; model Option
+    "inline_round_without_precision.yaml", // schema's allOf requires `precision` on inline ROUND/CEIL/FLOOR; model Option — the engine refuses the action at execution ("ROUND requires 'precision' at action level"), so nothing is ever rounded at a guessed precision
     "untranslatables_on_v0_6_0.yaml", // v0.6.0 dropped the old channel for `markings`; the model still parses it (it must read v0.5.x) and the engine honours the flag — flag-keeping, the safe side of wrong (see `Marking` rustdoc)
 ];
 

--- a/packages/engine/tests/conformance/invalid/article_without_url.yaml
+++ b/packages/engine/tests/conformance/invalid/article_without_url.yaml
@@ -1,0 +1,15 @@
+---
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.6.0/schema/v0.6.0/schema.json
+$id: test_conformance_article_without_url
+regulatory_layer: WET
+bwb_id: BWBR9999904
+publication_date: '2025-01-01'
+valid_from: '2025-01-01'
+url: https://example.invalid/law
+articles:
+  - number: '1'
+    text: >-
+      Het artikel heeft geen `url` en is daarmee niet herleidbaar naar zijn
+      plaats in de gepubliceerde tekst. Het schema eist het veld per artikel,
+      net als op documentniveau; het model heeft het als `Option` — de
+      per-artikel-evenknie van het gedocumenteerde top-level-gat.

--- a/packages/engine/tests/conformance/invalid/comparison_alias_not_equals.yaml
+++ b/packages/engine/tests/conformance/invalid/comparison_alias_not_equals.yaml
@@ -1,0 +1,31 @@
+---
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.6.0/schema/v0.6.0/schema.json
+$id: test_conformance_comparison_alias_not_equals
+regulatory_layer: WET
+bwb_id: BWBR9999904
+publication_date: '2025-01-01'
+valid_from: '2025-01-01'
+url: https://example.invalid/law
+articles:
+  - number: '1'
+    text: >-
+      NOT_EQUALS staat niet in de operatie-enum van het schema; de canonieke
+      schrijfwijze is NOT om EQUALS. Het model kent NOT_EQUALS (en IS_NULL,
+      NOT_NULL, NOT_IN en de alias SWITCH) als compat-alias voor bestanden
+      van vóór de canonisatie, en accepteert dus een operatie die het
+      contract niet noemt.
+    url: https://example.invalid/law/artikel/1
+    machine_readable:
+      execution:
+        parameters:
+          - name: woonland
+            type: string
+        output:
+          - name: woont_buiten_nederland
+            type: boolean
+        actions:
+          - output: woont_buiten_nederland
+            value:
+              operation: NOT_EQUALS
+              subject: $woonland
+              value: NL

--- a/packages/engine/tests/conformance/invalid/document_without_articles.yaml
+++ b/packages/engine/tests/conformance/invalid/document_without_articles.yaml
@@ -1,0 +1,8 @@
+---
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.6.0/schema/v0.6.0/schema.json
+$id: test_conformance_document_without_articles
+regulatory_layer: WET
+bwb_id: BWBR9999904
+publication_date: '2025-01-01'
+valid_from: '2025-01-01'
+url: https://example.invalid/law

--- a/packages/engine/tests/conformance/invalid/hook_without_legal_character.yaml
+++ b/packages/engine/tests/conformance/invalid/hook_without_legal_character.yaml
@@ -1,0 +1,22 @@
+---
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.6.0/schema/v0.6.0/schema.json
+$id: test_conformance_hook_without_legal_character
+regulatory_layer: WET
+bwb_id: BWBR9999904
+publication_date: '2025-01-01'
+valid_from: '2025-01-01'
+url: https://example.invalid/law
+articles:
+  - number: '1'
+    text: >-
+      De hook zegt wanneer hij vuurt maar niet waarop hij aansluit: het schema
+      eist `legal_character` in `applies_to` (RFC-007), zodat een hook nooit
+      op alles tegelijk haakt. Het model heeft het veld als optionele string
+      en laadt deze hook zonder bezwaar; welke artikelen hij dan raakt bepaalt
+      pas de runtime.
+    url: https://example.invalid/law/artikel/1
+    machine_readable:
+      hooks:
+        - hook_point: post_actions
+          applies_to:
+            decision_type: TOEKENNING

--- a/packages/engine/tests/conformance/invalid/hook_without_legal_character.yaml
+++ b/packages/engine/tests/conformance/invalid/hook_without_legal_character.yaml
@@ -10,10 +10,13 @@ articles:
   - number: '1'
     text: >-
       De hook zegt wanneer hij vuurt maar niet waarop hij aansluit: het schema
-      eist `legal_character` in `applies_to` (RFC-007), zodat een hook nooit
-      op alles tegelijk haakt. Het model heeft het veld als optionele string
-      en laadt deze hook zonder bezwaar; welke artikelen hij dan raakt bepaalt
-      pas de runtime.
+      eist `legal_character` in `applies_to` (RFC-007), omdat de hook-index op
+      dat veld sleutelt. Het model heeft het veld als optionele string en
+      parseert deze hook zonder bezwaar; de resolver weigert de wet
+      vervolgens al bij het laden (`check_hook_filters` in `resolver.rs`,
+      "hook declares no applies_to.legal_character, so it can never fire").
+      De leniency stopt dus bij de modelgrens, zoals bij een actie zonder
+      `output`.
     url: https://example.invalid/law/artikel/1
     machine_readable:
       hooks:

--- a/packages/engine/tests/conformance/invalid/inline_round_without_precision.yaml
+++ b/packages/engine/tests/conformance/invalid/inline_round_without_precision.yaml
@@ -12,8 +12,10 @@ articles:
       Afronden is nooit impliciet (RFC-024): een inline ROUND op een actie
       moet zeggen op hoeveel decimalen. Het schema eist `precision` zodra de
       operatie ROUND, CEIL of FLOOR is; het model heeft het veld als
-      `Option`, en welke precisie er dan geldt beslist de engine in plaats
-      van de wettekst.
+      `Option`, en de engine weigert de actie bij uitvoering ("ROUND requires
+      'precision' at action level", `engine.rs`). Er wordt dus nooit op een
+      gegokte precisie afgerond; de fout valt alleen pas bij evaluatie in
+      plaats van aan de poort.
     url: https://example.invalid/law/artikel/1
     machine_readable:
       execution:
@@ -26,5 +28,4 @@ articles:
         actions:
           - output: bedrag
             operation: ROUND
-            values:
-              - $grondslag
+            value: $grondslag

--- a/packages/engine/tests/conformance/invalid/inline_round_without_precision.yaml
+++ b/packages/engine/tests/conformance/invalid/inline_round_without_precision.yaml
@@ -1,0 +1,30 @@
+---
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.6.0/schema/v0.6.0/schema.json
+$id: test_conformance_inline_round_without_precision
+regulatory_layer: WET
+bwb_id: BWBR9999904
+publication_date: '2025-01-01'
+valid_from: '2025-01-01'
+url: https://example.invalid/law
+articles:
+  - number: '1'
+    text: >-
+      Afronden is nooit impliciet (RFC-024): een inline ROUND op een actie
+      moet zeggen op hoeveel decimalen. Het schema eist `precision` zodra de
+      operatie ROUND, CEIL of FLOOR is; het model heeft het veld als
+      `Option`, en welke precisie er dan geldt beslist de engine in plaats
+      van de wettekst.
+    url: https://example.invalid/law/artikel/1
+    machine_readable:
+      execution:
+        parameters:
+          - name: grondslag
+            type: amount
+        output:
+          - name: bedrag
+            type: amount
+        actions:
+          - output: bedrag
+            operation: ROUND
+            values:
+              - $grondslag

--- a/packages/engine/tests/conformance/invalid/input_without_source.yaml
+++ b/packages/engine/tests/conformance/invalid/input_without_source.yaml
@@ -1,0 +1,33 @@
+---
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.6.0/schema/v0.6.0/schema.json
+$id: test_conformance_input_without_source
+regulatory_layer: WET
+bwb_id: BWBR9999904
+publication_date: '2025-01-01'
+valid_from: '2025-01-01'
+url: https://example.invalid/law
+articles:
+  - number: '1'
+    text: >-
+      Een input zonder `source` zegt dat een waarde ergens vandaan komt en
+      zwijgt over waar. Het schema eist `source` op elke input; een lege
+      `source: {}` betekent registry-lookup, dus het weglaten is geen
+      verkorte schrijfwijze van hetzelfde. Het model heeft het veld als
+      `Option` en laadt het bestand; de engine kan de waarde nergens vandaan
+      halen en rekent verder met `Null`, dat in een berekening als nul of als
+      niet-voldaan telt.
+    url: https://example.invalid/law/artikel/1
+    machine_readable:
+      execution:
+        input:
+          - name: toetsingsinkomen
+            type: amount
+        output:
+          - name: komt_in_aanmerking
+            type: boolean
+        actions:
+          - output: komt_in_aanmerking
+            value:
+              operation: LESS_THAN
+              subject: $toetsingsinkomen
+              value: 30000

--- a/packages/engine/tests/conformance/invalid/input_without_source.yaml
+++ b/packages/engine/tests/conformance/invalid/input_without_source.yaml
@@ -13,9 +13,12 @@ articles:
       zwijgt over waar. Het schema eist `source` op elke input; een lege
       `source: {}` betekent registry-lookup, dus het weglaten is geen
       verkorte schrijfwijze van hetzelfde. Het model heeft het veld als
-      `Option` en laadt het bestand; de engine kan de waarde nergens vandaan
-      halen en rekent verder met `Null`, dat in een berekening als nul of als
-      niet-voldaan telt.
+      `Option` en laadt het bestand; bij resolutie wordt de bronloze input
+      overgeslagen (`resolve_inputs_with_service` in `service.rs`) en de
+      uitvoering strandt hard op "Variable not found: toetsingsinkomen". Er
+      wordt niets stil verkeerd berekend; de fout valt alleen pas bij
+      evaluatie, en de melding noemt de ontbrekende `source` niet als
+      oorzaak.
     url: https://example.invalid/law/artikel/1
     machine_readable:
       execution:

--- a/packages/engine/tests/conformance/invalid/open_term_type_array.yaml
+++ b/packages/engine/tests/conformance/invalid/open_term_type_array.yaml
@@ -1,0 +1,23 @@
+---
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.6.0/schema/v0.6.0/schema.json
+$id: test_conformance_open_term_type_array
+regulatory_layer: WET
+bwb_id: BWBR9999904
+publication_date: '2025-01-01'
+valid_from: '2025-01-01'
+url: https://example.invalid/law
+articles:
+  - number: '1'
+    text: >-
+      De open term belooft een waarde van het type `array`. Het schema staat
+      voor open terms vijf typen toe (string, number, boolean, amount, date);
+      het model leest hier de volledige `ParameterType`-enum van zeven en
+      accepteert dus meer dan het contract. Een implementerende regeling die
+      op deze belofte levert, schrijft iets dat het schema nooit had mogen
+      binnenlaten.
+    url: https://example.invalid/law/artikel/1
+    machine_readable:
+      open_terms:
+        - id: toegestane_categorieen
+          type: array
+          description: Lijst van categorieën die de minister aanwijst.

--- a/packages/engine/tests/conformance/invalid/operand_dollar_with_space.yaml
+++ b/packages/engine/tests/conformance/invalid/operand_dollar_with_space.yaml
@@ -11,9 +11,12 @@ articles:
     text: >-
       De operand begint met een dollarteken maar voldoet niet aan het
       variabelenpatroon. Het schema laat een string alleen toe als geldige
-      variabeleverwijzing of als literal die niet met een dollar begint,
-      zodat een verschreven verwijzing nooit stilzwijgend een letterlijke
-      tekst wordt; het model leest elke string.
+      variabeleverwijzing of als literal die niet met een dollar begint. Het
+      model leest elke string; de engine behandelt alles achter het
+      dollarteken als variabelenaam en strandt bij evaluatie op "Variable
+      not found: leeftijd oud". De verschrijving wordt dus geen stille
+      literal, maar de fout valt pas bij uitvoering in plaats van aan de
+      poort.
     url: https://example.invalid/law/artikel/1
     machine_readable:
       execution:

--- a/packages/engine/tests/conformance/invalid/operand_dollar_with_space.yaml
+++ b/packages/engine/tests/conformance/invalid/operand_dollar_with_space.yaml
@@ -1,0 +1,31 @@
+---
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.6.0/schema/v0.6.0/schema.json
+$id: test_conformance_operand_dollar_with_space
+regulatory_layer: WET
+bwb_id: BWBR9999904
+publication_date: '2025-01-01'
+valid_from: '2025-01-01'
+url: https://example.invalid/law
+articles:
+  - number: '1'
+    text: >-
+      De operand begint met een dollarteken maar voldoet niet aan het
+      variabelenpatroon. Het schema laat een string alleen toe als geldige
+      variabeleverwijzing of als literal die niet met een dollar begint,
+      zodat een verschreven verwijzing nooit stilzwijgend een letterlijke
+      tekst wordt; het model leest elke string.
+    url: https://example.invalid/law/artikel/1
+    machine_readable:
+      execution:
+        parameters:
+          - name: leeftijd
+            type: number
+        output:
+          - name: uitkomst
+            type: boolean
+        actions:
+          - output: uitkomst
+            value:
+              operation: EQUALS
+              subject: $leeftijd oud
+              value: 18

--- a/packages/engine/tests/conformance/invalid/produces_unknown_decision_type.yaml
+++ b/packages/engine/tests/conformance/invalid/produces_unknown_decision_type.yaml
@@ -1,0 +1,27 @@
+---
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.6.0/schema/v0.6.0/schema.json
+$id: test_conformance_produces_unknown_decision_type
+regulatory_layer: WET
+bwb_id: BWBR9999904
+publication_date: '2025-01-01'
+valid_from: '2025-01-01'
+url: https://example.invalid/law
+articles:
+  - number: '1'
+    text: >-
+      Het besluittype staat niet in de enum van negen die het schema voor
+      `produces.decision_type` vastlegt. Het model leest een vrije string; de
+      verschrijving valt pas op waar een consument het label leest, of
+      helemaal nooit.
+    url: https://example.invalid/law/artikel/1
+    machine_readable:
+      execution:
+        produces:
+          legal_character: BESCHIKKING
+          decision_type: TOEZEGGING
+        output:
+          - name: uitkomst
+            type: boolean
+        actions:
+          - output: uitkomst
+            value: true

--- a/packages/engine/tests/conformance/invalid/produces_unknown_legal_character.yaml
+++ b/packages/engine/tests/conformance/invalid/produces_unknown_legal_character.yaml
@@ -1,0 +1,26 @@
+---
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.6.0/schema/v0.6.0/schema.json
+$id: test_conformance_produces_unknown_legal_character
+regulatory_layer: WET
+bwb_id: BWBR9999904
+publication_date: '2025-01-01'
+valid_from: '2025-01-01'
+url: https://example.invalid/law
+articles:
+  - number: '1'
+    text: >-
+      Het artikel claimt een rechtskarakter dat de Awb-indeling niet kent.
+      Het schema pint `produces.legal_character` op vijf waarden; het model
+      leest een vrije string en geeft het etiket ongecontroleerd door aan
+      alles wat erop selecteert, van hooks tot procedurekeuze.
+    url: https://example.invalid/law/artikel/1
+    machine_readable:
+      execution:
+        produces:
+          legal_character: ADVIES
+        output:
+          - name: uitkomst
+            type: boolean
+        actions:
+          - output: uitkomst
+            value: true

--- a/packages/engine/tests/conformance/invalid/start_of_week_unit.yaml
+++ b/packages/engine/tests/conformance/invalid/start_of_week_unit.yaml
@@ -1,0 +1,31 @@
+---
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.6.0/schema/v0.6.0/schema.json
+$id: test_conformance_start_of_week_unit
+regulatory_layer: WET
+bwb_id: BWBR9999904
+publication_date: '2025-01-01'
+valid_from: '2025-01-01'
+url: https://example.invalid/law
+articles:
+  - number: '1'
+    text: >-
+      START_OF kapt een datum af op het begin van een kalendereenheid, en het
+      schema staat daarvoor alleen `year` en `month` toe: een weekbegin zou
+      een conventie vergen die geen wettekst oplegt. Het model leest de
+      eenheid als vrije string; de engine benoemt de fout pas op runtime,
+      zoals bij DATE_PART.
+    url: https://example.invalid/law/artikel/1
+    machine_readable:
+      execution:
+        parameters:
+          - name: peildatum
+            type: date
+        output:
+          - name: begin_van_de_week
+            type: date
+        actions:
+          - output: begin_van_de_week
+            value:
+              operation: START_OF
+              date: $peildatum
+              in: week

--- a/packages/engine/tests/conformance/invalid/temporal_unknown_type.yaml
+++ b/packages/engine/tests/conformance/invalid/temporal_unknown_type.yaml
@@ -1,0 +1,29 @@
+---
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.6.0/schema/v0.6.0/schema.json
+$id: test_conformance_temporal_unknown_type
+regulatory_layer: WET
+bwb_id: BWBR9999904
+publication_date: '2025-01-01'
+valid_from: '2025-01-01'
+url: https://example.invalid/law
+articles:
+  - number: '1'
+    text: >-
+      Temporele metadata kent twee soorten: een periode of een peilmoment.
+      Het schema pint `temporal.type` op die twee; het model leest een vrije
+      string, en wat een `interval` betekent beslist dan de eerste code die
+      het veld leest.
+    url: https://example.invalid/law/artikel/1
+    machine_readable:
+      execution:
+        parameters:
+          - name: inkomen
+            type: amount
+            temporal:
+              type: interval
+        output:
+          - name: uitkomst
+            type: boolean
+        actions:
+          - output: uitkomst
+            value: true

--- a/packages/engine/tests/conformance/invalid/untranslatables_on_v0_6_0.yaml
+++ b/packages/engine/tests/conformance/invalid/untranslatables_on_v0_6_0.yaml
@@ -1,0 +1,22 @@
+---
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.6.0/schema/v0.6.0/schema.json
+$id: test_conformance_untranslatables_on_v0_6_0
+regulatory_layer: WET
+bwb_id: BWBR9999904
+publication_date: '2025-01-01'
+valid_from: '2025-01-01'
+url: https://example.invalid/law
+articles:
+  - number: '1'
+    text: >-
+      Het document declareert v0.6.0 en draagt nog het oude
+      `untranslatables`-kanaal, dat in die versie is opgevolgd door
+      `markings`. Het schema weigert het veld; het model parseert het bewust
+      nog (het moet ook v0.5.x-bestanden lezen) en de engine honoreert de
+      vlag naast het nieuwe kanaal. Dat is de veilige kant van fout:
+      vlagbehoud in plaats van vlagverlies.
+    url: https://example.invalid/law/artikel/1
+    machine_readable:
+      untranslatables:
+        - construct: redelijkerwijs
+          reason: Open norm die menselijke weging vergt.

--- a/packages/engine/tests/conformance/invalid/wet_without_bwb_id.yaml
+++ b/packages/engine/tests/conformance/invalid/wet_without_bwb_id.yaml
@@ -1,0 +1,16 @@
+---
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.6.0/schema/v0.6.0/schema.json
+$id: test_conformance_wet_without_bwb_id
+regulatory_layer: WET
+publication_date: '2025-01-01'
+valid_from: '2025-01-01'
+url: https://example.invalid/law
+articles:
+  - number: '1'
+    text: >-
+      Een WET zonder `bwb_id` is niet terug te vinden in het Basiswettenbestand.
+      Het schema koppelt per laag de verplichte identificatie (WET vereist
+      `bwb_id`, EU-recht `celex_nummer`, enzovoort); het model kent die
+      conditionele eisen niet en laadt het document met alle identificaties
+      als `Option`.
+    url: https://example.invalid/law/artikel/1


### PR DESCRIPTION
De review van schema v0.6.0 tegen het law-model (#1126) vond 22 verschillen waar het model accepteert wat het schema weigert, tegenover zes gedocumenteerde. Dit is het mechanische deel: de veertien die bewust of onschadelijk lenient zijn krijgen elk een invalid-fixture en een gemotiveerde `KNOWN_GAPS`-entry, zodat de suite ze meet in plaats van mist. De twee reparaties en de twee model-enums blijven buiten deze lijst; die lopen via #1126 en #1127.
