### PR TITLE
build(ci): bouw-tools ophalen als gepinde binary in plaats van compileren

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -572,36 +572,38 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-registry-
 
       # `just test-e2e` hangt aan `wasm-build`, dat `wasm-bindgen` op PATH
-      # verwacht. De versie wordt uit packages/Cargo.lock gelezen in plaats van
-      # hier hardgecodeerd: wasm-bindgen-cli moet exact overeenkomen met de
-      # wasm-bindgen-crate, anders faalt het bindgen-stap met een versie-mismatch.
-      - name: Resolve wasm-bindgen version
-        id: wasm-bindgen-version
+      # verwacht. Versie en checksum staan in frontend/Dockerfile en worden hier
+      # gelezen in plaats van een tweede keer opgeschreven; dat houdt CI en het
+      # editor-image op precies dezelfde binary. De versie moet gelijk lopen met
+      # de wasm-bindgen-crate uit packages/Cargo.lock, anders faalt de
+      # bindgen-stap verderop met een versie-mismatch.
+      - name: Install wasm-bindgen-cli
         if: needs.changes.outputs.ci == 'true'
         run: |
-          version=$(grep -A1 '^name = "wasm-bindgen"$' packages/Cargo.lock \
-            | sed -n 's/^version = "\(.*\)"$/\1/p' | head -1)
-          if [ -z "$version" ]; then
+          set -eu
+          locked=$(grep -A1 '^name = "wasm-bindgen"$' packages/Cargo.lock \
+            | sed -n '/^version = /{s/^version = "\(.*\)"$/\1/p;q;}')
+          version=$(sed -n 's/^ARG WASM_BINDGEN_VERSION=\(.*\)$/\1/p' frontend/Dockerfile)
+          sha=$(sed -n 's/^ARG WASM_BINDGEN_SHA256_AMD64=\(.*\)$/\1/p' frontend/Dockerfile)
+          if [ -z "$locked" ]; then
             echo "::error::kon wasm-bindgen-versie niet uit packages/Cargo.lock lezen"
             exit 1
           fi
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-
-      - name: Cache wasm-bindgen-cli
-        id: wasm-bindgen-cache
-        if: needs.changes.outputs.ci == 'true'
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
-        with:
-          path: ~/.cargo/bin/wasm-bindgen
-          key: ${{ runner.os }}-wasm-bindgen-${{ steps.wasm-bindgen-version.outputs.version }}
-
-      # Overslaan bij een cache-hit. Zonder deze guard faalt elke run ná de
-      # eerste: de cache legt alleen het binary terug, niet `.crates.toml`,
-      # waardoor cargo het bestand niet als het zijne herkent en weigert te
-      # overschrijven ("binary `wasm-bindgen` already exists in destination").
-      - name: Install wasm-bindgen-cli
-        if: needs.changes.outputs.ci == 'true' && steps.wasm-bindgen-cache.outputs.cache-hit != 'true'
-        run: cargo install wasm-bindgen-cli@${{ steps.wasm-bindgen-version.outputs.version }} --locked
+          if [ -z "$version" ] || [ -z "$sha" ]; then
+            echo "::error::kon WASM_BINDGEN_VERSION/WASM_BINDGEN_SHA256_AMD64 niet uit frontend/Dockerfile lezen"
+            exit 1
+          fi
+          if [ "$version" != "$locked" ]; then
+            echo "::error::wasm-bindgen-cli is in frontend/Dockerfile gepind op $version, packages/Cargo.lock heeft $locked. Werk WASM_BINDGEN_VERSION en beide WASM_BINDGEN_SHA256_* bij naar $locked; de checksums staan naast de release op https://github.com/wasm-bindgen/wasm-bindgen/releases/tag/$locked"
+            exit 1
+          fi
+          dir="wasm-bindgen-${version}-x86_64-unknown-linux-musl"
+          curl -fsSLo "/tmp/${dir}.tar.gz" \
+            "https://github.com/wasm-bindgen/wasm-bindgen/releases/download/${version}/${dir}.tar.gz"
+          echo "${sha}  /tmp/${dir}.tar.gz" | sha256sum -c -
+          tar -xzf "/tmp/${dir}.tar.gz" -C /tmp
+          install -D -m0755 "/tmp/${dir}/wasm-bindgen" "$HOME/.cargo/bin/wasm-bindgen"
+          wasm-bindgen --version
 
       - name: Setup Node.js
         if: needs.changes.outputs.ci == 'true'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,6 +64,13 @@ repos:
         exclude: (^|/)\.[^/]*\.yaml$
         types: [yaml]
 
