### PR TITLE
fix(editor): deeplinks geven 200 in plaats van 404

### DIFF
--- a/packages/editor-api/Cargo.toml
+++ b/packages/editor-api/Cargo.toml
@@ -48,7 +48,6 @@ regelrecht-pipeline = { path = "../pipeline", features = ["test-utils"] }
 async-trait.workspace = true
 http-body-util.workspace = true
 pretty_assertions.workspace = true
-tower = { workspace = true, features = ["util"] }
 tempfile.workspace = true
 wiremock.workspace = true
 

--- a/packages/editor-api/src/lib.rs
+++ b/packages/editor-api/src/lib.rs
@@ -13,6 +13,8 @@ pub mod crypto;
 pub mod feature_flags;
 pub mod github_oauth;
 pub mod state;
+pub mod static_cache;
+pub mod static_spa;
 pub mod task_requests;
 pub mod traject_corpus;
 pub mod traject_index_diagnosis;

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -5,11 +5,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use axum::middleware as axum_middleware;
-use axum::routing::{get, MethodRouter};
+use axum::routing::get;
 use axum::Router;
 use tokio::sync::{Mutex, RwLock};
-use tower::ServiceExt;
-use tower_http::services::{ServeDir, ServeFile};
 use tower_http::trace::TraceLayer;
 use tower_sessions::ExpiredDeletion;
 use tower_sessions::Expiry;
@@ -29,6 +27,7 @@ mod harvest_proxy;
 mod middleware;
 mod state;
 mod static_cache;
+mod static_spa;
 mod task_requests;
 mod tasks_api;
 mod traject_corpus;
@@ -641,7 +640,7 @@ async fn main() {
             .layer(session_layer)
             .layer(axum_middleware::from_fn(middleware::security_headers))
             .layer(TraceLayer::new_for_http())
-            .fallback_service(static_service(&static_dir, &index_file));
+            .fallback_service(static_spa::static_service(&static_dir, &index_file));
 
         serve(app, Some(deletion_handle)).await;
     } else {
@@ -673,7 +672,7 @@ async fn main() {
             .layer(session_layer)
             .layer(axum_middleware::from_fn(middleware::security_headers))
             .layer(TraceLayer::new_for_http())
-            .fallback_service(static_service(&static_dir, index_file));
+            .fallback_service(static_spa::static_service(&static_dir, &index_file));
 
         serve(app, None).await;
     }
@@ -854,66 +853,6 @@ async fn init_backends(
     }
 
     backends
-}
-
-/// Static-file service for the built editor frontend.
-///
-/// The editor image has no nginx in front of it — this binary is the web
-/// server for `frontend/dist` as well as the API — so compression has to
-/// happen here or not at all.
-///
-/// `precompressed_br` / `precompressed_gzip` make `ServeDir` look for
-/// `foo.js.br` and `foo.js.gz` beside `foo.js` and serve one of those when
-/// the client's `Accept-Encoding` allows it. The variants are written at
-/// build time by `frontend/scripts/precompress.mjs`, so the container spends
-/// no CPU compressing per request, and a client that accepts neither still
-/// gets the plain file. `ServeDir` sets `Vary: accept-encoding` itself once a
-/// precompressed variant is configured, so shared caches stay correct.
-///
-/// Which encoding wins is the client's call, not ours: `ServeDir` picks the
-/// highest q-value from `Accept-Encoding` and breaks ties in favour of
-/// brotli. Builder order here is cosmetic. Note that a future
-/// `precompressed_zstd()` would outrank brotli in that tie-break — worth
-/// knowing before adding one.
-///
-/// Compression stops at the static files on purpose: the JSON API keeps
-/// serving uncompressed bodies. See the SPA fallback below for why the
-/// index gets the same treatment.
-///
-/// Compression makes the bytes smaller; the `Cache-Control` added on the
-/// way out ([`static_cache`]) stops most of them being sent a second time
-/// at all. That header has to be set per request, because the policy
-/// depends on the URL — hence the wrapping handler rather than a plain
-/// `SetResponseHeaderLayer`. `ServeDir` sets no `Cache-Control` of its
-/// own, and the ETag and `Vary` it does set are left untouched: they are
-/// what makes the `no-cache` half cheap.
-fn static_service(static_dir: &str, index_file: impl AsRef<std::path::Path>) -> MethodRouter {
-    // The SPA fallback (`/library/...`, `/editor/...` deep links) returns
-    // index.html, which is itself precompressed — hence the same flags on the
-    // not-found service.
-    let index = ServeFile::new(index_file)
-        .precompressed_br()
-        .precompressed_gzip();
-    let files = ServeDir::new(static_dir)
-        .precompressed_br()
-        .precompressed_gzip()
-        .not_found_service(index);
-
-    get(move |request: axum::extract::Request| {
-        let files = files.clone();
-        async move {
-            let uri = request.uri().clone();
-            // `ServeDir`'s error type is `Infallible` once a not-found
-            // service is set, so this cannot fail.
-            let mut response = files
-                .oneshot(request)
-                .await
-                .unwrap_or_else(|e| match e {})
-                .map(axum::body::Body::new);
-            static_cache::apply(&uri, &mut response);
-            response
-        }
-    })
 }
 
 /// Read favorites.json from the static directory.
