### PR TITLE
ci: productie deployt in één ZAD-taak

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -296,9 +296,7 @@ jobs:
   # -- Deploy production --
   deploy-production:
     runs-on: ubuntu-latest
-    # Sequential ZAD deploys of all changed components do not fit in 15 minutes
-    # on a broad merge.
-    timeout-minutes: 45
+    timeout-minutes: 20
     needs: [build, build-admin, build-harvester-worker, build-enrich-worker, build-pipeline-api, build-grafana, build-lawmaking, build-docs]
     if: >-
       always() &&
@@ -317,93 +315,80 @@ jobs:
     permissions: {}
     environment:
       name: production
-      url: ${{ steps.deploy.outputs.url }}
+      url: ${{ steps.editor-url.outputs.url }}
 
     steps:
       - name: Get short SHA
         id: sha
         run: echo "short=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
 
-      - name: Deploy admin to ZAD (Production)
-        if: needs.build-admin.result == 'success'
-        uses: RijksICTGilde/zad-actions/deploy@13434cd415db0cd195a2c5f12bf67645acfcb635  # v4.0.6
-        with:
-          api-key: ${{ secrets.RIG_API_KEY }}
-          project-id: ${{ env.ZAD_PROJECT }}
-          deployment-name: regelrecht
-          component: harvester-admin
-          image: ${{ env.REGISTRY }}/minbzk/regelrecht-admin:sha-${{ steps.sha.outputs.short }}
+      # Dezelfde reden als bij de preview: ZAD kent per deployment één
+      # taak-scope, dus een tweede taak voor regelrecht zet de eerste opzij
+      # ("superseded"). Alle componenten gaan als één lijst in één upsert-taak.
+      - name: Stel de componentenlijst samen
+        id: plan
+        env:
+          SHA: ${{ steps.sha.outputs.short }}
+          EDITOR: ${{ needs.build.result }}
+          ADMIN: ${{ needs.build-admin.result }}
+          HARVESTER_WORKER: ${{ needs.build-harvester-worker.result }}
+          ENRICH_WORKER: ${{ needs.build-enrich-worker.result }}
+          PIPELINE_API: ${{ needs.build-pipeline-api.result }}
+          GRAFANA: ${{ needs.build-grafana.result }}
+          LAWMAKING: ${{ needs.build-lawmaking.result }}
+          DOCS: ${{ needs.build-docs.result }}
+        run: |
+          set -euo pipefail
+          COMPONENTS='[]'
+          add() {
+            COMPONENTS=$(jq -c --arg name "$1" --arg image "${REGISTRY}/minbzk/$2:sha-${SHA}" \
+              '. + [{name: $name, image: $image}]' <<<"$COMPONENTS")
+          }
 
-      - name: Deploy pipeline-api to ZAD (Production)
-        if: needs.build-pipeline-api.result == 'success'
-        uses: RijksICTGilde/zad-actions/deploy@13434cd415db0cd195a2c5f12bf67645acfcb635  # v4.0.6
-        with:
-          api-key: ${{ secrets.RIG_API_KEY }}
-          project-id: ${{ env.ZAD_PROJECT }}
-          deployment-name: regelrecht
-          component: pipelineapi
-          image: ${{ env.REGISTRY }}/minbzk/regelrecht-pipeline-api:sha-${{ steps.sha.outputs.short }}
+          # De editor gaat als eerste in de lijst: de action leidt de
+          # environment-URL af van de eerste component.
+          if [ "$EDITOR" = success ]; then add editor regelrecht-editor; fi
+          if [ "$ADMIN" = success ]; then add harvester-admin regelrecht-admin; fi
+          if [ "$HARVESTER_WORKER" = success ]; then add harvester-worker regelrecht-harvester-worker; fi
+          if [ "$ENRICH_WORKER" = success ]; then add enrichworker regelrecht-enrich-worker; fi
+          if [ "$PIPELINE_API" = success ]; then add pipelineapi regelrecht-pipeline-api; fi
+          # Grafana bouwt alleen op main, dus alleen productie kent deze regel.
+          if [ "$GRAFANA" = success ]; then add grafana regelrecht-grafana; fi
+          if [ "$LAWMAKING" = success ]; then add lawmaking regelrecht-lawmaking; fi
+          if [ "$DOCS" = success ]; then add docs regelrecht-docs; fi
 
-      - name: Deploy editor to ZAD (Production)
-        if: needs.build.result == 'success'
+          jq -r '.[] | "  \(.name): \(.image)"' <<<"$COMPONENTS"
+          echo "components=$COMPONENTS" >> "$GITHUB_OUTPUT"
+
+      # Geen clone-from: regelrecht is zelf de bron waar de previews van
+      # klonen. Geen domain-format: de hostnamen van productie liggen vast in
+      # de bestaande config en moeten daar niet door een deploy verschuiven.
+      - name: Deploy to ZAD (Production)
         id: deploy
         uses: RijksICTGilde/zad-actions/deploy@13434cd415db0cd195a2c5f12bf67645acfcb635  # v4.0.6
         with:
           api-key: ${{ secrets.RIG_API_KEY }}
           project-id: ${{ env.ZAD_PROJECT }}
           deployment-name: regelrecht
-          component: editor
-          image: ${{ env.REGISTRY }}/minbzk/regelrecht-editor:sha-${{ steps.sha.outputs.short }}
+          components: ${{ steps.plan.outputs.components }}
 
