### PR TITLE
fix(github): stille gaten uit de leespaden van #1147

### DIFF
--- a/packages/corpus/src/github_api_backend.rs
+++ b/packages/corpus/src/github_api_backend.rs
@@ -25,6 +25,25 @@
 //! surfaced as [`CorpusError::Conflict`] for the caller to deal with.
 //! For `save_annotations`'s append-only flow this is safe because dedup
 //! happens against the freshly-read base before re-writing.
+//!
+//! ### Known gap: a branch minted by someone else
+//!
+//! A read that lands before the traject branch exists is told "absent",
+//! and the branch is then seeded from base, so the file may hold base
+//! content the read never saw. `persist` refuses to adopt such a file
+//! (`may_adopt_existing` in [`try_put`]) — but only when *this* backend
+//! instance minted the branch. A second replica or session minting it
+//! between this instance's read and its persist leaves the same window
+//! open, and nothing here notices.
+//!
+//! Closing it takes a compare-and-set against the branch tip, which the
+//! Contents API does not offer: its `sha` parameter guards the blob, not
+//! the ref. That means moving writes to the Git Data API (blob → tree →
+//! commit → `PATCH /git/refs` with the expected old sha), the same rework
+//! the multi-file atomicity gap above needs. Until then the gap is real
+//! and unguarded; it is narrow (the branch is minted on first activation,
+//! by whoever gets there first) and it fails loudly on the far more
+//! common single-instance path.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -773,10 +792,9 @@ impl RepoBackend for GitHubApiBackend {
         // (notes) would come back holding only the new entry. So a write
         // whose own read saw absence is create-only here.
         //