+      - id: tool-pins-in-sync
+        name: cargo-chef-pin gelijk in alle Dockerfiles
+        entry: script/check-tool-pins.sh
+        language: system
+        pass_filenames: false
+        files: (^frontend/Dockerfile$|^packages/(admin|pipeline)/Dockerfile$)
+
       - id: skills-no-casus
         name: Skills blijven dossier-agnostisch (geen casus-inhoud)
         entry: script/check-skills-no-casus.sh

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,11 +2,48 @@
 # Stage 1a: Build WASM module using cargo + wasm-bindgen-cli (no wasm-pack needed)
 # Rust version: keep in sync with rust-toolchain.toml (source of truth).
 FROM rust:1.96-alpine@sha256:2ea3db105d38fdfa4e31f366674287fcaa828087e2fe3973befdc537f2d443b1 AS wasm-builder
-RUN apk add --no-cache musl-dev
+RUN apk add --no-cache musl-dev curl
 RUN rustup target add wasm32-unknown-unknown
-RUN cargo install wasm-bindgen-cli@0.2.114 --locked
+# wasm-bindgen-cli als officiële prebuilt binary van de releasepagina van het
+# project, in plaats van vanaf broncode te compileren. De sha256's zijn de
+# gepubliceerde .sha256sum-bestanden van diezelfde release; zonder die pin zou
+# een gewijzigd of afgebroken artefact ongemerkt de build in glijden.
+ARG TARGETARCH
+ARG WASM_BINDGEN_VERSION=0.2.114
+ARG WASM_BINDGEN_SHA256_AMD64=ce21be002bdbc22ede2a5cf250cb801d2106956fc3c529c75d9452729db3490c
+ARG WASM_BINDGEN_SHA256_ARM64=39103878ad3c0016f2d04b7b4a6206c974240286852abac5736d017a43703958
+RUN set -eu; \
+    case "${TARGETARCH:-}" in \
+      amd64) arch=x86_64; sha="${WASM_BINDGEN_SHA256_AMD64}" ;; \
+      arm64) arch=aarch64; sha="${WASM_BINDGEN_SHA256_ARM64}" ;; \
+      *) echo "geen gepinde wasm-bindgen-cli-binary voor TARGETARCH='${TARGETARCH:-}'" >&2; exit 1 ;; \
+    esac; \
+    dir="wasm-bindgen-${WASM_BINDGEN_VERSION}-${arch}-unknown-linux-musl"; \
+    curl -fsSLo "/tmp/${dir}.tar.gz" \
+      "https://github.com/wasm-bindgen/wasm-bindgen/releases/download/${WASM_BINDGEN_VERSION}/${dir}.tar.gz"; \
+    echo "${sha}  /tmp/${dir}.tar.gz" | sha256sum -c -; \
+    tar -xzf "/tmp/${dir}.tar.gz" -C /tmp; \
+    install -m0755 "/tmp/${dir}/wasm-bindgen" /usr/local/bin/wasm-bindgen; \
+    rm -rf "/tmp/${dir}.tar.gz" "/tmp/${dir}"; \
+    wasm-bindgen --version
 WORKDIR /build
 COPY packages/Cargo.lock packages/Cargo.toml ./
