### PR TITLE
fix(editor): parametertabel heeft geen kopregel, dus lees elke rij

### DIFF
--- a/frontend/src/gherkin/actions.js
+++ b/frontend/src/gherkin/actions.js
@@ -9,8 +9,9 @@
  * feature can never silently no-op in the editor.
  *
  * `args` is the ordered capture list (typed per the grammar's argTypes) with any
- * grammar `literals` appended. `table` is the step's dataTable rows (string[][],
- * header row first) or null.
+ * grammar `literals` appended. `table` is the step's dataTable rows (string[][])
+ * or null. Whether row 0 is a header depends on the step: a data-source table
+ * has one, a parameter table does not.
  */
 
 /**
@@ -115,11 +116,12 @@ export async function dispatch(ctx, engine, action, args, table, { loadDependenc
       ctx.parameters[args[0]] = args[1];
       break;
 
+    // No header row on a parameter table (mirror of Rust `rows_to_params`);
+    // every row is a name/value pair.
     case 'set_parameters_table':
-      if (table) {
-        for (const row of table.slice(1)) {
-          ctx.parameters[row[0]] = parseValue(row[1] || '');
-        }
+      for (const row of table || []) {
+        if (row.length < 2) continue;
+        ctx.parameters[row[0].trim()] = parseValue(row[1] || '');
       }
       break;
 

--- a/frontend/src/gherkin/actions.js
+++ b/frontend/src/gherkin/actions.js
@@ -91,7 +91,8 @@ function tierUnsupported(tier) {
  * @param {object} engine - WasmEngine instance
  * @param {string} action - canonical action id from the grammar
  * @param {Array} args - ordered typed captures + literals
- * @param {string[][]|null} table - step dataTable rows (header first) or null
+ * @param {string[][]|null} table - step dataTable rows, or null; row 0 is a
+ *   header for a data-source table and a value row for a parameter table
  * @param {object} options
  * @param {(lawId: string) => Promise<void>} options.loadDependency
  */

--- a/frontend/src/gherkin/formMapper.js
+++ b/frontend/src/gherkin/formMapper.js
@@ -79,12 +79,16 @@ function extractFragment(entry, match, step) {
   }
 }
 
+// A `Given the following parameters:` table is two columns of name/value with
+// no header row (mirror of Rust `rows_to_params`), so every row is data.
 function tableToParams(dataTable) {
-  if (!dataTable || dataTable.length < 2) return [];
-  return dataTable.slice(1).map((row) => ({
-    name: row[0],
-    value: parseValue(row[1] || ''),
-  }));
+  if (!dataTable) return [];
+  return dataTable
+    .filter((row) => row.length >= 2)
+    .map((row) => ({
+      name: row[0].trim(),
+      value: parseValue(row[1] || ''),
+    }));
 }
 
 function classifyStep(step) {

--- a/frontend/src/gherkin/formMapper.test.js
+++ b/frontend/src/gherkin/formMapper.test.js
@@ -130,6 +130,9 @@ Feature: Params
     ]);
   });
 