-        // Residual: this catches the branch *we* mint. Another replica
-        // minting it between our read and our persist leaves the same
-        // window open, which only a compare-and-set against the branch
-        // tip would close.
+        // This catches the branch *we* mint, and only that one — see the
+        // "known gap" section in the module docs for the window a branch
+        // minted elsewhere leaves open, and what it takes to close it.
         let mut branch_just_created = false;
         if !inner.branch_ready {
             branch_just_created = Self::ensure_branch(
@@ -942,6 +960,10 @@ impl RepoBackend for GitHubApiBackend {
 /// on it). It is refused when the branch was just seeded from base,
 /// because then "already there" means base content the caller never read,
 /// and adopting it replaces that content instead of building on it.
+///
+/// The caller derives that flag from its own `ensure_branch` call, so a
+/// branch minted by another instance does not set it — the module docs'
+/// "known gap" section names what that leaves open.
 #[allow(clippy::too_many_arguments)]
 async fn try_put(
     client: &GithubClient,
@@ -994,7 +1016,8 @@ async fn try_put(
                 "refusing to overwrite base content on a freshly created branch"
             );
             Err(CorpusError::Conflict(format!(
-                "'{path}' already exists on the branch that was just created from base;                  the write was prepared against a branch that did not exist yet"
+                "'{path}' already exists on the branch that was just created from base; \
+                 the write was prepared against a branch that did not exist yet"
             )))
         }
         Err(e) if is_unsigned_existing_file(&e) => {

--- a/packages/corpus/src/implements_index.rs
+++ b/packages/corpus/src/implements_index.rs
@@ -106,7 +106,7 @@ impl ImplementsIndex {
         // verify. Such a file can only be a mistake; refuse it here so a
         // consumer falls back instead of reasoning about it. The generator
         // refuses to produce one for the same reason.
-        if index.root.trim_matches('/').is_empty() {
+        if normalise_root(&index.root).is_empty() {
             return Err(CorpusError::Config(
                 "implements index is rooted at the repo root, where its own file \
                  invalidates the tree sha it records"
@@ -194,6 +194,7 @@ pub struct ScanFailure {
     pub path: String,
     /// The error, for the generator's failure report.
     pub error: String,
+    /// Whether one file was lost or a whole directory went unseen.
     pub kind: ScanFailureKind,
 }
 
@@ -217,17 +218,7 @@ pub struct ScanOutcome {
 /// consistent with the backend tree walks and the tarball extraction
 /// (which only reads regular entries).
 pub fn scan_tree(repo_root: &Path, scan_root: &str) -> Result<ScanOutcome> {
-    // Normalised before it is joined: `Path::join` with an absolute path
-    // discards `repo_root` entirely, so a `--root /regulation` would scan
-    // an absolute filesystem path outside the checkout. `covers` and
-    // `to_source_relative` treat a leading slash as decorative, and this
-    // has to agree with them.
-    let scan_root = normalise_root(scan_root);
-    if scan_root.split('/').any(|segment| segment == "..") {
-        return Err(CorpusError::Config(format!(
-            "scan root must stay inside the repository, not climb out of it: '{scan_root}'"
-        )));
-    }
+    let scan_root = normalised_scan_root(scan_root)?;
     let abs_root = repo_root.join(&scan_root);
     if !abs_root.is_dir() {
         return Err(CorpusError::Config(format!(
@@ -298,6 +289,24 @@ pub fn scan_tree(repo_root: &Path, scan_root: &str) -> Result<ScanOutcome> {
     }
 
     Ok(ScanOutcome { files, failures })
+}
+
+/// The scan root in the one spelling everything downstream assumes:
+/// normalised, and inside the repository.
+///
+/// Normalising before the root is joined onto the checkout is what keeps
+/// the scan there at all — `Path::join` with an absolute path discards
+/// what it was joined to, so an unnormalised `/regulation` would walk an
+/// absolute filesystem path. A `..` cannot be normalised away without
+/// changing which directory is meant, so it is refused instead.
+pub fn normalised_scan_root(root: &str) -> Result<String> {
+    let root = normalise_root(root);
+    if root.split('/').any(|segment| segment == "..") {
+        return Err(CorpusError::Config(format!(
+            "scan root must stay inside the repository, not climb out of it: '{root}'"
+        )));
+    }
+    Ok(root)
 }
 
 /// Collapse a scan root to the form the consumer compares and strips with:
@@ -430,16 +439,30 @@ articles:
             .contains_key("regulation/nl/wet/wet_ok/2025-01-01.yaml"));
     }
 
-    /// Make `path` unreadable for the duration of `body`, restoring the
-    /// mode afterwards so `TempDir::drop` can still clean up.
+    /// Restores the mode of a directory the test made unreadable. A
+    /// `Drop` guard rather than a call after the body: a failing assertion
+    /// inside the body would otherwise leave a 0o000 directory that
+    /// `TempDir` cannot clean up.
     #[cfg(unix)]
-    pub(super) fn while_unreadable<T>(path: &Path, body: impl FnOnce() -> T) -> T {
+    pub(super) struct Unreadable<'a> {
+        path: &'a Path,
+        original: fs::Permissions,
+    }
+
+    #[cfg(unix)]
+    impl Drop for Unreadable<'_> {
+        fn drop(&mut self) {
+            let _ = fs::set_permissions(self.path, self.original.clone());
+        }
+    }
+
+    /// Make `path` unreadable until the returned guard is dropped.
+    #[cfg(unix)]
+    pub(super) fn make_unreadable(path: &Path) -> Unreadable<'_> {
         use std::os::unix::fs::PermissionsExt;
         let original = fs::metadata(path).unwrap().permissions();
         fs::set_permissions(path, fs::Permissions::from_mode(0o000)).unwrap();
-        let out = body();
-        fs::set_permissions(path, original).unwrap();
-        out
+        Unreadable { path, original }
     }
 
     /// Whether mode bits actually keep *this* process out of a directory.
@@ -447,17 +470,19 @@ articles:
     /// the unreadable-directory tests would assert a failure that cannot
     /// occur, so they skip instead of failing for the wrong reason.
     #[cfg(unix)]
-    pub(super) fn directory_permissions_bite(scratch: &Path) -> bool {
-        let probe = scratch.join("permission-probe");
+    pub(super) fn directory_permissions_bite() -> bool {
+        let scratch = TempDir::new().unwrap();
+        let probe = scratch.path().join("probe");
         fs::create_dir_all(&probe).unwrap();
-        while_unreadable(&probe, || fs::read_dir(&probe).is_err())
+        let _locked = make_unreadable(&probe);
+        fs::read_dir(&probe).is_err()
     }
 
     #[cfg(unix)]
     #[test]
     fn an_unreadable_directory_is_a_scan_failure_not_a_silent_hole() {
         let dir = TempDir::new().unwrap();
-        if !directory_permissions_bite(dir.path()) {
+        if !directory_permissions_bite() {
             eprintln!("skipped: this process reads directories regardless of mode bits");
             return;
         }
@@ -473,33 +498,32 @@ articles:
         );
 
         let locked = dir.path().join("regulation/nl/geheim");
-        while_unreadable(&locked, || {
-            let outcome = scan_tree(dir.path(), "regulation").unwrap();
+        let _guard = make_unreadable(&locked);
+        let outcome = scan_tree(dir.path(), "regulation").unwrap();
 
-            // The laws behind the locked directory are gone from the index
-            // either way; what must not happen is that they go quietly.
-            assert!(!outcome.files.keys().any(|k| k.contains("wet_weg")));
-            let walk: Vec<&ScanFailure> = outcome
-                .failures
-                .iter()
-                .filter(|f| f.kind == ScanFailureKind::Walk)
-                .collect();
-            assert_eq!(
-                walk.len(),
-                1,
-                "an unreadable directory must surface as a failure, got {:?}",
-                outcome.failures
-            );
-            assert!(
-                walk[0].path.contains("geheim"),
-                "the failure must name the directory: {:?}",
-                walk[0]
-            );
-            // The readable half is still indexed.
-            assert!(outcome
-                .files
-                .contains_key("regulation/nl/wet/wet_ok/2025-01-01.yaml"));
-        });
+        // The laws behind the locked directory are gone from the index
+        // either way; what must not happen is that they go quietly.
+        assert!(!outcome.files.keys().any(|k| k.contains("wet_weg")));
+        let walk: Vec<&ScanFailure> = outcome
+            .failures
+            .iter()
+            .filter(|f| f.kind == ScanFailureKind::Walk)
+            .collect();
+        assert_eq!(
+            walk.len(),
+            1,
+            "an unreadable directory must surface as a failure, got {:?}",
+            outcome.failures
+        );
+        assert!(
+            walk[0].path.contains("geheim"),
+            "the failure must name the directory: {:?}",
+            walk[0]
+        );
+        // The readable half is still indexed.
+        assert!(outcome
+            .files
+            .contains_key("regulation/nl/wet/wet_ok/2025-01-01.yaml"));
     }
 
     #[test]

--- a/packages/corpus/src/implements_index.rs
+++ b/packages/corpus/src/implements_index.rs
@@ -170,14 +170,31 @@ impl ImplementsIndex {
     }
 }
 
-/// One file the scan could not parse. Recorded instead of silently
-/// indexing the file as "implements nothing".
+/// What kind of loss a [`ScanFailure`] represents. The two are gated
+/// differently by the generator: a per-file failure names exactly one path
+/// that stays out of the index, a walk failure names a directory whose
+/// contents were never enumerated at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScanFailureKind {
+    /// A known `.yaml`/`.yml` file that could not be read or parsed. The
+    /// loss is exactly one path, and a path missing from the index means
+    /// "fetch and parse this law" — the behaviour without an index.
+    File,
+    /// A directory the walk could not enter (permissions, a vanished
+    /// path). How many laws are behind it is unknown, so the ratio net
+    /// over per-file failures says nothing about the size of this hole.
+    Walk,
+}
+
+/// One thing the scan could not take in. Recorded instead of silently
+/// indexing a file as "implements nothing" or dropping a subtree.
 #[derive(Debug)]
 pub struct ScanFailure {
-    /// Repo-relative path of the failing file.
+    /// Repo-relative path of the failing file or directory.
     pub path: String,
-    /// The parse error, for the generator's failure report.
+    /// The error, for the generator's failure report.
     pub error: String,
+    pub kind: ScanFailureKind,
 }
 
 /// Result of [`scan_tree`]: the per-file entries plus every file that
@@ -200,7 +217,18 @@ pub struct ScanOutcome {
 /// consistent with the backend tree walks and the tarball extraction
 /// (which only reads regular entries).
 pub fn scan_tree(repo_root: &Path, scan_root: &str) -> Result<ScanOutcome> {
-    let abs_root = repo_root.join(scan_root);
+    // Normalised before it is joined: `Path::join` with an absolute path
+    // discards `repo_root` entirely, so a `--root /regulation` would scan
+    // an absolute filesystem path outside the checkout. `covers` and
+    // `to_source_relative` treat a leading slash as decorative, and this
+    // has to agree with them.
+    let scan_root = normalise_root(scan_root);
+    if scan_root.split('/').any(|segment| segment == "..") {
+        return Err(CorpusError::Config(format!(
+            "scan root must stay inside the repository, not climb out of it: '{scan_root}'"
+        )));
+    }
+    let abs_root = repo_root.join(&scan_root);
     if !abs_root.is_dir() {
         return Err(CorpusError::Config(format!(
             "scan root does not exist or is not a directory: {}",
@@ -211,10 +239,26 @@ pub fn scan_tree(repo_root: &Path, scan_root: &str) -> Result<ScanOutcome> {
     let mut files = BTreeMap::new();
     let mut failures = Vec::new();
 
-    for entry in walkdir::WalkDir::new(&abs_root)
-        .into_iter()
-        .filter_map(|e| e.ok())
-    {
+    for entry in walkdir::WalkDir::new(&abs_root) {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(e) => {
+                // A directory the walk cannot enter takes an unknown
+                // number of laws with it. Dropping it here would produce
+                // an index that looks complete, which is the one thing
+                // this scan must never hand its consumer.
+                let path = e
+                    .path()
+                    .and_then(|p| repo_relative(repo_root, p))
+                    .unwrap_or_else(|| scan_root.clone());
+                failures.push(ScanFailure {
+                    path,
+                    error: format!("walk failed: {e}"),
+                    kind: ScanFailureKind::Walk,
+                });
+                continue;
+            }
+        };
         if !entry.file_type().is_file() {
             continue;
         }
@@ -226,18 +270,9 @@ pub fn scan_tree(repo_root: &Path, scan_root: &str) -> Result<ScanOutcome> {
         if !is_yaml {
             continue;
         }
-        // Repo-relative with forward slashes, matching git/GitHub paths.
-        let Ok(rel) = path.strip_prefix(repo_root) else {
+        let Some(rel) = repo_relative(repo_root, path) else {
             continue;
         };
-        let rel = rel
-            .components()
-            .filter_map(|c| match c {
-                std::path::Component::Normal(s) => s.to_str(),
-                _ => None,
-            })
-            .collect::<Vec<_>>()
-            .join("/");
 
         let content = match std::fs::read_to_string(path) {
             Ok(c) => c,
@@ -245,6 +280,7 @@ pub fn scan_tree(repo_root: &Path, scan_root: &str) -> Result<ScanOutcome> {
                 failures.push(ScanFailure {
                     path: rel,
                     error: format!("read failed: {e}"),
+                    kind: ScanFailureKind::File,
                 });
                 continue;
             }
@@ -256,11 +292,39 @@ pub fn scan_tree(repo_root: &Path, scan_root: &str) -> Result<ScanOutcome> {
             Err(e) => failures.push(ScanFailure {
                 path: rel,
                 error: e.to_string(),
+                kind: ScanFailureKind::File,
             }),
         }
     }
 
     Ok(ScanOutcome { files, failures })
+}
+
+/// Collapse a scan root to the form the consumer compares and strips with:
+/// no leading or trailing slash, no empty or `.` segment. Shared with the
+/// generator, which records the result in the index — the two must agree,
+/// or a root the index accepts strips no prefix and projects to an empty
+/// map that reads as "this corpus holds no laws".
+pub fn normalise_root(root: &str) -> String {
+    root.split('/')
+        .filter(|segment| !segment.is_empty() && *segment != ".")
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+/// `path` relative to `repo_root`, with forward slashes, matching
+/// git/GitHub paths. `None` when `path` lies outside `repo_root`.
+fn repo_relative(repo_root: &Path, path: &Path) -> Option<String> {
+    let rel = path.strip_prefix(repo_root).ok()?;
+    Some(
+        rel.components()
+            .filter_map(|c| match c {
+                std::path::Component::Normal(s) => s.to_str(),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("/"),
+    )
 }
 
 #[cfg(test)]
@@ -364,6 +428,114 @@ articles:
         assert!(outcome
             .files
             .contains_key("regulation/nl/wet/wet_ok/2025-01-01.yaml"));
+    }
+
+    /// Make `path` unreadable for the duration of `body`, restoring the
+    /// mode afterwards so `TempDir::drop` can still clean up.
+    #[cfg(unix)]
+    pub(super) fn while_unreadable<T>(path: &Path, body: impl FnOnce() -> T) -> T {
+        use std::os::unix::fs::PermissionsExt;
+        let original = fs::metadata(path).unwrap().permissions();
+        fs::set_permissions(path, fs::Permissions::from_mode(0o000)).unwrap();
+        let out = body();
+        fs::set_permissions(path, original).unwrap();
+        out
+    }
+
+    /// Whether mode bits actually keep *this* process out of a directory.
+    /// They don't for uid 0, and some CI images run tests as root — there
+    /// the unreadable-directory tests would assert a failure that cannot
+    /// occur, so they skip instead of failing for the wrong reason.
+    #[cfg(unix)]
+    pub(super) fn directory_permissions_bite(scratch: &Path) -> bool {
+        let probe = scratch.join("permission-probe");
+        fs::create_dir_all(&probe).unwrap();
+        while_unreadable(&probe, || fs::read_dir(&probe).is_err())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn an_unreadable_directory_is_a_scan_failure_not_a_silent_hole() {
+        let dir = TempDir::new().unwrap();
+        if !directory_permissions_bite(dir.path()) {
+            eprintln!("skipped: this process reads directories regardless of mode bits");
+            return;
+        }
+        write(
+            dir.path(),
+            "regulation/nl/wet/wet_ok/2025-01-01.yaml",
+            "$id: wet_ok\narticles: []\n",
+        );
+        write(
+            dir.path(),
+            "regulation/nl/geheim/wet_weg/2025-01-01.yaml",
+            "$id: wet_weg\narticles: []\n",
+        );
+
+        let locked = dir.path().join("regulation/nl/geheim");
+        while_unreadable(&locked, || {
+            let outcome = scan_tree(dir.path(), "regulation").unwrap();
+
+            // The laws behind the locked directory are gone from the index
+            // either way; what must not happen is that they go quietly.
+            assert!(!outcome.files.keys().any(|k| k.contains("wet_weg")));
+            let walk: Vec<&ScanFailure> = outcome
+                .failures
+                .iter()
+                .filter(|f| f.kind == ScanFailureKind::Walk)
+                .collect();
+            assert_eq!(
+                walk.len(),
+                1,
+                "an unreadable directory must surface as a failure, got {:?}",
+                outcome.failures
+            );
+            assert!(
+                walk[0].path.contains("geheim"),
+                "the failure must name the directory: {:?}",
+                walk[0]
+            );
+            // The readable half is still indexed.
+            assert!(outcome
+                .files
+                .contains_key("regulation/nl/wet/wet_ok/2025-01-01.yaml"));
+        });
+    }
+
+    #[test]
+    fn scan_root_is_normalised_before_it_is_joined() {
+        let dir = TempDir::new().unwrap();
+        write(
+            dir.path(),
+            "regulation/nl/wet/wet_ok/2025-01-01.yaml",
+            "$id: wet_ok\narticles: []\n",
+        );
+
+        // A leading slash is decorative for `covers`/`to_source_relative`,
+        // so it must be here too — `join` with an absolute path would drop
+        // `repo_root` and scan outside the checkout entirely.
+        for root in ["/regulation", "regulation/", "./regulation", "regulation//"] {
+            let outcome = scan_tree(dir.path(), root).unwrap();
+            assert_eq!(
+                outcome.files.len(),
+                1,
+                "root {root} must resolve inside the checkout"
+            );
+        }
+
+        assert!(scan_tree(dir.path(), "../etc").is_err());
+    }
+
+    #[test]
+    fn normalise_root_drops_decoration_and_current_dir() {
+        assert_eq!(normalise_root("regulation"), "regulation");
+        assert_eq!(normalise_root("/regulation/nl/"), "regulation/nl");
+        assert_eq!(normalise_root("regulation//nl"), "regulation/nl");
+        // `.` names the repo root exactly as `/` does; both must collapse
+        // to the empty root the generator refuses.
+        assert_eq!(normalise_root("."), "");
+        assert_eq!(normalise_root("./"), "");
+        assert_eq!(normalise_root("./regulation"), "regulation");
     }
 
     #[test]

--- a/packages/corpus/src/implements_index/generator.rs
+++ b/packages/corpus/src/implements_index/generator.rs
@@ -24,7 +24,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use super::{
-    normalise_root, scan_tree, ImplementsIndex, ScanFailure, ScanFailureKind,
+    normalised_scan_root, scan_tree, ImplementsIndex, ScanFailure, ScanFailureKind,
     IMPLEMENTS_INDEX_FILENAME, IMPLEMENTS_INDEX_VERSION,
 };
 
@@ -119,16 +119,16 @@ fn git(repo_root: &Path, args: &[&str]) -> Result<String, String> {
 /// tree, git error, unreadable index, an unreadable directory, systematic
 /// parse breakage); the caller maps it to exit code 2.
 pub fn run(args: &Args) -> Result<Outcome, String> {
+    // Normalised once, here: this is what git is asked about, what the
+    // scan walks, and what the index records for the consumer to compare
+    // and strip. All four have to agree on one spelling.
+    let scan_root = normalised_scan_root(&args.scan_root).map_err(|e| e.to_string())?;
     // An index over the repo root contains its own file, so writing it
     // changes the tree sha it just recorded and no consumer would ever
     // accept it. Refuse here rather than in the CLI's argument parsing:
-    // `Args` is public, so a library caller reaches this too. Normalised
-    // first, so `.` — which names the repo root just as `/` does — is
-    // caught by the same gate.
-    // Normalised once here: it is what gets recorded in the index (the
-    // consumer compares and strips it as a path prefix) and what git and
-    // the scan are asked about, so all four agree on one spelling.
-    let scan_root = normalise_root(&args.scan_root);
+    // `Args` is public, so a library caller reaches this too. `.` names
+    // that root as much as `/` does, and normalising is what makes both
+    // meet this gate.
     if scan_root.is_empty() {
         return Err(
             "scan root must name a subtree: an index rooted at the repo root contains \
@@ -337,13 +337,13 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn an_unwalkable_directory_is_fatal_however_few_files_it_hides() {
-        use super::super::tests::{directory_permissions_bite, while_unreadable};
+        use super::super::tests::{directory_permissions_bite, make_unreadable};
 
         // 20 readable laws against one locked directory: far under
         // `MAX_UNPARSEABLE_RATIO`, which is exactly why the ratio net
         // cannot be what catches this.
         let dir = fixture(20, 0);
-        if !directory_permissions_bite(dir.path()) {
+        if !directory_permissions_bite() {
             eprintln!("skipped: this process reads directories regardless of mode bits");
             return;
         }
@@ -355,7 +355,10 @@ mod tests {
         commit_all(dir.path(), "add a law that will be locked away");
 
         let locked = dir.path().join("regulation/nl/geheim");
-        let result = while_unreadable(&locked, || run(&Args::new(dir.path())));
+        let result = {
+            let _guard = make_unreadable(&locked);
+            run(&Args::new(dir.path()))
+        };
 
         let err = result.expect_err("an unwalkable directory must not yield an index");
         assert!(err.contains("could not be walked"), "unexpected: {err}");
@@ -366,9 +369,26 @@ mod tests {
     }
 
     #[test]
+    fn a_root_that_climbs_out_of_the_checkout_is_refused() {
+        let dir = TempDir::new().unwrap();
+        // `regulation/..` is the repo root, `../elders` is outside it
+        // entirely. Neither can be normalised into a subtree, so both are
+        // refused before git or the scan sees them.
+        for root in ["../elders", "regulation/.."] {
+            let args = Args {
+                scan_root: root.to_string(),
+                ..Args::new(dir.path())
+            };
+            let err = run(&args).expect_err("a scan may not climb out of the checkout");
+            assert!(err.contains("inside the repository"), "unexpected: {err}");
+        }
+    }
+
+    #[test]
     fn a_repo_root_scan_is_refused() {
         let dir = TempDir::new().unwrap();
-        // `.` names the repo root just as `""` and `/` do.
+        // `.` names the repo root as much as `""` and `/` do, and a root
+        // that names it can never verify.
         for root in ["", "/", ".", "./"] {
             let args = Args {
                 repo_root: dir.path().to_path_buf(),

--- a/packages/corpus/src/implements_index/generator.rs
+++ b/packages/corpus/src/implements_index/generator.rs
@@ -24,7 +24,8 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use super::{
-    scan_tree, ImplementsIndex, ScanFailure, IMPLEMENTS_INDEX_FILENAME, IMPLEMENTS_INDEX_VERSION,
+    normalise_root, scan_tree, ImplementsIndex, ScanFailure, ScanFailureKind,
+    IMPLEMENTS_INDEX_FILENAME, IMPLEMENTS_INDEX_VERSION,
 };
 
 /// Default subtree to scan, relative to the repo root.
@@ -115,23 +116,20 @@ fn git(repo_root: &Path, args: &[&str]) -> Result<String, String> {
 }
 
 /// Generate or verify the index. `Err` is an operational failure (dirty
-/// tree, git error, unreadable index, systematic parse breakage); the
-/// caller maps it to exit code 2.
-/// Collapse a scan root to the form the consumer compares and strips
-/// with: no leading or trailing slash, no empty interior segment.
-fn normalise_root(root: &str) -> String {
-    root.split('/')
-        .filter(|segment| !segment.is_empty())
-        .collect::<Vec<_>>()
-        .join("/")
-}
-
+/// tree, git error, unreadable index, an unreadable directory, systematic
+/// parse breakage); the caller maps it to exit code 2.
 pub fn run(args: &Args) -> Result<Outcome, String> {
     // An index over the repo root contains its own file, so writing it
     // changes the tree sha it just recorded and no consumer would ever
     // accept it. Refuse here rather than in the CLI's argument parsing:
-    // `Args` is public, so a library caller reaches this too.
-    if args.scan_root.trim_matches('/').is_empty() {
+    // `Args` is public, so a library caller reaches this too. Normalised
+    // first, so `.` — which names the repo root just as `/` does — is
+    // caught by the same gate.
+    // Normalised once here: it is what gets recorded in the index (the
+    // consumer compares and strips it as a path prefix) and what git and
+    // the scan are asked about, so all four agree on one spelling.
+    let scan_root = normalise_root(&args.scan_root);
+    if scan_root.is_empty() {
         return Err(
             "scan root must name a subtree: an index rooted at the repo root contains \
              its own file and so invalidates the tree sha it records"
@@ -143,24 +141,47 @@ pub fn run(args: &Args) -> Result<Outcome, String> {
     // has no uncommitted changes. Refuse a dirty subtree — no bypass.
     let dirty = git(
         &args.repo_root,
-        &["status", "--porcelain", "--", &args.scan_root],
+        &["status", "--porcelain", "--", &scan_root],
     )?;
     if !dirty.is_empty() {
         return Err(format!(
-            "scan subtree '{}' has uncommitted changes; commit or stash them first \
-             (the recorded tree sha must describe exactly what was scanned):\n{dirty}",
-            args.scan_root
+            "scan subtree '{scan_root}' has uncommitted changes; commit or stash them \
+             first (the recorded tree sha must describe exactly what was scanned):\n{dirty}"
         ));
     }
 
     let tree_sha = git(
         &args.repo_root,
-        &["rev-parse", &format!("HEAD:{}", args.scan_root)],
+        &["rev-parse", &format!("HEAD:{scan_root}")],
     )
-    .map_err(|e| format!("cannot resolve tree sha of '{}': {e}", args.scan_root))?;
+    .map_err(|e| format!("cannot resolve tree sha of '{scan_root}': {e}"))?;
 
     let outcome =
-        scan_tree(&args.repo_root, &args.scan_root).map_err(|e| format!("scan failed: {e}"))?;
+        scan_tree(&args.repo_root, &scan_root).map_err(|e| format!("scan failed: {e}"))?;
+
+    // A directory the walk could not enter is not corpus noise: how many
+    // laws it holds is unknown, so no ratio over the files we *did* see
+    // bounds the hole. Refuse rather than emit an index that omits a
+    // subtree while reporting success.
+    let unwalkable: Vec<&ScanFailure> = outcome
+        .failures
+        .iter()
+        .filter(|f| f.kind == ScanFailureKind::Walk)
+        .collect();
+    if !unwalkable.is_empty() {
+        let listed = unwalkable
+            .iter()
+            .map(|f| format!("  {}: {}", f.path, f.error))
+            .collect::<Vec<_>>()
+            .join("\n");
+        return Err(format!(
+            "{} director{} under '{scan_root}' could not be walked, so an unknown number \
+             of laws was never seen; refusing to emit an index that would look \
+             complete:\n{listed}",
+            unwalkable.len(),
+            if unwalkable.len() == 1 { "y" } else { "ies" }
+        ));
+    }
 
     let scanned = outcome.files.len() + outcome.failures.len();
     let failed = outcome.failures.len();
@@ -172,10 +193,9 @@ pub fn run(args: &Args) -> Result<Outcome, String> {
     };
     if ratio > MAX_UNPARSEABLE_RATIO {
         return Err(format!(
-            "{failed} of {scanned} files under '{}' failed to parse ({:.1}%, limit {:.0}%) — \
-             that is a systematic failure, not corpus noise; refusing to emit an index \
-             that would omit them all",
-            args.scan_root,
+            "{failed} of {scanned} files under '{scan_root}' failed to parse \
+             ({:.1}%, limit {:.0}%) — that is a systematic failure, not corpus noise; \
+             refusing to emit an index that would omit them all",
             ratio * 100.0,
             MAX_UNPARSEABLE_RATIO * 100.0
         ));
@@ -184,12 +204,7 @@ pub fn run(args: &Args) -> Result<Outcome, String> {
     let declaring = outcome.files.values().filter(|v| !v.is_empty()).count();
     let index = ImplementsIndex {
         version: IMPLEMENTS_INDEX_VERSION,
-        // Normalised, because the consumer compares this root against a
-        // source root and strips it as a path prefix. A stored `foo//bar`
-        // or `/foo/bar` would pass the coverage check and then strip
-        // nothing, projecting to an empty map that reads as "this corpus
-        // holds no laws".
-        root: normalise_root(&args.scan_root),
+        root: scan_root,
         tree_sha,
         files: outcome.files,
     };
@@ -309,15 +324,52 @@ mod tests {
 
     #[test]
     fn the_recorded_root_is_normalised() {
-        assert_eq!(normalise_root("regulation"), "regulation");
-        assert_eq!(normalise_root("/regulation/nl/"), "regulation/nl");
-        assert_eq!(normalise_root("regulation//nl"), "regulation/nl");
+        let dir = fixture(1, 0);
+        let args = Args {
+            scan_root: "/regulation/".to_string(),
+            ..Args::new(dir.path())
+        };
+        run(&args).unwrap();
+        let raw = fs::read_to_string(dir.path().join(IMPLEMENTS_INDEX_FILENAME)).unwrap();
+        assert_eq!(ImplementsIndex::parse(&raw).unwrap().root, "regulation");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn an_unwalkable_directory_is_fatal_however_few_files_it_hides() {
+        use super::super::tests::{directory_permissions_bite, while_unreadable};
+
+        // 20 readable laws against one locked directory: far under
+        // `MAX_UNPARSEABLE_RATIO`, which is exactly why the ratio net
+        // cannot be what catches this.
+        let dir = fixture(20, 0);
+        if !directory_permissions_bite(dir.path()) {
+            eprintln!("skipped: this process reads directories regardless of mode bits");
+            return;
+        }
+        write(
+            dir.path(),
+            "regulation/nl/geheim/wet_weg/2025-01-01.yaml",
+            "$id: wet_weg\narticles: []\n",
+        );
+        commit_all(dir.path(), "add a law that will be locked away");
+
+        let locked = dir.path().join("regulation/nl/geheim");
+        let result = while_unreadable(&locked, || run(&Args::new(dir.path())));
+
+        let err = result.expect_err("an unwalkable directory must not yield an index");
+        assert!(err.contains("could not be walked"), "unexpected: {err}");
+        assert!(
+            !dir.path().join(IMPLEMENTS_INDEX_FILENAME).exists(),
+            "no index may be written when part of the tree was never seen"
+        );
     }
 
     #[test]
     fn a_repo_root_scan_is_refused() {
         let dir = TempDir::new().unwrap();
-        for root in ["", "/"] {
+        // `.` names the repo root just as `""` and `/` do.
+        for root in ["", "/", ".", "./"] {
             let args = Args {
                 repo_root: dir.path().to_path_buf(),
                 scan_root: root.to_string(),

--- a/packages/corpus/tests/github_api_backend.rs
+++ b/packages/corpus/tests/github_api_backend.rs
@@ -821,4 +821,15 @@ async fn a_write_after_creating_the_branch_does_not_overwrite_base_content() {
         matches!(err, regelrecht_corpus::error::CorpusError::Conflict(_)),
         "a caller can redo a conflict; it cannot undo a silent overwrite: {err}"
     );
+    // The message reaches an editor and the logs, so it has to read as a
+    // sentence — a line-wrapped literal leaves a run of spaces in the middle.
+    let message = err.to_string();
+    assert!(
+        !message.contains("  "),
+        "the message must not carry a run of spaces: {message}"
+    );
+    assert!(
+        message.contains("did not exist yet"),
+        "the message must say why the write was refused: {message}"
+    );
 }

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -1584,8 +1584,26 @@ async fn resolve_backend_for_law(
             continue;
         }
         let backend = entry.backend.lock().await;
-        let exists = backend.read_file(law_rel).await.ok().flatten().is_some();
+        let read = backend.read_file(law_rel).await;
         drop(backend);
+        // A failed read is not "this source doesn't hold the law". The
+        // candidate is still skipped — another one may serve the write,
+        // and failing the whole resolve on one unreachable source would be
+        // worse — but the reason has to reach the logs, or a fallback that
+        // silently stopped matching is undiagnosable.
+        let exists = match read {
+            Ok(found) => found.is_some(),
+            Err(e) => {
+                tracing::warn!(
+                    law_id = %law_id,
+                    candidate_source = %source_id,
+                    error = %e,
+                    "could not read the law from a candidate source; skipping it as a \
+                     write target without knowing whether it holds the law"
+                );
+                false
+            }
+        };
         if exists {
             tracing::warn!(
                 law_id = %law_id,

--- a/packages/github/Cargo.toml
+++ b/packages/github/Cargo.toml
@@ -17,6 +17,9 @@ categories = ["api-bindings"]
 # TLS stack.
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 bytes = "1"
+# `sync`: the per-repo probe gate is held across an await, which a
+# `std::sync::Mutex` cannot be. No runtime, no macros.
+tokio = { workspace = true, features = ["sync"] }
 base64.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/packages/github/src/client.rs
+++ b/packages/github/src/client.rs
@@ -23,9 +23,11 @@
 //!   what makes the 304 path safe: there is never an ETag whose body was
 //!   dropped, so a 304 can never degrade into "empty" or "does not exist".
 //!
-//! Both caches are keyed per (url, token identity): a conditional request
-//! authenticated as a different principal must not be answered from another
-//! principal's cache entry. The token itself is never stored — only a hash.
+//! Both caches are keyed per (url, token identity), so one principal's
+//! entries do not answer another principal's reads. The token itself is
+//! never stored, only a 64-bit non-cryptographic hash of it; what actually
+//! keeps a body away from a credential that may not read it is GitHub
+//! revalidating every hit — see [`cache_key`](GithubClient::cache_key).
 //!
 //! The response cache never serves content without asking GitHub first: it
 //! only turns a 200 into a 304, which costs no rate-limit quota. It can
@@ -37,7 +39,7 @@
 use std::collections::hash_map::DefaultHasher;
 use std::collections::{HashMap, VecDeque};
 use std::hash::{Hash, Hasher};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, USER_AGENT};
@@ -57,6 +59,60 @@ use crate::error::{GithubError, Result};
 /// session re-reads across snapshot rebuilds, which is where the
 /// rate-limit saving is.
 pub const RESPONSE_CACHE_BUDGET_BYTES: usize = 8 * 1024 * 1024;
+
+/// Entry cap for the two small key→flag/ETag maps. Both are keyed per
+/// `(url or repo, token identity)`, and the token identity is what makes
+/// the key space grow: a long-lived editor process reads on behalf of
+/// every user that opens a traject, so each new user opens a new set of
+/// keys for the same handful of URLs. The entries themselves are tiny
+/// (an ETag, a bool), so the cap is about the key space, not the payload —
+/// hence a count rather than the byte budget the response cache uses.
+/// Oldest-inserted entries are dropped first; both maps are caches whose
+/// miss path is a plain request.
+pub const KEY_CACHE_MAX_ENTRIES: usize = 4096;
+
+/// A `String`-keyed map with a hard entry cap, oldest insertion evicted
+/// first. Re-inserting a key updates its value and leaves its place in the
+/// eviction order alone — an entry that keeps being refreshed still ages
+/// out, which for these two caches costs one request.
+struct BoundedMap<V> {
+    entries: HashMap<String, V>,
+    order: VecDeque<String>,
+    cap: usize,
+}
+
+impl<V> Default for BoundedMap<V> {
+    fn default() -> Self {
+        Self {
+            entries: HashMap::new(),
+            order: VecDeque::new(),
+            cap: KEY_CACHE_MAX_ENTRIES,
+        }
+    }
+}
+
+impl<V> BoundedMap<V> {
+    fn get(&self, key: &str) -> Option<&V> {
+        self.entries.get(key)
+    }
+
+    fn insert(&mut self, key: &str, value: V) {
+        if self.entries.insert(key.to_string(), value).is_some() {
+            return;
+        }
+        self.order.push_back(key.to_string());
+        while self.order.len() > self.cap {
+            if let Some(oldest) = self.order.pop_front() {
+                self.entries.remove(&oldest);
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
 
 /// User-Agent sent on every request, so GitHub audit logs attribute reads and
 /// writes to this client uniformly (the three hand-rolled predecessors each
@@ -127,7 +183,7 @@ pub(crate) struct CachedResponse {
 struct ClientState {
     /// ETag cache: cache key → last ETag value. Feeds `If-None-Match` on
     /// the Trees read so an unchanged tree comes back as a cheap 304.
-    etag_cache: HashMap<String, String>,
+    etag_cache: BoundedMap<String>,
     /// Conditional-GET cache for the Contents reads: cache key → ETag +
     /// the payload it belongs to.
     response_cache: HashMap<String, CachedResponse>,
@@ -142,7 +198,12 @@ struct ClientState {
     /// see `GithubClient::confirm_absence`. Both answers are remembered:
     /// the negative one especially, because that is the case where every
     /// single read 404s and would otherwise re-probe forever.
-    repo_readable: HashMap<String, bool>,
+    repo_readable: BoundedMap<bool>,
+    /// One gate per `(repo, token identity)` for the readability probe, so
+    /// callers that miss the answer at the same moment queue behind one
+    /// lookup instead of each issuing their own. Entries are dropped once
+    /// nobody holds them any more.
+    repo_probe_gates: HashMap<String, Arc<tokio::sync::Mutex<()>>>,
     /// Most recent `x-ratelimit-remaining` seen on any response.
     rate_limit_remaining: Option<u32>,
 }
@@ -292,8 +353,16 @@ impl GithubClient {
     /// Cache key for a conditional GET: the URL, the representation asked
     /// for, and the identity of the token it is made with.
     ///
-    /// The token is part of the key so a 304 can never hand one principal a
-    /// body fetched under another's credential; it is hashed, never stored.
+    /// The token is part of the key so one principal's entries do not
+    /// answer another principal's reads; it is hashed, never stored. The
+    /// hash is `DefaultHasher` — 64 bits, unkeyed, not cryptographic — so
+    /// the separation it gives is compartmenting, not a security boundary:
+    /// two distinct tokens colliding into one key is astronomically
+    /// unlikely but not excluded. What does bound the damage is that the
+    /// entry is never served on its own. Every hit is revalidated against
+    /// GitHub with the caller's own credential, so a credential that may
+    /// not read the resource gets a 404 or 403 there, not a cached body.
+    ///
     /// The representation is part of it because the Contents API serves the
     /// same URL as JSON or raw depending on `Accept`, and those two bodies
     /// must not share an entry.
@@ -318,10 +387,24 @@ impl GithubClient {
             .and_then(|s| s.repo_readable.get(key).copied())
     }
 
+    /// The gate that serialises readability probes for one `(repo, token)`
+    /// pair. Gates nobody is waiting on are dropped here rather than kept
+    /// for the client's lifetime: the map is keyed by token identity too,
+    /// so it would otherwise grow with every user the process serves.
+    pub(crate) fn repo_probe_gate(&self, key: &str) -> Arc<tokio::sync::Mutex<()>> {
+        let Ok(mut state) = self.state.lock() else {
+            return Arc::new(tokio::sync::Mutex::new(()));
+        };
+        state
+            .repo_probe_gates
+            .retain(|k, gate| k == key || Arc::strong_count(gate) > 1);
+        Arc::clone(state.repo_probe_gates.entry(key.to_string()).or_default())
+    }
+
     /// Record what a repo lookup said about a `(repo, token)` pair.
     pub(crate) fn remember_repo_readable(&self, key: &str, readable: bool) {
         if let Ok(mut state) = self.state.lock() {
-            state.repo_readable.insert(key.to_string(), readable);
+            state.repo_readable.insert(key, readable);
         }
     }
 
@@ -336,7 +419,7 @@ impl GithubClient {
     /// Store the ETag observed for `key`. Guard scope is this call only.
     pub(crate) fn store_etag(&self, key: &str, etag: &str) {
         if let Ok(mut state) = self.state.lock() {
-            state.etag_cache.insert(key.to_string(), etag.to_string());
+            state.etag_cache.insert(key, etag.to_string());
         }
     }
 
@@ -361,12 +444,12 @@ impl GithubClient {
         let Ok(mut state) = self.state.lock() else {
             return;
         };
-        // A payload larger than the whole budget would be inserted and
-        // immediately evicted; skip the churn.
-        let size = payload.size_bytes();
-        if size > budget {
-            return;
-        }
+        // The previous entry for this key goes first, and unconditionally:
+        // what we just observed supersedes it, so keeping it around when
+        // the new payload does not fit would leave an ETag for content
+        // that has since changed. Harmless on the wire (it revalidates and
+        // gets a 200) but it is dead state, and it would sit there until
+        // unrelated LRU pressure happened to reach it.
         if let Some(previous) = state.response_cache.remove(key) {
             state.response_bytes = state
                 .response_bytes
@@ -374,6 +457,12 @@ impl GithubClient {
             if let Some(pos) = state.response_order.iter().position(|k| k == key) {
                 state.response_order.remove(pos);
             }
+        }
+        // A payload larger than the whole budget would be inserted and
+        // immediately evicted; skip the churn.
+        let size = payload.size_bytes();
+        if size > budget {
+            return;
         }
         state.response_bytes += size;
         state.response_cache.insert(
@@ -475,6 +564,57 @@ mod tests {
                 .contains("not valid in an HTTP header value"),
             "message must name the real cause: {err}"
         );
+    }
+
+    #[test]
+    fn the_key_caches_stop_growing_at_their_cap() {
+        let client = GithubClient::new().unwrap();
+        // One key per (url, token identity): the same URL read on behalf
+        // of ever more users is exactly how this map grows in a
+        // long-running editor process.
+        let url = "https://api.github.test/repos/example-org/corpus-example";
+        for i in 0..(KEY_CACHE_MAX_ENTRIES + 50) {
+            let key = GithubClient::cache_key(url, None, Some(&format!("token-{i}")));
+            client.store_etag(&key, "\"etag\"");
+            client.remember_repo_readable(&key, true);
+        }
+
+        let first = GithubClient::cache_key(url, None, Some("token-0"));
+        let last = GithubClient::cache_key(
+            url,
+            None,
+            Some(&format!("token-{}", KEY_CACHE_MAX_ENTRIES + 49)),
+        );
+        let state = client.state.lock().unwrap();
+        assert_eq!(state.etag_cache.len(), KEY_CACHE_MAX_ENTRIES);
+        assert_eq!(state.repo_readable.len(), KEY_CACHE_MAX_ENTRIES);
+        assert!(state.etag_cache.get(&first).is_none());
+        assert!(state.repo_readable.get(&first).is_none());
+        assert!(state.etag_cache.get(&last).is_some());
+        assert!(state.repo_readable.get(&last).is_some());
+    }
+
+    #[test]
+    fn an_over_budget_payload_drops_the_entry_it_supersedes() {
+        let mut client = GithubClient::new().unwrap();
+        client.set_cache_budget_bytes(64);
+
+        client.store_response(
+            "key",
+            "\"old\"",
+            CachedPayload::Raw("small".repeat(2).to_string()),
+        );
+        assert!(client.cached_response("key").is_some());
+
+        // The same path, now too big to cache. Keeping the old ETag would
+        // leave the cache pointing at content that has been superseded.
+        client.store_response("key", "\"new\"", CachedPayload::Raw("x".repeat(500)));
+        assert!(
+            client.cached_response("key").is_none(),
+            "the superseded entry must be gone, not waiting for LRU pressure"
+        );
+        let state = client.state.lock().unwrap();
+        assert_eq!(state.response_bytes, 0);
     }
 
     #[tokio::test]

--- a/packages/github/src/client.rs
+++ b/packages/github/src/client.rs
@@ -25,9 +25,9 @@
 //!
 //! Both caches are keyed per (url, token identity), so one principal's
 //! entries do not answer another principal's reads. The token itself is
-//! never stored, only a 64-bit non-cryptographic hash of it; what actually
-//! keeps a body away from a credential that may not read it is GitHub
-//! revalidating every hit — see [`cache_key`](GithubClient::cache_key).
+//! never stored, only a non-cryptographic digest of it — see
+//! [`cache_key`](GithubClient::cache_key) for what that does and does not
+//! guarantee.
 //!
 //! The response cache never serves content without asking GitHub first: it
 //! only turns a 200 into a 304, which costs no rate-limit quota. It can
@@ -92,11 +92,22 @@ impl<V> Default for BoundedMap<V> {
 }
 
 impl<V> BoundedMap<V> {
+    #[cfg(test)]
+    fn with_cap(cap: usize) -> Self {
+        Self {
+            cap,
+            ..Self::default()
+        }
+    }
+
     fn get(&self, key: &str) -> Option<&V> {
         self.entries.get(key)
     }
 
     fn insert(&mut self, key: &str, value: V) {
+        // Returning here is what keeps `order` free of duplicates. With a
+        // duplicate in it, an eviction pops a key that is still live in
+        // `entries` and removes an entry that was nowhere near the oldest.
         if self.entries.insert(key.to_string(), value).is_some() {
             return;
         }
@@ -113,6 +124,18 @@ impl<V> BoundedMap<V> {
         self.entries.len()
     }
 }
+
+/// Salt for the second token digest in [`GithubClient::cache_key`], so the
+/// two halves of the key's token identity are not the same function of the
+/// same input.
+const TOKEN_HASH_SALT: u64 = 0x9e37_79b9_7f4a_7c15;
+
+/// Serialises the repo-readability probe for one `(repo, token identity)`
+/// and holds what it found, so whoever queues behind it reads the answer
+/// instead of asking again. `None` means nobody has answered yet — either
+/// the first probe is still running, or it failed to answer at all and the
+/// next in the queue should try.
+pub(crate) type ProbeGate = Arc<tokio::sync::Mutex<Option<crate::contents::RepoAccess>>>;
 
 /// User-Agent sent on every request, so GitHub audit logs attribute reads and
 /// writes to this client uniformly (the three hand-rolled predecessors each
@@ -201,9 +224,10 @@ struct ClientState {
     repo_readable: BoundedMap<bool>,
     /// One gate per `(repo, token identity)` for the readability probe, so
     /// callers that miss the answer at the same moment queue behind one
-    /// lookup instead of each issuing their own. Entries are dropped once
-    /// nobody holds them any more.
-    repo_probe_gates: HashMap<String, Arc<tokio::sync::Mutex<()>>>,
+    /// lookup instead of each issuing their own, and read its answer
+    /// instead of repeating it. Entries are dropped once nobody holds them
+    /// any more.
+    repo_probe_gates: HashMap<String, ProbeGate>,
     /// Most recent `x-ratelimit-remaining` seen on any response.
     rate_limit_remaining: Option<u32>,
 }
@@ -355,13 +379,15 @@ impl GithubClient {
     ///
     /// The token is part of the key so one principal's entries do not
     /// answer another principal's reads; it is hashed, never stored. The
-    /// hash is `DefaultHasher` — 64 bits, unkeyed, not cryptographic — so
-    /// the separation it gives is compartmenting, not a security boundary:
-    /// two distinct tokens colliding into one key is astronomically
-    /// unlikely but not excluded. What does bound the damage is that the
-    /// entry is never served on its own. Every hit is revalidated against
-    /// GitHub with the caller's own credential, so a credential that may
-    /// not read the resource gets a 404 or 403 there, not a cached body.
+    /// hash is `DefaultHasher` — unkeyed, not cryptographic — so what it
+    /// gives is compartmenting, not a security boundary. Two independent
+    /// 64-bit digests of the token go into the key rather than one,
+    /// because the answer this key guards is not always rechecked: an ETag
+    /// entry is only ever revalidated against GitHub with the caller's own
+    /// credential, but `repo_readable` (same key shape) is *believed*, and
+    /// a token that inherited another's "readable" would read a 404 as
+    /// absence. 128 bits puts that beyond arithmetic rather than beyond
+    /// worry.
     ///
     /// The representation is part of it because the Contents API serves the
     /// same URL as JSON or raw depending on `Accept`, and those two bodies
@@ -370,9 +396,18 @@ impl GithubClient {
         let representation = accept.unwrap_or("default");
         match token {
             Some(token) => {
-                let mut hasher = DefaultHasher::new();
-                token.hash(&mut hasher);
-                format!("{url}#{representation}#{:016x}", hasher.finish())
+                // Two digests of the same token, salted apart, read as one
+                // 128-bit value. `DefaultHasher` is fixed-seed, so the
+                // salt is the only thing making the halves independent.
+                let mut low = DefaultHasher::new();
+                token.hash(&mut low);
+                let mut high = DefaultHasher::new();
+                (TOKEN_HASH_SALT, token).hash(&mut high);
+                format!(
+                    "{url}#{representation}#{:016x}{:016x}",
+                    high.finish(),
+                    low.finish()
+                )
             }
             None => format!("{url}#{representation}#anon"),
         }
@@ -391,13 +426,17 @@ impl GithubClient {
     /// pair. Gates nobody is waiting on are dropped here rather than kept
     /// for the client's lifetime: the map is keyed by token identity too,
     /// so it would otherwise grow with every user the process serves.
-    pub(crate) fn repo_probe_gate(&self, key: &str) -> Arc<tokio::sync::Mutex<()>> {
+    pub(crate) fn repo_probe_gate(&self, key: &str) -> ProbeGate {
         let Ok(mut state) = self.state.lock() else {
-            return Arc::new(tokio::sync::Mutex::new(()));
+            return ProbeGate::default();
         };
+        // A gate nobody holds any more takes its answer with it, this
+        // key's included. That is what keeps a refusal from outliving the
+        // burst it answered: the next caller to arrive alone builds a
+        // fresh gate and asks GitHub again.
         state
             .repo_probe_gates
-            .retain(|k, gate| k == key || Arc::strong_count(gate) > 1);
+            .retain(|_, gate| Arc::strong_count(gate) > 1);
         Arc::clone(state.repo_probe_gates.entry(key.to_string()).or_default())
     }
 
@@ -564,6 +603,26 @@ mod tests {
                 .contains("not valid in an HTTP header value"),
             "message must name the real cause: {err}"
         );
+    }
+
+    #[test]
+    fn a_bounded_map_evicts_in_insertion_order_and_keeps_its_order_intact() {
+        let mut map = BoundedMap::with_cap(3);
+        for key in ["a", "b", "c"] {
+            map.insert(key, key.to_string());
+        }
+        // Refreshing an existing key updates it without queueing it again.
+        map.insert("a", "a2".to_string());
+        assert_eq!(map.order.len(), map.entries.len());
+        assert_eq!(map.get("a"), Some(&"a2".to_string()));
+
+        map.insert("d", "d".to_string());
+        assert_eq!(map.len(), 3);
+        assert_eq!(map.order.len(), map.entries.len());
+        assert!(map.get("a").is_none(), "the oldest insertion goes first");
+        for key in ["b", "c", "d"] {
+            assert!(map.get(key).is_some(), "{key} was evicted out of turn");
+        }
     }
 
     #[test]

--- a/packages/github/src/contents.rs
+++ b/packages/github/src/contents.rs
@@ -91,7 +91,7 @@ struct PutContent {
 /// readability are settled, a refusal is something the user can go and
 /// change in the GitHub UI.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum RepoAccess {
+pub(crate) enum RepoAccess {
     /// The repo answered — this credential can read it.
     Readable,
     /// 404: no repo at this address for anyone this credential is.
@@ -223,11 +223,14 @@ impl GithubClient {
     /// unreadable repo 404s *every* read, and re-probing each one would
     /// double the traffic of the worst case instead of halving it.
     ///
-    /// "Once" holds under concurrency too: readers that all miss the
-    /// remembered answer queue behind one gate per (repo, token identity),
-    /// and every one after the first finds the answer already there. A
-    /// snapshot rebuild reads many paths at once, which is precisely when
-    /// an uncoordinated probe-per-miss would be at its worst.
+    /// Readers that all miss the remembered answer queue behind one gate
+    /// per (repo, token identity), so a burst costs one lookup rather than
+    /// one each. The gate carries the answer, including the refusal that
+    /// is deliberately not remembered on the client: everyone queued
+    /// behind that probe right now gets it, and the gate is gone as soon
+    /// as nobody holds it, so the next reader asks again. A probe that
+    /// could not answer at all (rate limit, transport) settles nothing —
+    /// the next in the queue tries it rather than inheriting a failure.
     ///
     /// It is a snapshot: access changed mid-process stays as first
     /// observed until the client is rebuilt, which is the price of not
@@ -239,26 +242,26 @@ impl GithubClient {
             Some(true) => RepoAccess::Readable,
             Some(false) => RepoAccess::NoSuchRepo,
             None => {
-                // Nobody has answered yet — take the gate for this
-                // (repo, token) and look again behind it, so a burst of
-                // concurrent misses costs one lookup rather than one each.
                 let gate = self.repo_probe_gate(&key);
-                let _probing = gate.lock().await;
-                match self.known_repo_readable(&key) {
-                    Some(true) => return Ok(()),
-                    Some(false) => RepoAccess::NoSuchRepo,
-                    None => {
+                let mut probed = gate.lock().await;
+                match (self.known_repo_readable(&key), *probed) {
+                    (Some(true), _) => RepoAccess::Readable,
+                    (Some(false), _) => RepoAccess::NoSuchRepo,
+                    (None, Some(access)) => access,
+                    (None, None) => {
                         let access = self.repo_access(repo, token).await?;
-                        // Only a settled answer is worth remembering.
-                        // "Readable" and "no such repo" don't change under
-                        // us; a refusal can — an org OAuth-App restriction
-                        // or SAML sign-in is authorised in the GitHub UI in
-                        // seconds, with the same token — and pinning that
-                        // for the client's lifetime would keep failing long
-                        // after the user fixed it.
+                        // Only a settled answer is worth remembering
+                        // beyond this gate. "Readable" and "no such repo"
+                        // don't change under us; a refusal can — an org
+                        // OAuth-App restriction or SAML sign-in is
+                        // authorised in the GitHub UI in seconds, with the
+                        // same token — and pinning that for the client's
+                        // lifetime would keep failing long after the user
+                        // fixed it.
                         if !matches!(access, RepoAccess::Denied) {
                             self.remember_repo_readable(&key, access == RepoAccess::Readable);
                         }
+                        *probed = Some(access);
                         access
                     }
                 }
@@ -986,7 +989,7 @@ mod tests {
             .await;
         for name in ["a", "b", "c", "d"] {
             Mock::given(method("GET"))
-                .and(path_matcher(&format!(
+                .and(path_matcher(format!(
                     "/repos/acme/corpus/contents/wet/{name}.yaml"
                 )))
                 .respond_with(ResponseTemplate::new(404).set_body_string(MISSING_PATH_BODY))
@@ -1011,6 +1014,53 @@ mod tests {
             assert!(read.await.unwrap().unwrap().is_none());
         }
         // `expect(1)` on the probe mock is verified when the server drops.
+    }
+
+    /// A refusal is not remembered on the client, so it is the answer the
+    /// memo can never hand to the rest of a concurrent burst. The gate
+    /// carries it for as long as that burst lasts — and no longer, which
+    /// `a_refused_repo_is_re_probed_rather_than_written_off` pins down.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_misses_on_a_refused_repo_share_one_probe() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path_matcher("/repos/acme/corpus"))
+            .respond_with(
+                ResponseTemplate::new(403)
+                    .set_delay(std::time::Duration::from_millis(150))
+                    .set_body_string("must authorize the app"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        for name in ["a", "b", "c", "d"] {
+            Mock::given(method("GET"))
+                .and(path_matcher(format!(
+                    "/repos/acme/corpus/contents/wet/{name}.yaml"
+                )))
+                .respond_with(ResponseTemplate::new(404).set_body_string(MISSING_PATH_BODY))
+                .mount(&server)
+                .await;
+        }
+
+        let c = std::sync::Arc::new(client(&server));
+        let reads = ["a", "b", "c", "d"].map(|name| {
+            let c = std::sync::Arc::clone(&c);
+            tokio::spawn(async move {
+                c.fetch_file_with_sha(
+                    "acme/corpus",
+                    "main",
+                    &format!("wet/{name}.yaml"),
+                    Some("tok"),
+                )
+                .await
+            })
+        });
+        for read in reads {
+            read.await
+                .unwrap()
+                .expect_err("a refused repo proves no absence, for any of them");
+        }
     }
 
     /// A probe that cannot answer (rate limit) leaves absence unproven, so

--- a/packages/github/src/contents.rs
+++ b/packages/github/src/contents.rs
@@ -223,6 +223,12 @@ impl GithubClient {
     /// unreadable repo 404s *every* read, and re-probing each one would
     /// double the traffic of the worst case instead of halving it.
     ///
+    /// "Once" holds under concurrency too: readers that all miss the
+    /// remembered answer queue behind one gate per (repo, token identity),
+    /// and every one after the first finds the answer already there. A
+    /// snapshot rebuild reads many paths at once, which is precisely when
+    /// an uncoordinated probe-per-miss would be at its worst.
+    ///
     /// It is a snapshot: access changed mid-process stays as first
     /// observed until the client is rebuilt, which is the price of not
     /// paying a lookup per miss. A token that gains access later comes
@@ -233,17 +239,29 @@ impl GithubClient {
             Some(true) => RepoAccess::Readable,
             Some(false) => RepoAccess::NoSuchRepo,
             None => {
-                let access = self.repo_access(repo, token).await?;
-                // Only a settled answer is worth remembering. "Readable"
-                // and "no such repo" don't change under us; a refusal can
-                // — an org OAuth-App restriction or SAML sign-in is
-                // authorised in the GitHub UI in seconds, with the same
-                // token — and pinning that for the client's lifetime would
-                // keep failing long after the user fixed it.
-                if !matches!(access, RepoAccess::Denied) {
-                    self.remember_repo_readable(&key, access == RepoAccess::Readable);
+                // Nobody has answered yet — take the gate for this
+                // (repo, token) and look again behind it, so a burst of
+                // concurrent misses costs one lookup rather than one each.
+                let gate = self.repo_probe_gate(&key);
+                let _probing = gate.lock().await;
+                match self.known_repo_readable(&key) {
+                    Some(true) => return Ok(()),
+                    Some(false) => RepoAccess::NoSuchRepo,
+                    None => {
+                        let access = self.repo_access(repo, token).await?;
+                        // Only a settled answer is worth remembering.
+                        // "Readable" and "no such repo" don't change under
+                        // us; a refusal can — an org OAuth-App restriction
+                        // or SAML sign-in is authorised in the GitHub UI in
+                        // seconds, with the same token — and pinning that
+                        // for the client's lifetime would keep failing long
+                        // after the user fixed it.
+                        if !matches!(access, RepoAccess::Denied) {
+                            self.remember_repo_readable(&key, access == RepoAccess::Readable);
+                        }
+                        access
+                    }
                 }
-                access
             }
         };
         if access == RepoAccess::Readable {
@@ -945,6 +963,54 @@ mod tests {
                 .unwrap()
                 .is_none());
         }
+    }
+
+    /// Concurrent misses are the case the memo alone does not cover: none
+    /// of them sees a remembered answer, so without coalescing they each
+    /// probe. A snapshot rebuild reads many paths at once, which is exactly
+    /// this shape.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_misses_share_one_readability_probe() {
+        let server = MockServer::start().await;
+        // Delayed so the readers genuinely overlap on the probe rather
+        // than finishing one after another by luck of scheduling.
+        Mock::given(method("GET"))
+            .and(path_matcher("/repos/acme/corpus"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_delay(std::time::Duration::from_millis(150))
+                    .set_body_json(serde_json::json!({"full_name": "acme/corpus"})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        for name in ["a", "b", "c", "d"] {
+            Mock::given(method("GET"))
+                .and(path_matcher(&format!(
+                    "/repos/acme/corpus/contents/wet/{name}.yaml"
+                )))
+                .respond_with(ResponseTemplate::new(404).set_body_string(MISSING_PATH_BODY))
+                .mount(&server)
+                .await;
+        }
+
+        let c = std::sync::Arc::new(client(&server));
+        let reads = ["a", "b", "c", "d"].map(|name| {
+            let c = std::sync::Arc::clone(&c);
+            tokio::spawn(async move {
+                c.fetch_file_with_sha(
+                    "acme/corpus",
+                    "main",
+                    &format!("wet/{name}.yaml"),
+                    Some("tok"),
+                )
+                .await
+            })
+        });
+        for read in reads {
+            assert!(read.await.unwrap().unwrap().is_none());
+        }
+        // `expect(1)` on the probe mock is verified when the server drops.
     }
 
     /// A probe that cannot answer (rate limit) leaves absence unproven, so


### PR DESCRIPTION
Haalt de bevindingen op van de geautomatiseerde review die op #1147 binnenkwam vlak voordat die PR werd gemerged.

De scan van de implements-index liet elke walkdir-fout vallen. Een map zonder leesrecht verdween daarmee spoorloos uit de index, en `MAX_UNPARSEABLE_RATIO` telt alleen wat is gezien. Loopfouten worden nu vastgelegd en de generator weigert dan een index, en de scan-root gaat genormaliseerd de `join` in zodat een leidende slash niet buiten de checkout scant. In de GitHub-client kregen `etag_cache` en `repo_readable` een gedeelde entry-cap, want beide zijn op tokenidentiteit gesleuteld en groeiden dus met elke gebruiker. `confirm_absence` coördineert nu echt op één poort in plaats van dat alleen te beloven.

Wat blijft staan: de `branch_just_created`-guard vangt alleen de branch die deze instantie zelf muntte. Een compare-and-set tegen de branch-tip biedt de Contents API niet, dus dat vraagt de overstap naar de Git Data API; de beperking staat nu in de module-docs. Elke opgeloste bevinding heeft een test die zonder de fix rood is.