### PR TITLE
docs(docs): rfc-034 over het concept-anker en de blokkerende notitie

### DIFF
--- a/docs/src/content/rfcs/rfc-031.md
+++ b/docs/src/content/rfcs/rfc-031.md
@@ -1,0 +1,397 @@
+---
+title: "RFC-031: Concept-anker en blokkerende notitie"
+status: Draft
+implementation: Not implemented
+date: '2026-08-07'
+authors:
+  - Eelco Hotting
+depends_on:
+  - RFC-005 (Stand-off notes and the TextQuoteSelector)
+  - RFC-018 (Note infrastructure, sidecars and vocabulary)
+  - RFC-009 (Competent authority and note authority)
+short_title: Concept-anker
+---
+
+## Context
+
+Twee onderdelen uit de gesloten PR #528 zijn blijven liggen. Ze staan samen in
+issue #1047 en ze staan samen in deze RFC, omdat ze allebei hetzelfde bestand
+veranderen: `annotation-schema.json`, gecontroleerd door dezelfde
+`validate-annotations`.
+
+### Notities hangen aan één vindplaats
+
+Een notitie hangt aan een `TextQuoteSelector`: de letterlijke passage met de
+context eromheen, en het artikelnummer als niet-gezaghebbende `regelrecht:hint`
+(RFC-005). Dat anker is inhoudsgeadresseerd. Vernummert een artikel, dan volgt
+de notitie de tekst. Verandert de tekst licht, dan vindt fuzzy matching hem
+alsnog. Verandert de tekst te veel, dan wordt de notitie `orphaned` en blijft hij
+met zijn oorspronkelijke context bewaard.
+
+Het anker kent één wet. `target.source` is één `regelrecht://{law_id}`, de
+resolver scant de artikelen van die ene wet, en `resolve()` in
+`packages/engine/src/annotation/resolver.rs` neemt een `&[Article]` van precies
+die wet. Een begrip dat in de ene wet gedefinieerd is en in tien andere gebruikt
+wordt, past daar niet in.
+
+Het corpus laat dat zien. `ingezetene` komt voor in drie wetten:
+
+- De Wet basisregistratie personen definieert het begrip in artikel 1.1 onder f:
+  de ingeschrevene die zijn adres heeft in een gemeente in Nederland en op wiens
+  persoonslijst geen overlijden of vertrek als actueel gegeven staat. Een
+  administratieve status, vastgesteld door een inschrijving.
+- De Wet langdurige zorg hangt de verzekeringsplicht er in artikel 2.1.1 lid 1
+  onder a aan op. De Wlz definieert het begrip niet in artikel 1.1.1. Voor een
+  volksverzekering is het het fiscale ingezetenebegrip, waar iemand woont wordt
+  naar de omstandigheden beoordeeld, en de bepaling die dat zegt zit niet in het
+  corpus.
+- De Kieswet gebruikt in artikel B 1 lid 2 onder a "gedurende ten minste tien
+  jaren ingezetene van Nederland geweest".
+
+In de vertaling van de Wlz staat de verwarring al met zoveel woorden:
+
+```yaml
+- name: is_ingezetene
+  type: boolean
+  description: Ingezetene per BRP (Art 2.1.1 lid a) — TODO output ontbreekt in BRP corpus
+  source: {}
+```
+
+Een registerstatus staat hier in voor een weging van feiten. De
+`reference-and-concept-hygiene`-skill noemt dat een false friend: één woord, twee
+vaststellingswijzen, twee begrippen. De engine draait die koppeling zonder te
+klagen.
+
+De notitie die dat opschrijft, "let op, dit is niet het BRP-begrip", hangt
+vandaag aan het woord `ingezetene` in Wlz artikel 2.1.1 en wordt nergens anders
+gezien. Wie de Kieswet openslaat krijgt hem niet. Dat is het geval dat misgaat.
+
+De verleiding is om het anker op het woord te laten pakken en de notitie overal
+te tonen waar dat woord staat. Dan landt de notitie ook op BRP artikel 1.1 onder
+f, waar hij onwaar is. Een anker dat op het lexeem grijpt is slechter dan geen
+anker, want een ontbrekende notitie is een gat en een verplaatste notitie is een
+onjuistheid.
+
+### Aftekenen zonder poort
+
+De validatiemethode wil in fase D dat een casus niet afgetekend wordt zolang er
+zwaarwegende notities open staan. Het schema kent `workflow: open | resolved` en
+verder niets over gewicht. In de code bestaat de poort helemaal niet:
+`validate_status()` in `packages/editor-api/src/trajects.rs` accepteert
+`"bezig"` en `"afgerond"` en kijkt naar geen enkele notitie. Aftekenen is een
+regel in een methodedocument.
+
+Issue #1047 wijst op de route die RFC-018 voor de inhoudelijke staat koos: geen
+enum in het schema, maar een `tagging`-body met een waarde uit
+`corpus/annotations/_vocabulary/ambiguity.yaml`, zacht gevalideerd. Die route
+past hier niet, om redenen die onder [Decision](#blokkerende-notities) staan.
+
+### Stand van de begrippenlijst
+
+Issue #1047 gaat ervan uit dat RFC-027 de begrippenlijst al bouwt als onderdeel
+van de contextassemblage. Op `main` klopt dat niet. RFC-026 tot en met RFC-030
+zijn daar gereserveerde nummers met een alinea context en zonder ontwerp. Er is
+geen begrippenlijst, geen extractiestap, geen `placement`-veld en geen
+schemaveld dat begripsbepalingen apart zet. Het `definitions:`-blok in de
+wets-YAML draagt constanten, geen begrippen. De enige begrippenlijst in de repo
+is `docs/src/content/docs/reference/glossary.md`, een handgeschreven
+platformwoordenlijst zonder relatie tot corpusdata.
+
+Ook als RFC-027 landt, is een bijproduct van contextassemblage geen anker. Een
+contextassemblage hoeft alleen goed genoeg te zijn om één verrijkingsronde mee te
+prompten, en wordt bij de volgende ronde opnieuw gemaakt. Een anker moet een
+identiteit dragen die een nieuwe versie van de wet en een nieuwe run van de
+enricher overleeft, anders verhuizen bestaande notities als bijwerking van een
+her-run. Die eis is hard genoeg om de begrippenlijst hieronder als gereviewd
+corpusartefact neer te zetten in plaats van als tussenresultaat.
+
+## Decision
+
+### Begrippen in een sidecar
+
+Begrippen komen naast de wet te staan, langs dezelfde weg als notities (RFC-018
+beslissing 1): `corpus/concepts/{law_id}/concepts.yaml`, gesleuteld op de `$id`
+van de wet, meeversioneerd in git, gevalideerd door een nieuwe
+`validate-concepts`.
+
+```yaml
+$schema: https://.../schema/v0.5.7/concept-schema.json
+concepts:
+  - id: ingezetene
+    label: [ingezetene, de ingezetene, ingezetenen]
+    mode: register
+    definition:
+      type: TextQuoteSelector
+      exact: 'de ingeschrevene, die zijn adres heeft in een gemeente in Nederland'
+      prefix: '*de ingezetene:* '
+      suffix: ', en op wiens persoonslijst'
+    distinct_from:
+      - regelrecht://wet_langdurige_zorg#ingezetene
+    usages:
+      - source: regelrecht://wet_basisregistratie_personen
+        relation: same-concept
+        selector:
+          type: TextQuoteSelector
+          exact: ingezetene
+          prefix: 'op personen die als '
+          suffix: ' in de basisregistratie zijn'
+```
+
+De identiteit van een begrip is de bepaling die het definieert. Het volledige
+adres is `regelrecht://{law_id}#{concept_id}`, hier
+`regelrecht://wet_basisregistratie_personen#ingezetene`. De `$id` van een wet is
+al de stabiele sleutel waarmee wetten naar elkaar verwijzen. De URI-grammatica in
+`packages/engine/src/uri.rs` is `regelrecht://{law_id}/{output}#{field}`; een
+begrip laat het outputsegment weg, dus de twee vormen zijn uit elkaar te houden.
+
+Het begrip zelf hangt aan een tekstanker. `definition` is een gewone
+`TextQuoteSelector` op de definiërende passage. Daarmee erft een begrip de
+versiebestendigheid en de `orphaned`-staat van RFC-005 zonder één regel nieuwe
+matchlogica. Raakt de definitie zoek, dan is het begrip zoek, en dat is zichtbaar
+in plaats van stil.
+
+`mode` scheidt de false friends. De waarden komen uit de vaststellingswijzen van
+de concept-hygiëne: `register`, `computed`, `factual-open-norm`, `composite`,
+`brute-fact`. Het BRP-ingezetenebegrip is `register`, het Wlz-begrip is
+`factual-open-norm`. Twee begrippen met hetzelfde label en een verschillende
+`mode` zijn per definitie twee begrippen, en dat is af te lezen zonder de
+wettekst erbij te halen.
+
+Vindplaatsen staan opgeschreven. Elke `usages`-regel heeft een eigen
+`TextQuoteSelector` en een `relation`. Er is geen matcher die het woord door het
+corpus jaagt. Een vindplaats die niemand heeft bevestigd bestaat niet, en een
+notitie komt daar dus niet. Het anker generaliseert over een bevestigde lijst
+vindplaatsen.
+
+`relation` kent twee waarden. `same-concept` is een vindplaats van hetzelfde
+begrip. `proxy` is een gedocumenteerde benadering, een register dat een
+feitelijke weging voedt, die in de editor zichtbaar gemarkeerd wordt. Een
+vindplaats die hetzelfde woord gebruikt voor een ander begrip staat bij
+`distinct_from`, als expliciete uitspraak dat de twee uit elkaar gehouden zijn.
+Een notitie bereikt een `distinct_from`-begrip nooit.
+
+### Derde ankertype
+
+```yaml
+- type: Annotation
+  motivation: commenting
+  creator: interpreter-team
+  target:
+    source: regelrecht://wet_langdurige_zorg
+    selector:
+      type: regelrecht:ConceptSelector
+      concept: regelrecht://wet_langdurige_zorg#ingezetene
+      scope: all-sites
+  body:
+    type: TextualBody
+    value: >-
+      Dit is het feitelijke ingezetenebegrip: waar iemand woont wordt naar de
+      omstandigheden beoordeeld. Het is niet het BRP-begrip van artikel 1.1
+      onder f, dat op inschrijving berust.
+    purpose: commenting
+    language: nl
+```
+
+Oplossen is een uitwaaiering over bestaande tekstankers. De resolver zoekt het
+begrip op, zet `scope` om in een verzameling `TextQuoteSelector`s, en laat
+`resolve()` daar per wet los. Onder de uitwaaiering gebeurt niets nieuws.
+
+`scope` kent twee waarden. `definition` raakt alleen de definiërende passage,
+voor een notitie over de formulering van de bepaling zelf. `all-sites` raakt de
+definitie plus elke `usages`-regel, en is de standaard.
+
+`resolution` van een concept-genankerde notitie is de samenvatting van de
+deelresultaten: `found` zodra minstens één plek oplost, `orphaned` als geen
+enkele plek oplost. `ambiguous` blijft per plek gelden en telt niet mee in de
+samenvatting, want meerdere treffers binnen één artikel zeggen niets over de
+vraag of het begrip nog bestaat.
+
+De Wlz-casus wordt daarmee: `regelrecht://wet_langdurige_zorg#ingezetene`, `mode:
+factual-open-norm`, `definition` verweesd omdat de bepaling niet in het corpus
+zit, met een `questioning`-notitie met tag `missing-document` erop, en
+`distinct_from` naar het BRP-begrip. De notitie hangt aan het Wlz-begrip, is
+zichtbaar op elke bevestigde Wlz-vindplaats, en komt op BRP artikel 1.1 onder f
+niet voor.
+
+### Voorstellen van de enricher
+
+Een door de enricher voorgestelde begripsingang komt binnen met `creator` op de
+naam van het gereedschap, zoals gegenereerde notities dat doen (RFC-018
+beslissing 8). Zo'n ingang is zichtbaar, apart gemarkeerd, en ankert geen
+notities. Pas als een mens hem overneemt door de `creator` op zijn eigen
+identiteit te zetten, gaat hij meetellen bij het oplossen. Een verrijkingsronde
+kan de lijst voorstellen en kan hem nooit verplaatsen.
+
+### Blokkerende notities
+
+Een nieuw veld op `Annotation`:
+
+```yaml
+regelrecht:blocking: true   # default false
+```
+
+De poort werkt zo:
+
+1. Een traject gaat alleen naar `afgerond` als er geen notitie in zijn eigen
+   annotatie-scope staat met `regelrecht:blocking: true` en `workflow: open`.
+2. `resolution: orphaned` of `ambiguous` heft de blokkade niet op. Het anker
+   kwijtraken is geen antwoord op de vraag.
+3. Notities uit andere bronnen blokkeren nooit. Blokkeren is een uitspraak binnen
+   één traject over het eigen werk. Het is geen middel waarmee de ene organisatie
+   de aftekening van de andere tegenhoudt. Dat volgt de gezagsverdeling van
+   RFC-009 en het lagenmodel van RFC-018 beslissing 8.
+4. `regelrecht:blocking: true` vereist een `workflow`. De editor kent vandaag een
+   notitie zonder taakkarakter, met `workflow` afwezig; die kan niet blokkeren,
+   want er is geen staat waarin hij ooit klaar is.
+
+De poort zit in `validate_status()` in `packages/editor-api/src/trajects.rs`, dat
+vandaag alleen de string controleert. De code om de notities van een traject te
+lezen bestaat al, als `read_annotations_in_scope` in `corpus_handlers.rs`.
+`validate-annotations` telt de openstaande blokkades en rapporteert ze, zodat CI
+ze laat zien; blokkeren doet de API.
+
+De `tagging`-route van RFC-018 past hier niet. Het argument daar was dat de
+verzameling toestanden nog groeit en dat een enum elke nieuwe toestand een
+schemabump plus migratie maakt. Dit veld wordt afgedwongen en die vocabulaire
+niet.
+
+De vocabulaire is zacht gevalideerd. Een tikfout levert een waarschuwing en een
+notitie die stil niet blokkeert. Een poort die bij een tikfout opengaat is erger
+dan geen poort, want de casus wordt afgetekend en niets kleurt rood. Een
+afgedwongen veld moet hard gevalideerd zijn en dus een gesloten verzameling
+hebben.
+
+De vocabulaire beschrijft wat voor soort gat er zit. Blokkeren zegt wat het
+proces hierna mag. Beschrijven en voorschrijven zijn twee assen, en ze in één
+body proppen geeft één veld twee taken.
+
+De verzameling groeit hier niet. Blokkeren of niet blokkeren is twee waarden en
+blijft twee waarden, omdat de poort maar twee kanten kent.
+
+## Why
+
+### Winst
+
+Een notitie over een begrip staat op elke plek waar dat begrip erkend gebruikt
+wordt, en op geen enkele plek waar hetzelfde woord iets anders betekent. De
+`ingezetene`-conflatie die nu in de Wlz-YAML staat wordt een uitspraak in een
+bestand met een `git blame`, in plaats van een TODO in een `description`.
+
+De begrippenlijst is meteen ook de invoer voor de concept-hygiëne-audit. `mode`
+per begrip en `relation` per vindplaats zijn de twee assen waarop die audit false
+friends, part/whole-fouten en duplicatie vindt. De analyse die vandaag met de
+hand gebeurt wordt een bestand dat te controleren valt.
+
+De ankermachinerie blijft één stuk. Een concept-anker is een uitwaaiering over
+tekstankers, dus fuzzy matching, drempel en `orphaned` bestaan één keer, in
+`resolver.rs`.
+
+De poort krijgt een grondslag die niet fail-open is. Wie een casus aftekent
+terwijl er een blokkerende vraag openstaat, krijgt een weigering met de notitie
+erbij.
+
+### Prijs
+
+Het ontwerp vindt de begrippen niet voor je. De extractie is het dure werk en dit
+ontwerp legt de correctheid bij een geschreven, reviewbare lijst. Een fout in dat
+bestand verplaatst een notitie net zo goed als een woordmatcher dat zou doen. Het
+verschil is dat de fout een regel is met een auteur.
+
+Een begrip dat in een wet gebruikt wordt zonder dat iemand daar een
+`usages`-regel voor schreef, toont de notitie daar niet. Het ontwerp faalt naar
+een ontbrekende notitie. Dat is de goede kant om naar te falen. De dekking van de
+lijst zelf moet daardoor wel bewaakt worden, en er is vandaag geen maat voor.
+
+Er komt een corpusartefact bij dat vandaag niet bestaat, met een eigen schema,
+een eigen validator en een eigen redactie-oppervlak in de editor. Dat laatste is
+het grootste stuk werk en de reden dat dit meer is dan "een derde ankertype".
+
+Blokkeren binnen één traject houden betekent dat een gemeente die een fout ziet
+in het werk van een ander traject dat traject niet kan tegenhouden. Die notitie
+is zichtbaar en adviserend. Wie dat te zwak vindt, moet dat nu zeggen, want het
+alternatief raakt de gezagsverdeling van RFC-009.
+
+### Geraakte code en schema's
+
+Schema: `Target.selector` is nu een kale `$ref` naar `TextQuoteSelector` en
+`Target` staat op `additionalProperties: false`, dus het wordt een `oneOf` over
+`TextQuoteSelector` en `regelrecht:ConceptSelector`. Daarbij `regelrecht:blocking`
+op `Annotation` met een `if/then` die `workflow` verplicht stelt, en een nieuwe
+`concept-schema.json`. Dat is een bump naar v0.5.7. De ingebakken kopie van het
+annotatieschema in `packages/corpus/src/annotation_schema.rs` moet mee.
+
+Engine: `resolve(selector: &TextQuoteSelector, articles: &[Article])` wordt
+`resolve(selector: &Selector, ...)` over een enum, en de concept-tak heeft de
+begrippenlijst nodig, dus er komt een lader bij in `packages/engine/src/concept/`.
+`resolveNote` en `resolveNotesDocument` in `wasm.rs` veranderen van vorm, want ze
+kunnen nu treffers in meerdere wetten teruggeven. De uitvoering blijft ongemoeid:
+begrippen komen nooit in een run terecht, `service.rs` en `types.rs` veranderen
+niet.
+
+Editor: `useNotes.js` leest vandaag één selector per notitie en filtert de
+treffers per artikel; dat wordt een lijst per wet. `AnnotatedText.vue` markeert
+per artikel en krijgt er een markering bij voor een `proxy`-vindplaats.
+`NoteCreator.vue` krijgt een tweede invoermodus, een begrip kiezen in plaats van
+tekst selecteren, plus een vinkje voor blokkeren. `NoteCard.vue` toont op hoeveel
+vindplaatsen in hoeveel wetten een notitie geldt. Nieuw is een scherm om de
+begrippenlijst te redigeren en voorstellen van de enricher over te nemen.
+
+### Overwogen en verworpen
+
+**Het woord matchen over het corpus.** Een concept-anker dat elke plek zoekt waar
+het label staat. Verworpen op `ingezetene`: het BRP-begrip en het Wlz-begrip
+delen het woord en niet de vaststellingswijze, dus de notitie landt op een plek
+waar hij onwaar is.
+
+**Een `TextQuoteSelector` met een jokerteken in `source`.** Dezelfde tekst in elke
+wet oplossen. Zelfde bezwaar, plus het breekt de uniciteitsregel van RFC-005, die
+per wet geldt.
+
+**Begrippen in de wets-YAML, naast `definitions:`.** Verworpen omdat de wets-YAML
+een getrouwe spiegel van de wettekst is en een begrippenlijst een reviewproduct.
+Dat hoort in een sidecar, om dezelfde reden waarom notities dat doen.
+
+**`open_terms` en `implements` hergebruiken (RFC-003).** Verworpen: dat is een
+delegatiemechanisme tussen regelingslagen, op waarden, opgelost door de engine
+tijdens uitvoering. Een concept-anker gaat over tekst en voert niets uit. Het
+overladen zou de IoC-resolutie van de engine laten afhangen van reviewartefacten.
+
+**SKOS of een andere RDF-woordenschat.** Verworpen: een volledige
+terminologiestandaard voor een lijst met vier velden, en niets anders in
+regelrecht spreekt RDF.
+
+**Een ernstschaal (`low`, `medium`, `high`, `critical`).** Verworpen: niemand kan
+zeggen waar de grens ligt, en de poort heeft een grens nodig. Die wordt dan
+alsnog willekeurig getrokken, dus trek hem één keer, in het veld zelf.
+
+**Een derde waarde in `workflow`.** Verworpen: dat gooit "is het beantwoord" en
+"moet het beantwoord zijn voor aftekenen" op één as. Een blokkerende vraag die
+beantwoord wordt zou naar `resolved` moeten, en dan is niet meer te zien dat hij
+blokkeerde.
+
+**De poort op `motivation: questioning` plus `workflow: open`.** Verworpen: dan
+blokkeert elke open vraag. Dat maakt de poort onbruikbaar en zet mensen ertoe aan
+vragen te sluiten die ze niet beantwoord hebben.
+
+### Implementatienotities
+
+Het annotatieschema reist niet mee met de versiemappen van het wetsschema.
+`schema/latest` wijst naar `v0.5.6` en daar staat geen `annotation-schema.json`;
+de laatste is `schema/v0.5.3/annotation-schema.json`. De bump naar v0.5.7 is een
+goed moment om die twee weer gelijk te laten lopen, of om vast te leggen dat ze
+apart versioneren.
+
+De volgorde die werkt: eerst het begripsschema en de begrippenlijst voor
+`ingezetene` over de drie wetten die hem gebruiken, want dat is de casus die het
+ontwerp moet dragen. Dan de resolver-uitwaaiering met de bijbehorende
+BDD-scenario's. Dan pas het editor-oppervlak. `regelrecht:blocking` staat daar
+los van en kan als eerste, omdat het één schemaveld en één functie raakt.
+
+## References
+
+- [RFC-005: Stand-off Notes for Legal Texts](./rfc-005)
+- [RFC-018: Note Infrastructure](./rfc-018)
+- [RFC-009: Multi-Organization Execution](./rfc-009)
+- [RFC-003: Inversion of Control](./rfc-003)
+- Issue #1047, uit de gesloten PR #528
+- [W3C Web Annotation Data Model](https://www.w3.org/TR/annotation-model/)

--- a/docs/src/content/rfcs/rfc-034.md
+++ b/docs/src/content/rfcs/rfc-034.md
@@ -1,5 +1,5 @@
 ---
-title: "RFC-031: Concept-anker en blokkerende notitie"
+title: "RFC-034: Concept-anker en blokkerende notitie"
 status: Draft
 implementation: Not implemented
 date: '2026-08-07'
@@ -89,21 +89,34 @@ past hier niet, om redenen die onder [Decision](#blokkerende-notities) staan.
 ### Stand van de begrippenlijst
 
 Issue #1047 gaat ervan uit dat RFC-027 de begrippenlijst al bouwt als onderdeel
-van de contextassemblage. Op `main` klopt dat niet. RFC-026 tot en met RFC-030
-zijn daar gereserveerde nummers met een alinea context en zonder ontwerp. Er is
-geen begrippenlijst, geen extractiestap, geen `placement`-veld en geen
+van de contextassemblage. Op `main` staat daar niets van: RFC-026 tot en met
+RFC-030 zijn gereserveerde nummers met een alinea context en zonder ontwerp. Er
+is geen begrippenlijst, geen extractiestap, geen `placement`-veld en geen
 schemaveld dat begripsbepalingen apart zet. Het `definitions:`-blok in de
 wets-YAML draagt constanten, geen begrippen. De enige begrippenlijst in de repo
 is `docs/src/content/docs/reference/glossary.md`, een handgeschreven
 platformwoordenlijst zonder relatie tot corpusdata.
 
-Ook als RFC-027 landt, is een bijproduct van contextassemblage geen anker. Een
-contextassemblage hoeft alleen goed genoeg te zijn om één verrijkingsronde mee te
-prompten, en wordt bij de volgende ronde opnieuw gemaakt. Een anker moet een
-identiteit dragen die een nieuwe versie van de wet en een nieuwe run van de
-enricher overleeft, anders verhuizen bestaande notities als bijwerking van een
-her-run. Die eis is hard genoeg om de begrippenlijst hieronder als gereviewd
-corpusartefact neer te zetten in plaats van als tussenresultaat.
+De uitgewerkte RFC-027 op de branch van PR #1037 komt dichterbij en levert het
+nog steeds niet. Tier 1 van de contextassemblage zet in het venster "which terms
+in this article are defined elsewhere". Tier 3 controleert of een begrip binnen
+zijn bereik gebruikt wordt, gedragen door een nieuw `placement`-veld op het
+artikel dat hoofdstuk, titel, afdeling en paragraaf vastlegt. Het woord glossary
+valt daar één keer, als "the concept glossary check in tier 3". Dat is een
+controle die per run wordt uitgerekend en daarna weg is.
+
+Een bijproduct van contextassemblage kan geen anker zijn. Een contextassemblage
+hoeft alleen goed genoeg te zijn om één verrijkingsronde mee te prompten, en
+wordt bij de volgende ronde opnieuw gemaakt. Een anker moet een identiteit dragen
+die een nieuwe versie van de wet en een nieuwe run van de enricher overleeft,
+anders verhuizen bestaande notities als bijwerking van een her-run. Die eis is
+hard genoeg om de begrippenlijst hieronder als gereviewd corpusartefact neer te
+zetten in plaats van als tussenresultaat.
+
+De twee sluiten elkaar niet uit. `placement` uit RFC-027 is precies de scoperegel
+die bepaalt welke begripsbepaling op welk artikel werkt, en die regel bepaalt ook
+welke `usages` verdedigbaar zijn. Wat RFC-027 per run uitrekent kan de vaste
+begrippenlijst hieronder voeden; het omgekeerde werkt niet.
 
 ## Decision
 
@@ -393,5 +406,7 @@ los van en kan als eerste, omdat het één schemaveld en één functie raakt.
 - [RFC-018: Note Infrastructure](./rfc-018)
 - [RFC-009: Multi-Organization Execution](./rfc-009)
 - [RFC-003: Inversion of Control](./rfc-003)
+- RFC-027 (Enrichment a Legal Expert Can Check), voor `placement` en de
+  begripsbereik-controle in tier 3
 - Issue #1047, uit de gesloten PR #528
 - [W3C Web Annotation Data Model](https://www.w3.org/TR/annotation-model/)


### PR DESCRIPTION
Werkt de twee punten uit issue #1047 uit, allebei afkomstig uit de gesloten PR #528.

Het eerste is een concept-anker als derde ankertype naast de TextQuoteSelector. Het wijst naar een begrip via de bepaling die het definieert, met een `mode` voor de vaststellingswijze en een opgeschreven lijst vindplaatsen. Er is geen matcher die het woord door het corpus jaagt, want `ingezetene` is in de Wet BRP een registerstatus en in de Wlz een weging van feiten, en die twee mogen elkaars notities niet krijgen. Het tweede is een veld `regelrecht:blocking` op de notitie, met een poort in `validate_status()` die een traject niet naar `afgerond` laat gaan zolang er een blokkerende notitie openstaat.

Daar wijkt het ontwerp af van de `tagging`-route van RFC-018: een zacht gevalideerde vocabulaire laat een tikfout de poort opendoen, en dat is de verkeerde faalrichting voor iets dat afdwingt. De aanname in #1047 dat RFC-027 de begrippenlijst al bouwt houdt geen stand; daar is het een controle die per run wordt uitgerekend, geen vast adresseerbaar artefact.

Closes #1047