@@ -1158,13 +1097,14 @@ mod http_localhost_tests {
 }
 
 /// The editor image serves its own static files, so the only place
-/// compression can happen is `static_service`. These tests pin that the
-/// precompressed variants written by `frontend/scripts/precompress.mjs` are
-/// actually picked up, and that a client which cannot decompress still gets
-/// the plain file.
+/// compression can happen is `static_spa::static_service`. These tests pin
+/// that the precompressed variants written by
+/// `frontend/scripts/precompress.mjs` are actually picked up, and that a
+/// client which cannot decompress still gets the plain file.
 #[cfg(test)]
 mod static_service_tests {
-    use super::{static_cache, static_service};
+    use super::static_cache;
+    use super::static_spa::static_service;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
     use http_body_util::BodyExt;
@@ -1318,17 +1258,18 @@ mod static_service_tests {
     /// Deep links like `/library/foo` are SPA routes with no file behind
     /// them; they fall through to index.html, which is precompressed as well.
     ///
-    /// The 404 is pre-existing and deliberately left alone here:
-    /// `not_found_service` is `fallback` wrapped in `SetStatus(404)`, so the
-    /// editor has always answered deep links with the index body under a 404
-    /// status. The browser runs the SPA regardless. Changing that is a
-    /// separate decision from compressing the body.
+    /// The status assertion used to read `NOT_FOUND`, because
+    /// `not_found_service` is `fallback` wrapped in `SetStatus(404)`. That
+    /// wrapper is gone (see `static_spa`), so the deep link now answers
+    /// `200`. What this test is here for is unchanged: the index on the
+    /// fallback path must keep its precompressed variants, or the fallback
+    /// silently loses the compression the rest of the bundle has.
     #[tokio::test]
     async fn spa_fallback_serves_the_precompressed_index() {
         let dir = fixture();
         let response = get(&dir, "/library/some-law", Some("br")).await;
 
-        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response.headers()["content-encoding"], "br");
         assert_eq!(body(response).await, BROTLIED);
     }
@@ -1379,9 +1320,8 @@ mod static_service_tests {
         );
     }
 