-      - name: Deploy harvester-worker to ZAD (Production)
-        if: needs.build-harvester-worker.result == 'success'
-        uses: RijksICTGilde/zad-actions/deploy@13434cd415db0cd195a2c5f12bf67645acfcb635  # v4.0.6
-        with:
-          api-key: ${{ secrets.RIG_API_KEY }}
-          project-id: ${{ env.ZAD_PROJECT }}
-          deployment-name: regelrecht
-          component: harvester-worker
-          image: ${{ env.REGISTRY }}/minbzk/regelrecht-harvester-worker:sha-${{ steps.sha.outputs.short }}
+      - name: Editor-URL voor de environment
+        id: editor-url
+        if: needs.build.result == 'success'
+        env:
+          URLS: ${{ steps.deploy.outputs.urls }}
+        run: echo "url=$(jq -r '.editor // empty' <<<"$URLS")" >> "$GITHUB_OUTPUT"
 
-      - name: Deploy enrich-worker to ZAD (Production)
-        if: needs.build-enrich-worker.result == 'success'
-        uses: RijksICTGilde/zad-actions/deploy@13434cd415db0cd195a2c5f12bf67645acfcb635  # v4.0.6
-        with:
-          api-key: ${{ secrets.RIG_API_KEY }}
-          project-id: ${{ env.ZAD_PROJECT }}
-          deployment-name: regelrecht
-          component: enrichworker
-          image: ${{ env.REGISTRY }}/minbzk/regelrecht-enrich-worker:sha-${{ steps.sha.outputs.short }}
-
-      - name: Deploy grafana to ZAD (Production)
-        if: needs.build-grafana.result == 'success'
-        uses: RijksICTGilde/zad-actions/deploy@13434cd415db0cd195a2c5f12bf67645acfcb635  # v4.0.6
-        with:
-          api-key: ${{ secrets.RIG_API_KEY }}
-          project-id: ${{ env.ZAD_PROJECT }}
-          deployment-name: regelrecht
-          component: grafana
-          image: ${{ env.REGISTRY }}/minbzk/regelrecht-grafana:sha-${{ steps.sha.outputs.short }}
-
-      - name: Deploy lawmaking to ZAD (Production)
-        if: needs.build-lawmaking.result == 'success'
-        uses: RijksICTGilde/zad-actions/deploy@13434cd415db0cd195a2c5f12bf67645acfcb635  # v4.0.6
-        with:
-          api-key: ${{ secrets.RIG_API_KEY }}
-          project-id: ${{ env.ZAD_PROJECT }}
-          deployment-name: regelrecht
-          component: lawmaking
-          image: ${{ env.REGISTRY }}/minbzk/regelrecht-lawmaking:sha-${{ steps.sha.outputs.short }}
-
-      - name: Deploy docs to ZAD (Production)
-        if: needs.build-docs.result == 'success'
-        uses: RijksICTGilde/zad-actions/deploy@13434cd415db0cd195a2c5f12bf67645acfcb635  # v4.0.6
-        with:
-          api-key: ${{ secrets.RIG_API_KEY }}
-          project-id: ${{ env.ZAD_PROJECT }}
-          deployment-name: regelrecht
-          component: docs
-          image: ${{ env.REGISTRY }}/minbzk/regelrecht-docs:sha-${{ steps.sha.outputs.short }}
+      - name: Verklaar een mislukte deploy
+        if: failure() && steps.deploy.outcome == 'failure'
+        env:
+          COMPONENTS: ${{ steps.plan.outputs.components }}
+        run: |
+          echo "::notice::Deploy van regelrecht mislukt voor: $(jq -r '[.[].name] | join(", ")' <<<"$COMPONENTS")"
+          echo "'status: superseded' in de output hierboven betekent dat een nieuwere taak"
+          echo "voor dit deployment (een volgende merge naar main) het werk heeft overgenomen."
+          echo "Deze job opnieuw draaien is dan veilig."
+          echo "Iets anders? Zie 'Debugging deploy-preview failures' in CLAUDE.md."
 
   # -- Cleanup preview --
   cleanup-preview:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,8 +244,9 @@ One failure is benign: `Could not extract URL from result` met `"status":
 "superseded"` in de JSON eronder. ZAD laat een taak wijken voor een nieuwere
 taak die dezelfde deployment dekt (een nieuwe push, of het opruimen van een
 gesloten PR). Het werk is dan door die nieuwere taak gedaan; alleen deze job
-opnieuw draaien volstaat. Om die reden deployt `deploy-preview` alle componenten
-in één taak: twee taken voor `pr<N>` naast elkaar zetten elkaar opzij.
+opnieuw draaien volstaat. Om die reden deployen `deploy-preview` en
+`deploy-production` alle componenten in één taak: twee taken voor hetzelfde
+deployment naast elkaar zetten elkaar opzij.
 
 ### Required Secrets
 


### PR DESCRIPTION
`deploy-production` deployde acht componenten in acht losse stappen naar hetzelfde ZAD-deployment. Dat kan niet sneller: ZAD geeft een upsert de scope van de deploymentnaam, dus gelijktijdige taken voor `regelrecht` zetten elkaar opzij. De job kost daardoor 8,1 minuten per merge naar main.

Productie krijgt nu dezelfde vorm als de preview sinds PR 1148: een plan-stap zet de componenten met een geslaagde build in één JSON-lijst, en één aanroep van `zad-actions/deploy` rolt ze samen uit. Diezelfde vorm deed 78 seconden op PR 1149.

Wat productie anders houdt dan de preview: geen `clone-from`/`force-clone` (regelrecht is zelf de bron waar previews van klonen), geen `domain-format` (de hostnamen liggen vast in de bestaande config), geen PR-comment, en grafana staat wel in de lijst omdat dat image alleen op main gebouwd wordt.