+# wasm-bindgen-cli en de wasm-bindgen-crate moeten exact dezelfde versie
+# hebben; lopen ze uiteen dan faalt de bindgen-stap verderop met een cryptische
+# melding of levert hij verkeerde bindings. Hier faalt het meteen, met de twee
+# versies en de vindplaats van de nieuwe checksums erbij.
+RUN set -eu; \
+    locked=$(grep -A1 '^name = "wasm-bindgen"$' Cargo.lock \
+      | sed -n '/^version = /{s/^version = "\(.*\)"$/\1/p;q;}'); \
+    if [ -z "$locked" ]; then \
+      echo "kon wasm-bindgen-versie niet uit packages/Cargo.lock lezen" >&2; exit 1; \
+    fi; \
+    if [ "$locked" != "${WASM_BINDGEN_VERSION}" ]; then \
+      echo "versie-mismatch: wasm-bindgen-cli is gepind op ${WASM_BINDGEN_VERSION}, packages/Cargo.lock heeft ${locked}." >&2; \
+      echo "Werk WASM_BINDGEN_VERSION en beide WASM_BINDGEN_SHA256_* in frontend/Dockerfile bij naar ${locked}; de checksums staan naast de release op" >&2; \
+      echo "  https://github.com/wasm-bindgen/wasm-bindgen/releases/tag/${locked}" >&2; \
+      exit 1; \
+    fi
 # Trim workspace members to engine + shared (the only crates the wasm build
 # needs); everything else is dropped so chef does not try to resolve their
 # source paths. The `grep` assertion fails the build loudly if
@@ -43,8 +80,29 @@ RUN npm run build -w frontend
 # Stage 2: Chef base
 # Rust version: keep in sync with rust-toolchain.toml (source of truth).
 FROM rust:1.96-alpine@sha256:2ea3db105d38fdfa4e31f366674287fcaa828087e2fe3973befdc537f2d443b1 AS chef
-RUN apk add --no-cache musl-dev
-RUN cargo install cargo-chef --locked
+RUN apk add --no-cache musl-dev curl xz
+# cargo-chef als officiële prebuilt binary van de releasepagina van het project,
+# in plaats van vanaf broncode te compileren. De sha256's zijn de gepubliceerde
+# .sha256-bestanden van diezelfde release; zonder die pin zou een gewijzigd of
+# afgebroken artefact ongemerkt de build in glijden.
+ARG TARGETARCH
+ARG CARGO_CHEF_VERSION=0.1.77
+ARG CARGO_CHEF_SHA256_AMD64=a3733ab416c3ffddd37914cd13919ca05fee1a1cf654f3016dcfe7f399d89cd1
+ARG CARGO_CHEF_SHA256_ARM64=3bff2e7ff979db837c7e820dfd8d51d2d97b9c94283506c6e596ae4887ef178b
+RUN set -eu; \
+    case "${TARGETARCH:-}" in \
+      amd64) arch=x86_64; sha="${CARGO_CHEF_SHA256_AMD64}" ;; \
+      arm64) arch=aarch64; sha="${CARGO_CHEF_SHA256_ARM64}" ;; \
+      *) echo "geen gepinde cargo-chef-binary voor TARGETARCH='${TARGETARCH:-}'" >&2; exit 1 ;; \
+    esac; \
+    dir="cargo-chef-${arch}-unknown-linux-musl"; \
+    curl -fsSLo "/tmp/${dir}.tar.xz" \
+      "https://github.com/LukeMathWalker/cargo-chef/releases/download/v${CARGO_CHEF_VERSION}/${dir}.tar.xz"; \
+    echo "${sha}  /tmp/${dir}.tar.xz" | sha256sum -c -; \
+    tar -xJf "/tmp/${dir}.tar.xz" -C /tmp; \
+    install -m0755 "/tmp/${dir}/cargo-chef" /usr/local/bin/cargo-chef; \
+    rm -rf "/tmp/${dir}.tar.xz" "/tmp/${dir}"; \
+    cargo chef --version
 WORKDIR /build
 
 # Stage 3: Plan dependencies