-    /// A request for an asset that is not on disk is answered with the
-    /// index HTML. Marking that immutable would pin a broken page under
-    /// a bundle URL for a year.
+    /// A request for an asset that is not on disk stays a `404`. Marking
+    /// that immutable would pin the miss under a bundle URL for a year.
     #[tokio::test]
     async fn a_missing_asset_is_not_cached_as_one() {
         let dir = fixture();

--- a/packages/editor-api/src/static_cache.rs
+++ b/packages/editor-api/src/static_cache.rs
@@ -52,10 +52,10 @@ const MIN_HASH_LEN: usize = 8;
 ///
 /// Takes the *request* URI rather than reading the response, because the
 /// decision is about the URL's stability, not about the bytes. The
-/// status is consulted for one reason: a request for a missing
-/// `/assets/…` file falls through to the SPA index, and that HTML must
-/// never be cached for a year under an asset URL. Only a response that
-/// actually delivered (or confirmed) the asset may be marked immutable.
+/// status is consulted so that only a response which actually delivered
+/// (or confirmed) the asset may be marked immutable; a missing
+/// `/assets/…` file must never leave an error body pinned for a year
+/// under an asset URL.
 pub fn apply<B>(uri: &Uri, response: &mut Response<B>) {
     let immutable = response_is_authoritative(response.status()) && is_hashed_asset(uri.path());
     let value = if immutable { IMMUTABLE } else { REVALIDATE };
@@ -63,8 +63,8 @@ pub fn apply<B>(uri: &Uri, response: &mut Response<B>) {
 }
 
 /// `200`, `304` and `206` mean the URL resolved to the file it names.
-/// Anything else (notably the `404` the SPA fallback carries) is some
-/// other resource wearing this URL and must stay revalidated.
+/// Anything else is some other resource wearing this URL and must stay
+/// revalidated.
 fn response_is_authoritative(status: StatusCode) -> bool {
     matches!(
         status,

--- a/packages/editor-api/src/static_spa.rs
+++ b/packages/editor-api/src/static_spa.rs
@@ -1,0 +1,366 @@
+//! Static-file serving for the built editor frontend, with an SPA index
+//! fallback that answers `200` instead of `404`.
+//!
+//! The editor image has no nginx in front of it — this binary is the web
+//! server for `frontend/dist` as well as the API — so both compression
+//! and the deep-link behaviour have to be decided here or not at all.
+//!
+//! # Compression
+//!
+//! `precompressed_br` / `precompressed_gzip` make `ServeDir` look for
+//! `foo.js.br` and `foo.js.gz` beside `foo.js` and serve one of those when
+//! the client's `Accept-Encoding` allows it. The variants are written at
+//! build time by `frontend/scripts/precompress.mjs`, so the container spends
+//! no CPU compressing per request, and a client that accepts neither still
+//! gets the plain file. `ServeDir` sets `Vary: accept-encoding` itself once a
+//! precompressed variant is configured, so shared caches stay correct.
+//!
+//! Which encoding wins is the client's call, not ours: `ServeDir` picks the
+//! highest q-value from `Accept-Encoding` and breaks ties in favour of
+//! brotli. Builder order here is cosmetic. Note that a future
+//! `precompressed_zstd()` would outrank brotli in that tie-break — worth
+//! knowing before adding one.
+//!
+//! Compression stops at the static files on purpose: the JSON API keeps
+//! serving uncompressed bodies. The index served on the deep-link path
+//! gets the same flags, because it is the same `index.html` and it is
+//! precompressed too.
+//!
+//! # Caching
+//!
+//! Which URLs may be cached for a year and which must revalidate is
+//! decided in [`crate::static_cache`]; [`static_service`] is where that
+//! decision is stamped onto the response.
+//!
+//! # Deep links
+//!
+//! The editor is a single-page app: every deep route (`/trajecten/…`,
+//! `/library/…`) exists only in the client-side router, so the server has
+//! no file to hand back. `ServeDir::not_found_service` does return
+//! `index.html`, but it wraps the inner service in `SetStatus` and forces
+//! the status to `404` — the page renders, the status code lies. Anything
+//! that reads the status instead of the body (uptime monitors, crawlers,
+//! `curl -f`, caches, smoketests) then treats a working page as missing.
+//!
+//! Answering `200` for *everything* unmatched is the opposite mistake: a
+//! bundle asset that genuinely disappeared would be served as HTML, the
+//! browser would fail on `Unexpected token '<'`, and the real error would
+//! surface far from its cause. So the fallback is deliberately narrow —
+//! see [`wants_index_fallback`] for the boundary.
+
+use std::path::Path;
+use std::path::PathBuf;
+
+use axum::body::Body;
+use axum::extract::Request;
+use axum::http::{header, HeaderMap, StatusCode, Uri};
+use axum::response::{IntoResponse, Response};
+use axum::routing::{any, get, MethodRouter};
+use tower::ServiceExt;
+use tower_http::services::{ServeDir, ServeFile};
+
+/// Path prefixes that belong to the backend, never to the client router.
+/// An unmatched path under one of these is a wrong URL or a removed
+/// endpoint; handing it `index.html` would turn a broken API call into a
+/// confusing HTML parse error at the caller.
+const BACKEND_PREFIXES: &[&str] = &["/api", "/auth", "/health"];
+
+/// Directories the build writes files into: `/assets` is Vite's own
+/// output, `/data` is the corpus tree that `frontend/scripts/copy-laws.js`
+/// copies from `public/data`. Everything under either is a file or nothing
+/// at all — see [`wants_index_fallback`] gate 2.
+const STATIC_DIRS: &[&str] = &["/assets", "/data"];
+
+/// Extensions of things that are *files or nothing* outside the bundle
+/// directory: sourcemaps, fonts, images, data files, and anything else
+/// copied from `public/` to the root of `dist`. A request for one of
+/// these that `ServeDir` could not satisfy is a genuinely missing asset
+/// and must stay `404`.
+///
+/// Deliberately an allowlist rather than "any path with a dot": editor
+/// routes do carry dots in their parameters — the legacy `/editor.html`
+/// route, and werkdocument deeplinks such as
+/// `/werkdocumenten/<traject>/notities/plan.md` — and those are real
+/// client-side routes that deserve the index.
+const ASSET_EXTENSIONS: &[&str] = &[
+    "js",
+    "mjs",
+    "cjs",
+    "css",
+    "map",
+    "json",
+    "wasm",
+    "ico",
+    "png",
+    "jpg",
+    "jpeg",
+    "gif",
+    "svg",
+    "webp",
+    "avif",
+    "woff",
+    "woff2",
+    "ttf",
+    "otf",
+    "eot",
+    "txt",
+    "xml",
+    "webmanifest",
+    "mp4",
+    "webm",
+];
+
+/// Decide whether an unmatched request should be answered with the SPA
+/// index (`200`) or left as a real `404`.
+///
+/// Four gates, all of which must pass:
+///
+/// 1. the path is not under a backend prefix ([`BACKEND_PREFIXES`]);
+/// 2. the path is not one of the [`STATIC_DIRS`], nor under one, whatever
+///    it looks like;
+/// 3. the path does not end in an asset extension ([`ASSET_EXTENSIONS`]);
+/// 4. the client is willing to accept HTML — an `Accept` header that asks
+///    only for, say, `application/json` gets its `404` rather than a page
+///    it cannot parse. An absent or wildcard `Accept` (curl, monitors)
+///    counts as willing.
+///
+/// Gates 2 and 3 overlap on the common case and are both needed at the
+/// edges. The extension allowlist alone leaves a hole exactly where the
+/// build puts real files under names it does not recognise: the
+/// precompressed variants `…-Ab12Cd34.js.gz` and `…-Ab12Cd34.js.br`
+/// written by `frontend/scripts/precompress.mjs`, any extensionless
+/// chunk, and under `/data/` the corpus itself — `*.yaml` law files,
+/// `*.feature` scenarios and the `annotations.yaml` note sidecars, which
+/// exist for one law in twenty-five. Those would fall through to the
+/// index at `200`, and that is worse than a `404` in two ways. A bundle
+/// URL answering `200 text/html` defeats caching policy keyed on the
+/// immutability of hashed bundle names: the HTML gets pinned under an
+/// asset URL and no deploy can reach a browser holding it. A corpus URL
+/// answering `200 text/html` defeats the callers, which read the absence
+/// of a file from its `404` — `useDraftNotes.js` runs `yaml.load()` over
+/// whatever comes back. Neither directory ever holds a client-side
+/// route, so blanket-excluding both costs nothing.
+pub fn wants_index_fallback(uri: &Uri, headers: &HeaderMap) -> bool {
+    let path = uri.path();
+
+    if is_under_any(path, BACKEND_PREFIXES) {
+        return false;
+    }
+
+    if is_under_any(path, STATIC_DIRS) {
+        return false;
+    }
+
+    if let Some(segment) = path.rsplit('/').next() {
+        if let Some((_, ext)) = segment.rsplit_once('.') {
+            let ext = ext.to_ascii_lowercase();
+            if ASSET_EXTENSIONS.contains(&ext.as_str()) {
+                return false;
+            }
+        }
+    }
+
+    accepts_html(headers)
+}
+
+/// `true` when `path` is one of `prefixes` or lies under one. Matching is
+/// on whole segments, so `/apiary` is not under `/api` and
+/// `/assetsoverzicht` is not under `/assets`; both are ordinary client
+/// routes. The bare directory itself counts as a match: `/assets` has no
+/// file behind it either.
+fn is_under_any(path: &str, prefixes: &[&str]) -> bool {
+    prefixes.iter().any(|prefix| {
+        path == *prefix
+            || (path.starts_with(prefix) && path.as_bytes().get(prefix.len()) == Some(&b'/'))
+    })
+}
+
+/// `true` when the `Accept` header does not rule out HTML. Missing,
+/// empty or unparseable headers are treated as permissive: a monitor that
+/// sends no `Accept` should still see the page it would get in a browser.
+fn accepts_html(headers: &HeaderMap) -> bool {
+    let Some(accept) = headers.get(header::ACCEPT) else {
+        return true;
+    };
+    let Ok(accept) = accept.to_str() else {
+        return true;
+    };
+    if accept.trim().is_empty() {
+        return true;
+    }
+    accept.split(',').any(|entry| {
+        let media = entry.split(';').next().unwrap_or("").trim();
+        media.eq_ignore_ascii_case("text/html")
+            || media.eq_ignore_ascii_case("text/*")
+            || media == "*/*"
+            || media.eq_ignore_ascii_case("application/xhtml+xml")
+    })
+}
+
+/// The static-file service mounted as the router's fallback: `ServeDir`
+/// for real files, and for everything else the narrow index fallback
+/// above — served with its own status (`200`), not forced to `404`.
+///
+/// The outer `get` does two things. It is the method gate for the whole
+/// static surface (`GET`/`HEAD`; anything else is `405`), and it gives
+/// every static response a single exit point where [`static_cache`]
+/// stamps its `Cache-Control`. That header depends on the URL rather
+/// than on the bytes, so it has to be set per request; a plain
+/// `SetResponseHeaderLayer` could not tell a hashed bundle file from the
+/// index. `ServeDir` sets no `Cache-Control` of its own, and the ETag
+/// and `Vary` it does set are left untouched: they are what makes the
+/// `no-cache` half cheap.
+pub fn static_service(static_dir: &str, index_file: impl AsRef<Path>) -> MethodRouter {
+    let files = ServeDir::new(static_dir)
+        .precompressed_br()
+        .precompressed_gzip()
+        .fallback(index_fallback_route(index_file.as_ref().to_path_buf()));
+
+    get(move |request: Request| {
+        let files = files.clone();
+        async move {
+            let uri = request.uri().clone();
+            // `ServeDir`'s error type is `Infallible` once a fallback is
+            // set, so this cannot fail.
+            let mut response = files
+                .oneshot(request)
+                .await
+                .unwrap_or_else(|e| match e {})
+                .map(Body::new);
+            crate::static_cache::apply(&uri, &mut response);
+            response
+        }
+    })
+}
+
+/// `any`, not `get`: the method gate lives on the outer service in
+/// [`static_service`], and `ServeDir` never reaches its fallback for
+/// anything but `GET`/`HEAD` anyway.
+fn index_fallback_route(index_file: PathBuf) -> MethodRouter {
+    any(move |req: Request| {
+        let index_file = index_file.clone();
+        async move { serve_index_or_404(index_file, req).await }
+    })
+}
+
+async fn serve_index_or_404(index_file: PathBuf, req: Request) -> Response {
+    if !wants_index_fallback(req.uri(), req.headers()) {
+        return (StatusCode::NOT_FOUND, "Not Found").into_response();
+    }
+
+    // The index on this path is the same `index.html` `ServeDir` serves
+    // at `/`, and it is precompressed at build time like the rest of the
+    // bundle — hence the same flags here.
+    let index = ServeFile::new(&index_file)
+        .precompressed_br()
+        .precompressed_gzip();
+
+    match index.oneshot(req).await {
+        Ok(response) => response.map(Body::new),
+        Err(e) => {
+            tracing::error!(error = %e, path = %index_file.display(), "failed to serve SPA index");
+            (StatusCode::INTERNAL_SERVER_ERROR, "Internal Server Error").into_response()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn headers(accept: Option<&str>) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        if let Some(accept) = accept {
+            headers.insert(header::ACCEPT, accept.parse().unwrap());
+        }
+        headers
+    }
+
+    fn wants(path: &str, accept: Option<&str>) -> bool {
+        wants_index_fallback(&path.parse::<Uri>().unwrap(), &headers(accept))
+    }
+
+    #[test]
+    fn deep_routes_get_the_index() {
+        assert!(wants("/trajecten/zorgtoeslag-0a1b2c3d", None));
+        assert!(wants("/library/wet_op_de_zorgtoeslag/3", Some("text/html")));
+        assert!(wants("/editor.html", Some("text/html,*/*;q=0.8")));
+        assert!(wants(
+            "/werkdocumenten/zorgtoeslag-0a1b2c3d/notities/plan.md",
+            None
+        ));
+        assert!(wants("/trajecten/zorgtoeslag-0a1b2c3d?tab=leden", None));
+    }
+
+    #[test]
+    fn missing_bundle_assets_stay_404() {
+        assert!(!wants("/assets/index-deadbeef.js", Some("*/*")));
+        assert!(!wants("/assets/index-deadbeef.css", Some("*/*")));
+        assert!(!wants("/assets/index-deadbeef.js.map", None));
+        assert!(!wants("/favorites.json", None));
+        assert!(!wants("/regelrecht-icon.SVG", None));
+    }
+
+    /// The hole gate 3 alone leaves: real build output under `/assets/`
+    /// whose name ends in something the extension allowlist does not
+    /// know. These must not become HTML at `200`.
+    #[test]
+    fn everything_under_assets_stays_404_whatever_the_extension() {
+        assert!(!wants("/assets/index-Ab12Cd34.js.gz", Some("text/html")));
+        assert!(!wants("/assets/index-Ab12Cd34.js.br", Some("text/html")));
+        assert!(!wants("/assets/index-Ab12Cd34.css.br", None));
+        assert!(!wants("/assets/chunk-Ab12Cd34.yaml", None));
+        assert!(!wants("/assets/index-Ab12Cd34", None));
+        assert!(!wants("/assets/nested/chunk-Ab12Cd34.js.gz", None));
+        assert!(!wants("/assets/", Some("text/html")));
+        assert!(!wants("/assets", Some("text/html")));
+        // A route that merely starts with the same letters is not the
+        // bundle directory.
+        assert!(wants("/assetsoverzicht", None));
+    }
+
+    /// The corpus tree `frontend/scripts/copy-laws.js` writes to
+    /// `public/data`. The sidecar is the sharp case: it exists for one
+    /// law in twenty-five, the browser asks for it with `Accept: */*`,
+    /// and `useDraftNotes.js` reads "no committed notes yet" from the
+    /// `404`.
+    #[test]
+    fn missing_corpus_files_stay_404() {
+        assert!(!wants(
+            "/data/annotations/wet_op_de_zorgtoeslag/annotations.yaml",
+            Some("*/*")
+        ));
+        assert!(!wants("/data/annotations/_vocabulary/ambiguity.yaml", None));
+        assert!(!wants(
+            "/data/nl/wet/wet_op_de_zorgtoeslag/2025-01-01.yaml",
+            Some("text/html")
+        ));
+        assert!(!wants(
+            "/data/nl/wet/wet_op_de_zorgtoeslag/scenarios/eligibility.feature",
+            Some("*/*")
+        ));
+        assert!(!wants("/data/index.json", None));
+        assert!(!wants("/data/", Some("text/html")));
+        assert!(!wants("/data", Some("text/html")));
+        // A route that merely starts with the same letters is not the
+        // corpus directory.
+        assert!(wants("/dataverkenner", None));
+    }
+
+    #[test]
+    fn backend_paths_stay_404() {
+        assert!(!wants("/api/does-not-exist", Some("text/html")));
+        assert!(!wants("/auth/nope", Some("text/html")));
+        assert!(!wants("/health/extra", None));
+        // A path that merely starts with the same letters is a normal route.
+        assert!(wants("/apiary", None));
+    }
+
+    #[test]
+    fn json_clients_keep_their_404() {
+        assert!(!wants(
+            "/trajecten/zorgtoeslag-0a1b2c3d",
+            Some("application/json")
+        ));
+    }
+}

--- a/packages/editor-api/tests/spa_deeplink_test.rs
+++ b/packages/editor-api/tests/spa_deeplink_test.rs
@@ -1,0 +1,290 @@
+//! End-to-end test for the SPA deeplink fallback.
+//!
+//! The regression this pins: the editor answered every deep route with
+//! `index.html` under a `404` status, so the page rendered but every
+//! status-reading client (monitor, crawler, `curl -f`, cache) saw a
+//! missing page. These tests drive the real fallback service against a
+//! real static directory on disk, so the premise is actually built: the
+//! deeplink resolves to no file, the asset resolves to no file, and the
+//! two must end up with different statuses.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::Router;
+use pretty_assertions::assert_eq;
+use tower::ServiceExt;
+
+use regelrecht_editor_api::static_spa::static_service;
+
+const INDEX_HTML: &str = "<!doctype html><title>regelrecht editor</title><div id=\"app\"></div>";
+
+const INDEX_BROTLI: &str = "pretend brotli index";
+
+const SIDECAR_YAML: &str = "annotations: []\n";
+
+/// A static dir shaped like a Vite build: an index with its precompressed
+/// variant, one content-hashed asset with both variants beside it, one
+/// public file, and the corpus tree `frontend/scripts/copy-laws.js` writes
+/// to `public/data` — with a note sidecar for one law and none for the
+/// other, which is the ratio in the real corpus. Everything else
+/// genuinely does not exist.
+fn static_dir() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("index.html"), INDEX_HTML).unwrap();
+    std::fs::write(dir.path().join("index.html.br"), INDEX_BROTLI).unwrap();
+    std::fs::create_dir(dir.path().join("assets")).unwrap();
+    std::fs::write(
+        dir.path().join("assets/index-Ab12Cd34.js"),
+        "console.log('bundle');",
+    )
+    .unwrap();
+    std::fs::write(dir.path().join("assets/index-Ab12Cd34.js.gz"), "gz").unwrap();
+    std::fs::write(dir.path().join("assets/index-Ab12Cd34.js.br"), "br").unwrap();
+    std::fs::write(dir.path().join("favorites.json"), "[]").unwrap();
+    let sidecar = dir
+        .path()
+        .join("data/annotations/wet_op_de_zorgtoeslag/annotations.yaml");
+    std::fs::create_dir_all(sidecar.parent().unwrap()).unwrap();
+    std::fs::write(&sidecar, SIDECAR_YAML).unwrap();
+    dir
+}
+
+fn app(dir: &tempfile::TempDir) -> Router {
+    let static_path = dir.path().to_string_lossy().into_owned();
+    let index = dir.path().join("index.html");
+    Router::new()
+        .route("/health", axum::routing::get(|| async { "OK" }))
+        .fallback_service(static_service(&static_path, &index))
+}
+
+async fn get(dir: &tempfile::TempDir, path: &str, accept: Option<&str>) -> (StatusCode, String) {
+    let response = raw_get(dir, path, accept, None).await;
+    let status = response.status();
+    (status, body_of(response).await)
+}
+
+async fn raw_get(
+    dir: &tempfile::TempDir,
+    path: &str,
+    accept: Option<&str>,
+    accept_encoding: Option<&str>,
+) -> axum::http::Response<Body> {
+    let mut request = Request::builder().uri(path).method("GET");
+    if let Some(accept) = accept {
+        request = request.header("accept", accept);
+    }
+    if let Some(encoding) = accept_encoding {
+        request = request.header("accept-encoding", encoding);
+    }
+    app(dir)
+        .oneshot(request.body(Body::empty()).unwrap())
+        .await
+        .unwrap()
+}
+
+async fn body_of(response: axum::http::Response<Body>) -> String {
+    let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    String::from_utf8_lossy(&body).into_owned()
+}
+
+#[tokio::test]
+async fn deeplink_answers_200_with_the_index() {
+    let dir = static_dir();
+
+    // Sanity: the deeplink is not a file on disk, so this really exercises
+    // the fallback rather than a lucky hit in ServeDir.
+    assert!(!dir.path().join("trajecten").exists());
+
+    let (status, body) = get(
+        &dir,
+        "/trajecten/zorgtoeslag-0a1b2c3d/corpus/wet_op_de_zorgtoeslag/3",
+        Some("text/html,application/xhtml+xml"),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, INDEX_HTML);
+}
+
+#[tokio::test]
+async fn deeplink_without_accept_header_also_answers_200() {
+    // The uptime-monitor / `curl -f` case: no Accept header at all.
+    let dir = static_dir();
+    let (status, _) = get(&dir, "/trajecten/zorgtoeslag-0a1b2c3d", None).await;
+    assert_eq!(status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn missing_bundle_asset_stays_404() {
+    let dir = static_dir();
+    assert!(!dir.path().join("assets/index-gone.js").exists());
+
+    let (status, body) = get(&dir, "/assets/index-gone.js", Some("*/*")).await;
+
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_ne!(
+        body, INDEX_HTML,
+        "a missing script must not be answered with HTML"
+    );
+}
+
+#[tokio::test]
+async fn existing_asset_is_still_served() {
+    let dir = static_dir();
+    let (status, body) = get(&dir, "/assets/index-Ab12Cd34.js", Some("*/*")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, "console.log('bundle');");
+}
+
+#[tokio::test]
+async fn unknown_api_path_stays_404() {
+    let dir = static_dir();
+    let (status, body) = get(&dir, "/api/verdwenen-endpoint", Some("application/json")).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_ne!(body, INDEX_HTML);
+}
+
+#[tokio::test]
+async fn json_client_on_a_deep_route_stays_404() {
+    let dir = static_dir();
+    let (status, _) = get(
+        &dir,
+        "/trajecten/zorgtoeslag-0a1b2c3d",
+        Some("application/json"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn real_routes_are_untouched() {
+    let dir = static_dir();
+    let (status, body) = get(&dir, "/health", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, "OK");
+}
+
+#[tokio::test]
+async fn root_serves_the_index_directly() {
+    let dir = static_dir();
+    let (status, body) = get(&dir, "/", Some("text/html")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, INDEX_HTML);
+}
+
+#[tokio::test]
+async fn non_get_on_an_unmatched_path_is_405() {
+    let dir = static_dir();
+    let response = app(&dir)
+        .oneshot(
+            Request::builder()
+                .uri("/trajecten/zorgtoeslag-0a1b2c3d")
+                .method("POST")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+}
+
+/// The hole the extension allowlist alone leaves. `precompress.mjs`
+/// writes `.js.gz` and `.js.br` beside every bundle file, and neither
+/// tail is in the allowlist, so without the `/assets/` gate this URL
+/// would answer `200 text/html`. Under a cache policy that treats hashed
+/// bundle names as immutable, a visitor would then hold that HTML at an
+/// asset URL for a year and no deploy could reach them.
+#[tokio::test]
+async fn missing_precompressed_variant_under_assets_stays_404() {
+    let dir = static_dir();
+    // The premise: this exact file is not on disk, while a sibling of the
+    // very same shape is — so the 404 comes from the gate, not from an
+    // empty directory that would 404 anything.
+    assert!(!dir.path().join("assets/index-Zz98Yx76.js.gz").exists());
+    assert!(dir.path().join("assets/index-Ab12Cd34.js.gz").exists());
+
+    let (status, body) = get(&dir, "/assets/index-Zz98Yx76.js.gz", Some("text/html")).await;
+
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_ne!(
+        body, INDEX_HTML,
+        "a missing bundle variant must not be answered with the index"
+    );
+}
+
+/// Same gate, for the shapes that carry no allowlisted extension at all.
+#[tokio::test]
+async fn extensionless_and_unknown_assets_stay_404() {
+    let dir = static_dir();
+    for path in [
+        "/assets/index-Zz98Yx76",
+        "/assets/chunk-Zz98Yx76.yaml",
+        "/assets/nested/chunk-Zz98Yx76.js.br",
+    ] {
+        let (status, body) = get(&dir, path, Some("text/html")).await;
+        assert_eq!(status, StatusCode::NOT_FOUND, "{path}");
+        assert_ne!(body, INDEX_HTML, "{path}");
+    }
+}
+
+/// The note sidecar is the case the editor reads a `404` as data:
+/// `useDraftNotes.js` treats it as "no committed notes yet" and exports
+/// the drafts alone. Answer `200 text/html` instead and it runs
+/// `yaml.load()` over an HTML document. The browser asks with
+/// `Accept: */*`, so gate 4 does not save this one.
+#[tokio::test]
+async fn missing_note_sidecar_stays_404() {
+    let dir = static_dir();
+    let present = "/data/annotations/wet_op_de_zorgtoeslag/annotations.yaml";
+    let absent = "/data/annotations/algemene_wet_bestuursrecht/annotations.yaml";
+
+    let (status, body) = get(&dir, present, Some("*/*")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, SIDECAR_YAML);
+
+    let (status, body) = get(&dir, absent, Some("*/*")).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_ne!(
+        body, INDEX_HTML,
+        "a law without notes must not be answered with the index"
+    );
+}
+
+/// The rest of the corpus tree, which the extension allowlist knows just
+/// as little about: law YAML and the scenario `.feature` files copied
+/// alongside them.
+#[tokio::test]
+async fn missing_corpus_files_stay_404() {
+    let dir = static_dir();
+    for path in [
+        "/data/nl/wet/wet_op_de_zorgtoeslag/2025-01-01.yaml",
+        "/data/nl/wet/wet_op_de_zorgtoeslag/scenarios/eligibility.feature",
+    ] {
+        let (status, body) = get(&dir, path, Some("*/*")).await;
+        assert_eq!(status, StatusCode::NOT_FOUND, "{path}");
+        assert_ne!(body, INDEX_HTML, "{path}");
+    }
+}
+
+/// The precompressed variants must survive on the fallback path too, or
+/// deep links quietly stop being compressed while the rest of the bundle
+/// still is.
+#[tokio::test]
+async fn the_deeplink_index_is_still_precompressed() {
+    let dir = static_dir();
+    let response = raw_get(
+        &dir,
+        "/trajecten/zorgtoeslag-0a1b2c3d",
+        Some("text/html"),
+        Some("br"),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.headers()["content-encoding"], "br");
+    assert_eq!(body_of(response).await, INDEX_BROTLI);
+}


### PR DESCRIPTION
Een diepe route in de editor gaf HTTP 404 met `index.html` als body. `ServeDir::not_found_service` wikkelt zijn fallback in `SetStatus` en dwingt de status naar 404, dus alles wat naar de status kijkt in plaats van naar de body liep stuk, van uptime-monitoring tot caches die het antwoord niet mochten bewaren.

De fallback staat nu naast `ServeDir` en houdt zijn eigen 200, achter vier poorten die alle vier open moeten staan: het pad valt niet onder `/api`, `/auth` of `/health`, het is niet `/assets` of `/data` en valt daar ook niet onder, het eindigt niet op een extensie uit de bundel-allowlist, en de client sluit HTML niet uit via `Accept`.

Poort 3 is een allowlist en geen "elk pad met een punt", want `/editor.html` en werkdocument-deeplinks dragen zelf punten en zijn echte client-routes. Poort 2 dicht het gat dat dat achterlaat. Onder `/assets/` zijn dat de precompressed `.js.gz` en `.js.br`, waar cachebeleid voor gehashte namen HTML een jaar zou vastpinnen. Onder `/data/` is dat het corpus: `useDraftNotes.js` leest een 404 op een ontbrekende `annotations.yaml` als gegeven, en zou anders `yaml.load()` over een HTML-document draaien. Die poort vergelijkt op hele segmenten, zodat `/assetsoverzicht` een gewone client-route blijft.

De test bouwt een statische map in de vorm van een echte build en asserteert eerst dat het gevraagde pad er niet staat, zodat de premisse geconstrueerd is; tegen de oude implementatie falen negen tests. `frontend-lawmaking` heeft de spiegelfout en is hier buiten gelaten.