+  // A parameter table has no header row, so its first row is a parameter too.
+  // Shape taken verbatim from
+  // corpus/regulation/nl/wet/burgerlijk_wetboek_boek_5/scenarios/erfgrensbeplanting.feature.
   it('maps parameter table', () => {
     const parsed = parseFeature(`
 Feature: Param table
@@ -137,18 +140,54 @@ Feature: Param table
   Scenario: Bulk params
     Given the calculation date is "2025-01-01"
     Given the following parameters:
-      | name   | value |
-      | bsn    | 123   |
-      | amount | 500   |
-    When I evaluate "x" of "law"
+      | gemeente_code   | GM0363 |
+      | type_beplanting | boom   |
+      | postcode        | 1012   |
+    When I evaluate "minimale_afstand_cm" of "burgerlijk_wetboek_boek_5"
 `);
 
     const form = mapFeatureToForm(parsed);
     const params = form.scenarios[0].setup.parameters;
     expect(params).toEqual([
-      { name: 'bsn', value: 123 },
-      { name: 'amount', value: 500 },
+      { name: 'gemeente_code', value: 'GM0363' },
+      { name: 'type_beplanting', value: 'boom' },
+      { name: 'postcode', value: 1012 },
     ]);
+  });
+
+  it('keeps a single-row parameter table', () => {
+    const parsed = parseFeature(`
+Feature: One param
+
+  Scenario: Single row
+    Given the following parameters:
+      | indieningsdatum | 2025-01-01 |
+    When I evaluate "tijdig_ingediend" of "test_date_operations"
+`);
+
+    const form = mapFeatureToForm(parsed);
+    expect(form.scenarios[0].setup.parameters).toEqual([
+      { name: 'indieningsdatum', value: '2025-01-01' },
+    ]);
+  });
+
+  // Round-trip guard: saving from the visual form rewrites the table as
+  // individual `Given parameter ...` steps, so a row lost on read is lost
+  // in the .feature file for good.
+  it('keeps every parameter through a table load/save round-trip', () => {
+    const parsed = parseFeature(`
+Feature: Round trip
+
+  Scenario: Bulk params
+    Given the following parameters:
+      | gemeente_code   | GM0363 |
+      | type_beplanting | boom   |
+    When I evaluate "minimale_afstand_cm" of "burgerlijk_wetboek_boek_5"
+`);
+
+    const gherkin = formStateToGherkin(mapFeatureToForm(parsed));
+    expect(gherkin).toContain('Given parameter "gemeente_code" is "GM0363"');
+    expect(gherkin).toContain('Given parameter "type_beplanting" is "boom"');
   });
 
   it('puts unrecognized steps in unmatchedSteps', () => {

--- a/frontend/src/gherkin/steps.test.js
+++ b/frontend/src/gherkin/steps.test.js
@@ -82,3 +82,32 @@ describe('core grammar patterns match their canonical example lines', () => {
     });
   }
 });
+
+// Mirror of Rust `rows_to_params` in packages/engine/tests/bdd/dispatch.rs:
+// a parameter table carries no header row.
+describe('set_parameters_table dispatch', () => {
+  async function runTable(dataTable) {
+    const ctx = { calculationDate: null, parameters: {}, result: null, error: null, executed: false };
+    const def = createStepDefinitions({ loadDependency: async () => {} }).find(
+      (d) => d.pattern.test('the following parameters:'),
+    );
+    await def.execute(ctx, null, 'the following parameters:'.match(def.pattern), { dataTable });
+    return ctx.parameters;
+  }
+
+  it('reads every row of a corpus parameter table', async () => {
+    expect(
+      await runTable([
+        ['gemeente_code', 'GM0363'],
+        ['type_beplanting', 'boom'],
+        ['postcode', '1012'],
+      ]),
+    ).toEqual({ gemeente_code: 'GM0363', type_beplanting: 'boom', postcode: 1012 });
+  });
+
+  it('reads a single-row parameter table', async () => {
+    expect(await runTable([['indieningsdatum', '2025-01-01']])).toEqual({
+      indieningsdatum: '2025-01-01',
+    });
+  });
+});


### PR DESCRIPTION
De editor las een `Given the following parameters:`-tabel alsof de eerste rij een kopregel was en sloeg die over, terwijl parametertabellen in dit project geen kop hebben en de Rust-kant elke rij leest. Wie een scenario via het visuele formulier opsloeg raakte daardoor de eerste parameter permanent kwijt, want bij opslaan schrijft de editor de tabel terug als losse `Given parameter`-regels; een tabel van één rij verdween in zijn geheel. Dezelfde aanname zat naast `formMapper.js` ook in de dispatch in `actions.js`. De testfixture verzon een kopregel en dekte de bug daarmee af; die is vervangen door een echte tabel uit het corpus, en de vijf nieuwe tests zijn zonder de fix rood.

De geschiedenis is doorzocht op corpusbestanden waar de bug al schade aanrichtte. Die zijn er niet.

Closes #1152