--- a/packages/admin/Dockerfile
+++ b/packages/admin/Dockerfile
@@ -7,8 +7,29 @@
 # Stage 1: Chef base
 # Rust version: keep in sync with rust-toolchain.toml (source of truth).
 FROM rust:1.96-alpine@sha256:a41f7740f8b45d45795624eec13a8b42263cc700f19f7e4e86e04d3dda08a479 AS chef
-RUN apk add --no-cache musl-dev
-RUN cargo install cargo-chef --locked
+RUN apk add --no-cache musl-dev curl xz
+# cargo-chef als officiële prebuilt binary van de releasepagina van het project,
+# in plaats van vanaf broncode te compileren. De sha256's zijn de gepubliceerde
+# .sha256-bestanden van diezelfde release; zonder die pin zou een gewijzigd of
+# afgebroken artefact ongemerkt de build in glijden.
+ARG TARGETARCH
+ARG CARGO_CHEF_VERSION=0.1.77
+ARG CARGO_CHEF_SHA256_AMD64=a3733ab416c3ffddd37914cd13919ca05fee1a1cf654f3016dcfe7f399d89cd1
+ARG CARGO_CHEF_SHA256_ARM64=3bff2e7ff979db837c7e820dfd8d51d2d97b9c94283506c6e596ae4887ef178b
+RUN set -eu; \
+    case "${TARGETARCH:-}" in \
+      amd64) arch=x86_64; sha="${CARGO_CHEF_SHA256_AMD64}" ;; \
+      arm64) arch=aarch64; sha="${CARGO_CHEF_SHA256_ARM64}" ;; \
+      *) echo "geen gepinde cargo-chef-binary voor TARGETARCH='${TARGETARCH:-}'" >&2; exit 1 ;; \
+    esac; \
+    dir="cargo-chef-${arch}-unknown-linux-musl"; \
+    curl -fsSLo "/tmp/${dir}.tar.xz" \
+      "https://github.com/LukeMathWalker/cargo-chef/releases/download/v${CARGO_CHEF_VERSION}/${dir}.tar.xz"; \
+    echo "${sha}  /tmp/${dir}.tar.xz" | sha256sum -c -; \
+    tar -xJf "/tmp/${dir}.tar.xz" -C /tmp; \
+    install -m0755 "/tmp/${dir}/cargo-chef" /usr/local/bin/cargo-chef; \
+    rm -rf "/tmp/${dir}.tar.xz" "/tmp/${dir}"; \
+    cargo chef --version
 WORKDIR /build
 
 # Stage 2: Plan dependencies

--- a/packages/pipeline/Dockerfile
+++ b/packages/pipeline/Dockerfile
@@ -18,8 +18,29 @@
 # Stage 1: Chef base
 # Rust version: keep in sync with rust-toolchain.toml (source of truth).
 FROM rust:1.96-alpine@sha256:a41f7740f8b45d45795624eec13a8b42263cc700f19f7e4e86e04d3dda08a479 AS chef
-RUN apk add --no-cache musl-dev
-RUN cargo install cargo-chef --locked
+RUN apk add --no-cache musl-dev curl xz
+# cargo-chef als officiële prebuilt binary van de releasepagina van het project,
+# in plaats van vanaf broncode te compileren. De sha256's zijn de gepubliceerde
+# .sha256-bestanden van diezelfde release; zonder die pin zou een gewijzigd of
+# afgebroken artefact ongemerkt de build in glijden.
+ARG TARGETARCH
+ARG CARGO_CHEF_VERSION=0.1.77
+ARG CARGO_CHEF_SHA256_AMD64=a3733ab416c3ffddd37914cd13919ca05fee1a1cf654f3016dcfe7f399d89cd1
+ARG CARGO_CHEF_SHA256_ARM64=3bff2e7ff979db837c7e820dfd8d51d2d97b9c94283506c6e596ae4887ef178b
+RUN set -eu; \
+    case "${TARGETARCH:-}" in \
+      amd64) arch=x86_64; sha="${CARGO_CHEF_SHA256_AMD64}" ;; \
+      arm64) arch=aarch64; sha="${CARGO_CHEF_SHA256_ARM64}" ;; \
+      *) echo "geen gepinde cargo-chef-binary voor TARGETARCH='${TARGETARCH:-}'" >&2; exit 1 ;; \
+    esac; \
+    dir="cargo-chef-${arch}-unknown-linux-musl"; \
+    curl -fsSLo "/tmp/${dir}.tar.xz" \
+      "https://github.com/LukeMathWalker/cargo-chef/releases/download/v${CARGO_CHEF_VERSION}/${dir}.tar.xz"; \
+    echo "${sha}  /tmp/${dir}.tar.xz" | sha256sum -c -; \
+    tar -xJf "/tmp/${dir}.tar.xz" -C /tmp; \
+    install -m0755 "/tmp/${dir}/cargo-chef" /usr/local/bin/cargo-chef; \
+    rm -rf "/tmp/${dir}.tar.xz" "/tmp/${dir}"; \
+    cargo chef --version
 WORKDIR /build
 
 # Stage 2: Plan dependencies

--- a/script/check-tool-pins.sh
+++ b/script/check-tool-pins.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# De cargo-chef-pin (versie + beide checksums) staat in drie Dockerfiles.
+# Uiteenlopen is stil: de build die de verkeerde pin heeft faalt pas als iemand
+# dat image toevallig koud bouwt, en dan met een checksum-fout zonder oorzaak.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+files=(frontend/Dockerfile packages/admin/Dockerfile packages/pipeline/Dockerfile)
+reference=""
+status=0
+
+for f in "${files[@]}"; do
+    pins=$(grep -E '^ARG CARGO_CHEF_(VERSION|SHA256_[A-Z0-9]+)=' "$f" | sort)
+    if [ -z "$pins" ]; then
+        echo "FOUT: $f heeft geen ARG CARGO_CHEF_*-regels" >&2
+        status=1
+        continue
+    fi
+    if [ -z "$reference" ]; then
+        reference="$pins"
+        reference_file="$f"
+    elif [ "$pins" != "$reference" ]; then
+        echo "FOUT: de cargo-chef-pin in $f wijkt af van die in $reference_file:" >&2
+        diff <(echo "$reference") <(echo "$pins") >&2 || true
+        status=1
+    fi
+done
+
+if [ "$status" -eq 0 ]; then
+    echo "cargo-chef-pin is gelijk in ${#files[@]} Dockerfiles"
+fi
+exit "$status"


### PR DESCRIPTION
De Docker-builds compileerden `cargo-chef` en `wasm-bindgen-cli` elke keer vanaf broncode. Op een warme cache merk je dat niet, maar na een base-image-bump is de cache koud, en op een runner kostten die twee stappen samen ruim elf minuten. Beide projecten publiceren officiële musl-binaries; die worden nu opgehaald, gepind op een exacte versie en een sha256 uit dezelfde release, per architectuur zodat lokaal bouwen op Apple Silicon blijft werken. De output is gecontroleerd en byte-gelijk, op twaalf bytes `producers`-metadata in de `.wasm` na.

`wasm-bindgen-cli` moet exact meelopen met de `wasm-bindgen`-crate uit `packages/Cargo.lock`; dat was een hardgecodeerde versie zonder verband en is nu een assertie die de build meteen laat falen, met beide versies in de melding. Een HTTP-fout, een checksum die niet klopt of een architectuur zonder pin laat de build eveneens falen.