### PR TITLE
ci: geen merge voordat de review over deze commit iets gezegd heeft

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,8 +9,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # A fork PR gets no secrets, so CLAUDE_CODE_OAUTH_TOKEN is empty there and the
+  # action can only fail. Skip instead, and let review-gate report that.
   claude-review:
-    if: ${{ !github.event.pull_request.draft && github.event.pull_request.user.login != 'dependabot[bot]' }}
+    if: >-
+      ${{ !github.event.pull_request.draft &&
+          github.event.pull_request.head.repo.fork != true &&
+          github.event.pull_request.user.login != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -98,3 +103,35 @@ jobs:
             Also leave inline comments on specific lines where possible.
 
             If there are no issues, say so briefly. Do not pad the review with praise or filler.
+
+  # The merge gate. Unlike claude-review this job has no `if:` — it must run and
+  # report on every PR, forks and dependabot included, because a required check
+  # that never reports blocks such a PR forever.
+  review-gate:
+    name: Claude review completed
+    runs-on: ubuntu-latest
+    # Ruim boven de ~10 minuten die de review kost, zodat een trage run niet
+    # onterecht rood wordt; het script stopt zelf eerder met een duidelijke melding.
+    timeout-minutes: 40
+    permissions:
+      contents: read
+      checks: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 1
+
+      - name: Wait for the Claude review of this commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+          IS_DRAFT: ${{ github.event.pull_request.draft }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          CHECK_NAME: claude-review
+          MAX_WAIT_SECONDS: '2100'
+          POLL_SECONDS: '20'
+        run: script/await-claude-review.sh

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -116,6 +116,7 @@ jobs:
     permissions:
       contents: read
       checks: read
+      pull-requests: read
 
     steps:
       - name: Checkout repository
@@ -128,6 +129,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
           IS_DRAFT: ${{ github.event.pull_request.draft }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,12 +9,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # A fork PR gets no secrets, so CLAUDE_CODE_OAUTH_TOKEN is empty there and the
-  # action can only fail. Skip instead, and let review-gate report that.
+  # A cross-repo PR gets no secrets, so CLAUDE_CODE_OAUTH_TOKEN is empty there and
+  # the action can only fail. Skip instead, and let review-gate report that.
+  # Compare full_name rather than reading `head.repo.fork`: inside a fork of this
+  # repo its own PRs are not cross-repo and do have secrets.
   claude-review:
     if: >-
       ${{ !github.event.pull_request.draft &&
-          github.event.pull_request.head.repo.fork != true &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
           github.event.pull_request.user.login != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     permissions:
@@ -105,8 +107,8 @@ jobs:
             If there are no issues, say so briefly. Do not pad the review with praise or filler.
 
   # The merge gate. Unlike claude-review this job has no `if:` — it must run and
-  # report on every PR, forks and dependabot included, because a required check
-  # that never reports blocks such a PR forever.
+  # report on every PR, cross-repo and dependabot included, because a required
+  # check that never reports blocks such a PR forever.
   review-gate:
     name: Claude review completed
     runs-on: ubuntu-latest
@@ -114,8 +116,9 @@ jobs:
     # onterecht rood wordt; het script stopt zelf eerder met een duidelijke melding.
     timeout-minutes: 40
     permissions:
+      actions: read
       contents: read
-      checks: read
+      issues: read
       pull-requests: read
 
     steps:
@@ -124,16 +127,39 @@ jobs:
         with:
           fetch-depth: 1
 
+      # De poort mag niet draaien op de versie van zichzelf die in de PR staat:
+      # een PR die het script naar `exit 0` verandert zou anders per definitie
+      # groen zijn. Draai daarom de versie van de base-branch. Zolang die er nog
+      # niet is (de PR die dit script introduceert) valt hij terug op de PR-versie
+      # met een waarschuwing.
+      - name: Take the gate script from the base branch
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GATE: script/await-claude-review.sh
+        run: |
+          set -uo pipefail
+          if ! git fetch --depth=1 origin "$BASE_SHA"; then
+            echo "::error title=Claude review gate::base-commit ${BASE_SHA} is niet op te halen, dus de versie van de poort is niet vast te stellen. Draai deze job opnieuw."
+            exit 1
+          fi
+          if git cat-file -e "${BASE_SHA}:${GATE}" 2>/dev/null; then
+            git checkout "$BASE_SHA" -- "$GATE"
+            echo "Poort draait de versie van ${BASE_SHA}."
+          else
+            echo "::warning title=Claude review gate::${GATE} bestaat nog niet op de base-branch; de poort draait de versie uit deze PR."
+          fi
+
       - name: Wait for the Claude review of this commit
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          RUN_ID: ${{ github.run_id }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          IS_CROSS_REPO: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
           IS_DRAFT: ${{ github.event.pull_request.draft }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          CHECK_NAME: claude-review
+          JOB_NAME: claude-review
           MAX_WAIT_SECONDS: '2100'
           POLL_SECONDS: '20'
         run: script/await-claude-review.sh

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -129,25 +129,26 @@ jobs:
 
       # De poort mag niet draaien op de versie van zichzelf die in de PR staat:
       # een PR die het script naar `exit 0` verandert zou anders per definitie
-      # groen zijn. Draai daarom de versie van de base-branch. Zolang die er nog
-      # niet is (de PR die dit script introduceert) valt hij terug op de PR-versie
-      # met een waarschuwing.
+      # groen zijn. Draai daarom de versie van de base-branch, en blokkeer als
+      # die niet te krijgen is — terugvallen op de PR-versie is precies de
+      # bypass die deze stap moet dichten.
       - name: Take the gate script from the base branch
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           GATE: script/await-claude-review.sh
         run: |
           set -uo pipefail
-          if ! git fetch --depth=1 origin "$BASE_SHA"; then
-            echo "::error title=Claude review gate::base-commit ${BASE_SHA} is niet op te halen, dus de versie van de poort is niet vast te stellen. Draai deze job opnieuw."
+          fail() {
+            echo "::error title=Claude review gate::$1"
             exit 1
-          fi
-          if git cat-file -e "${BASE_SHA}:${GATE}" 2>/dev/null; then
-            git checkout "$BASE_SHA" -- "$GATE"
-            echo "Poort draait de versie van ${BASE_SHA}."
-          else
-            echo "::warning title=Claude review gate::${GATE} bestaat nog niet op de base-branch; de poort draait de versie uit deze PR."
-          fi
+          }
+          git fetch --depth=1 origin "$BASE_SHA" ||
+            fail "base-commit ${BASE_SHA} is niet op te halen, dus de versie van de poort is niet vast te stellen. Draai deze job opnieuw."
+          git cat-file -e "${BASE_SHA}:${GATE}" 2>/dev/null ||
+            fail "${GATE} bestaat niet op de base-branch (${BASE_SHA}). De poort kan dan niet voor zichzelf instaan; deze PR moet met de hand gereviewd worden."
+          git checkout "$BASE_SHA" -- "$GATE" ||
+            fail "${GATE} is niet uit ${BASE_SHA} te checkouten, dus de poort zou de versie uit deze PR draaien. Draai deze job opnieuw."
+          echo "Poort draait de versie van ${BASE_SHA}."
 
       - name: Wait for the Claude review of this commit
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,11 +14,15 @@ env:
   ZAD_PROJECT: regel-k4c
 
 jobs:
+  # De fork-voorwaarde schakelt via `needs: changes` de hele build- en
+  # deploy-keten uit. Een fork-PR krijgt geen secrets en een read-only
+  # GITHUB_TOKEN, dus de push naar GHCR faalt daar per definitie.
   changes:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: >-
       github.event.action != 'closed' &&
+      github.event.pull_request.head.repo.fork != true &&
       (github.event.action != 'labeled' || startsWith(github.event.label.name, 'deploy:'))
     permissions:
       contents: read
@@ -394,7 +398,11 @@ jobs:
   cleanup-preview:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    # Een fork-PR heeft nooit gebouwd of gedeployd, dus er valt niets op te
+    # ruimen en de GHCR-aanroepen zouden alleen maar op rechten stuklopen.
+    if: >-
+      github.event_name == 'pull_request' && github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.fork != true
     permissions:
       packages: write
       deployments: write

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,6 +71,13 @@ repos:
         pass_filenames: false
         files: (^frontend/Dockerfile$|^packages/(admin|pipeline)/Dockerfile$)
 
+      - id: review-gate-tests
+        name: Merge-poort op de Claude-review doet wat hij belooft
+        entry: script/await-claude-review.test.sh
+        language: system
+        pass_filenames: false
+        files: ^script/await-claude-review(\.test)?\.sh$
+
       - id: skills-no-casus
         name: Skills blijven dossier-agnostisch (geen casus-inhoud)
         entry: script/check-skills-no-casus.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,34 +219,41 @@ CI runs via `.github/workflows/ci.yml`.
 ten minutes, roughly twice as long as the required checks. Merging on green
 therefore used to be possible before the review had said anything. The
 `review-gate` job (check name **Claude review completed**) closes that window:
-it polls the `claude-review` check-run for the PR head SHA and only passes once
-that run is `completed` with `success` or `neutral`.
+it waits for the `claude-review` job **inside its own workflow run** and only
+passes once that job is `completed` with `success` or `neutral`. It looks the
+job up by run id rather than by head SHA, because `ready_for_review` and
+`reopened` keep the same SHA and a SHA lookup can then read a leftover check-run
+from the previous run.
 
-Read the check-run's `status`, never the number of review comments — zero
-comments is equally consistent with "still running".
+Drive the wait off the job's `status`, never off the number of review comments —
+zero comments is equally consistent with "still running".
 
 `claude-review` itself cannot be a required check, because it does not run on
-fork PRs (no secrets, so `CLAUDE_CODE_OAUTH_TOKEN` is absent) and a required
-check that never reports blocks such a PR forever. `review-gate` always runs and
-always reports; it derives "not applicable" from the PR itself (fork, draft,
-dependabot) rather than from `claude-review`'s conclusion, so a failed or
-skipped review can never pass as an inapplicable one.
+cross-repo (fork) PRs, where no secrets exist and `CLAUDE_CODE_OAUTH_TOKEN` is
+absent, and a required check that never reports blocks such a PR forever.
+`review-gate` always runs and always reports; it derives "not applicable" from
+the PR itself (cross-repo, draft, dependabot) rather than from `claude-review`'s
+conclusion, so a failed or skipped review can never pass as an inapplicable one.
 
-A green check-run is not enough on its own. `claude-code-action` exits with
-conclusion `success` **without reviewing anything** when the workflow file
-differs from the version on the default branch ("Exiting due to workflow
-validation skip"). The gate therefore also requires that `claude[bot]` posted a
-comment or review after the check-run started. Practical consequence: a PR that
-edits `.github/workflows/claude-code-review.yml` cannot get a green gate, and
-needs a human review plus an admin merge. Every other PR is unaffected.
+A green job is not enough on its own. `claude-code-action` exits with conclusion
+`success` **without reviewing anything** when the workflow file differs from the
+version on the default branch ("Exiting due to workflow validation skip"). The
+gate therefore also requires that `claude[bot]` posted a comment or review after
+the job started. Practical consequence: a PR that edits
+`.github/workflows/claude-code-review.yml` cannot get a green gate, and needs a
+human review plus an admin merge. Every other PR is unaffected.
+
+The gate runs the copy of its own script from the base branch, not the one in
+the PR — otherwise a PR could turn the script into `exit 0` and be green by
+construction.
 
 The gate proves the review ran to completion for this commit and produced
 output. It says nothing about the content of the findings or whether they were
 addressed.
 
 The logic lives in `script/await-claude-review.sh`, with
-`script/await-claude-review.test.sh` (a `gh` stub) covering every branch; the
-tests run as a pre-commit hook.
+`script/await-claude-review.test.sh` (a `gh` stub) covering every path that
+decides green versus red; the tests run as a pre-commit hook.
 
 ### Deployed Components
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,10 @@ absent, and a required check that never reports blocks such a PR forever.
 the PR itself (cross-repo, draft, dependabot) rather than from `claude-review`'s
 conclusion, so a failed or skipped review can never pass as an inapplicable one.
 
+Dependabot is a deliberate exemption, not an oversight: those PRs go through
+`claude-dependabot.yml`, and that workflow decides for itself whether to merge.
+The gate does not verify that it ran.
+
 A green job is not enough on its own. `claude-code-action` exits with conclusion
 `success` **without reviewing anything** when the workflow file differs from the
 version on the default branch ("Exiting due to workflow validation skip"). The
@@ -245,7 +249,12 @@ human review plus an admin merge. Every other PR is unaffected.
 
 The gate runs the copy of its own script from the base branch, not the one in
 the PR — otherwise a PR could turn the script into `exit 0` and be green by
-construction.
+construction. If that copy cannot be fetched or checked out, the gate blocks
+rather than falling back to the PR's version.
+
+It looks the review job up with `filter=all`, because the run id survives a
+"Re-run this job" and `claude-review` is then absent from the newest attempt's
+job list.
 
 The gate proves the review ran to completion for this commit and produced
 output. It says nothing about the content of the findings or whether they were

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,32 @@ After completing significant code changes, proactively use the `code-reviewer` s
 All components are deployed to ZAD (RIG/Quattro/rijksapps) via `.github/workflows/deploy.yml`.
 CI runs via `.github/workflows/ci.yml`.
 
+### The Claude review merge gate
+
+`claude-code-review.yml` posts its findings as review comments and takes about
+ten minutes, roughly twice as long as the required checks. Merging on green
+therefore used to be possible before the review had said anything. The
+`review-gate` job (check name **Claude review completed**) closes that window:
+it polls the `claude-review` check-run for the PR head SHA and only passes once
+that run is `completed` with `success` or `neutral`.
+
+Read the check-run's `status`, never the number of review comments — zero
+comments is equally consistent with "still running".
+
+`claude-review` itself cannot be a required check, because it does not run on
+fork PRs (no secrets, so `CLAUDE_CODE_OAUTH_TOKEN` is absent) and a required
+check that never reports blocks such a PR forever. `review-gate` always runs and
+always reports; it derives "not applicable" from the PR itself (fork, draft,
+dependabot) rather than from `claude-review`'s conclusion, so a failed or
+skipped review can never pass as an inapplicable one.
+
+The gate proves the review ran to completion for this commit. It says nothing
+about the content of the findings or whether they were addressed.
+
+The logic lives in `script/await-claude-review.sh`, with
+`script/await-claude-review.test.sh` (a `gh` stub) covering every branch; the
+tests run as a pre-commit hook.
+
 ### Deployed Components
 
 | Component | Image | Production URL |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,8 +232,17 @@ always reports; it derives "not applicable" from the PR itself (fork, draft,
 dependabot) rather than from `claude-review`'s conclusion, so a failed or
 skipped review can never pass as an inapplicable one.
 
-The gate proves the review ran to completion for this commit. It says nothing
-about the content of the findings or whether they were addressed.
+A green check-run is not enough on its own. `claude-code-action` exits with
+conclusion `success` **without reviewing anything** when the workflow file
+differs from the version on the default branch ("Exiting due to workflow
+validation skip"). The gate therefore also requires that `claude[bot]` posted a
+comment or review after the check-run started. Practical consequence: a PR that
+edits `.github/workflows/claude-code-review.yml` cannot get a green gate, and
+needs a human review plus an admin merge. Every other PR is unaffected.
+
+The gate proves the review ran to completion for this commit and produced
+output. It says nothing about the content of the findings or whether they were
+addressed.
 
 The logic lives in `script/await-claude-review.sh`, with
 `script/await-claude-review.test.sh` (a `gh` stub) covering every branch; the

--- a/script/await-claude-review.sh
+++ b/script/await-claude-review.sh
@@ -2,18 +2,19 @@
 # Merge gate: block until the Claude review check-run for this commit is done.
 #
 # Zero review comments is not evidence of "no findings" — it is equally
-# consistent with "the review is still running". So this gate reads the status
-# of the check-run, never the comments.
+# consistent with "the review is still running". So the wait is driven by the
+# check-run's status, never by a comment count.
 #
 # It exits 0 only when the review demonstrably ran to completion for this exact
-# commit, or when the review demonstrably cannot apply (fork, draft, dependabot).
-# Those reasons are read off the pull request itself, not off the review's own
-# result, so a review that ran and failed can never pass as one that was never
-# meant to run.
+# commit and left something behind, or when the review demonstrably cannot apply
+# (fork, draft, dependabot). Those reasons are read off the pull request itself,
+# not off the review's own result, so a review that ran and failed can never
+# pass as one that was never meant to run.
 set -uo pipefail
 
 : "${REPO:?REPO is verplicht}"
 : "${HEAD_SHA:?HEAD_SHA is verplicht}"
+: "${PR_NUMBER:?PR_NUMBER is verplicht}"
 
 IS_FORK="${IS_FORK:-false}"
 IS_DRAFT="${IS_DRAFT:-false}"
@@ -86,14 +87,36 @@ latest=$(jq -c '.check_runs | sort_by(.id) | last' <<<"$response")
 conclusion=$(jq -r '.conclusion // "none"' <<<"$latest")
 url=$(jq -r '.html_url // ""' <<<"$latest")
 
+started_at=$(jq -r '.started_at // ""' <<<"$latest")
+
+# Een groene check-run is niet genoeg. De claude-code-action stapt uit met
+# conclusie `success` zonder ook maar iets te reviewen zodra het workflowbestand
+# afwijkt van dat op de default branch ("Exiting due to workflow validation
+# skip"). Gemeten op PR 1157: veertien seconden, groen, geen review. Eis daarom
+# ook een spoor van de review zelf, geplaatst na de start van deze run. Dat is
+# geen comment-telling vooraf — de status zegt of hij klaar is, dit zegt of hij
+# iets heeft opgeleverd.
+assert_review_output() {
+  local comments reviews newest
+  comments=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" --paginate 2>/dev/null || echo '[]')
+  reviews=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100" --paginate 2>/dev/null || echo '[]')
+  newest=$(printf '%s\n%s\n' "$comments" "$reviews" |
+    jq -rs '[.[][] | select(.user.login == "claude[bot]") | (.updated_at // .submitted_at)] | map(select(. != null)) | sort | last // ""' 2>/dev/null)
+
+  if [ -z "$newest" ] || { [ -n "$started_at" ] && [[ "$newest" < "$started_at" ]]; }; then
+    blocked "\`${CHECK_NAME}\` meldt \`${conclusion}\` voor commit \`${HEAD_SHA}\`, maar claude[bot] heeft in die run niets geplaatst. De review-actie slaat zichzelf over (met conclusie success) zodra \`.github/workflows/claude-code-review.yml\` afwijkt van de versie op de default branch. Wijzigt deze PR dat bestand, dan is er geen automatische review en moet een mens de wijziging nalopen. ${url}"
+  fi
+}
+
 case "$conclusion" in
 success | neutral)
+  assert_review_output
   echo "::notice title=Claude review gate::review afgerond (${conclusion})"
   summary "### Claude review gate: groen"
   summary ""
   summary "\`${CHECK_NAME}\` is afgerond voor commit \`${HEAD_SHA}\` met conclusie \`${conclusion}\`."
   summary ""
-  summary "Wat deze check bewijst: de review is gedraaid en klaar voor precies deze commit. Wat hij niet bewijst: dat de bevindingen deugen of dat ze zijn verwerkt. Dat blijft mensenwerk."
+  summary "Wat deze check bewijst: de review is gedraaid, klaar voor precies deze commit, en heeft daadwerkelijk iets geplaatst. Wat hij niet bewijst: dat de bevindingen deugen of dat ze zijn verwerkt. Dat blijft mensenwerk."
   summary ""
   summary "[Bekijk de review-run](${url})"
   ;;

--- a/script/await-claude-review.sh
+++ b/script/await-claude-review.sh
@@ -1,25 +1,34 @@
 #!/usr/bin/env bash
-# Merge gate: block until the Claude review check-run for this commit is done.
+# Merge gate: block until the Claude review of this workflow run is done.
 #
 # Zero review comments is not evidence of "no findings" — it is equally
 # consistent with "the review is still running". So the wait is driven by the
-# check-run's status, never by a comment count.
+# job's status, never by a comment count.
 #
-# It exits 0 only when the review demonstrably ran to completion for this exact
-# commit and left something behind, or when the review demonstrably cannot apply
-# (fork, draft, dependabot). Those reasons are read off the pull request itself,
-# not off the review's own result, so a review that ran and failed can never
-# pass as one that was never meant to run.
+# It exits 0 only when the review demonstrably ran to completion and left
+# something behind, or when the review demonstrably cannot apply (cross-repo PR,
+# draft, dependabot). Those reasons are read off the pull request itself, not off
+# the review's own result, so a review that ran and failed can never pass as one
+# that was never meant to run.
+#
+# The review job is looked up inside *this* workflow run rather than by head SHA.
+# A `ready_for_review` or `reopened` event keeps the same SHA, so a SHA lookup can
+# race and read the previous run's leftover check-run.
 set -uo pipefail
 
+# Tijdstempels worden als string vergeleken; onder een collatie die interpunctie
+# negeert klopt die volgorde niet meer.
+export LC_ALL=C
+
 : "${REPO:?REPO is verplicht}"
-: "${HEAD_SHA:?HEAD_SHA is verplicht}"
+: "${RUN_ID:?RUN_ID is verplicht}"
 : "${PR_NUMBER:?PR_NUMBER is verplicht}"
 
-IS_FORK="${IS_FORK:-false}"
+IS_CROSS_REPO="${IS_CROSS_REPO:-false}"
 IS_DRAFT="${IS_DRAFT:-false}"
 PR_AUTHOR="${PR_AUTHOR:-}"
-CHECK_NAME="${CHECK_NAME:-claude-review}"
+HEAD_SHA="${HEAD_SHA:-onbekend}"
+JOB_NAME="${JOB_NAME:-claude-review}"
 MAX_WAIT_SECONDS="${MAX_WAIT_SECONDS:-2100}"
 POLL_SECONDS="${POLL_SECONDS:-20}"
 GITHUB_STEP_SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/null}"
@@ -42,69 +51,75 @@ blocked() {
   exit 1
 }
 
-if [ "$IS_FORK" = "true" ]; then
-  not_applicable "Deze PR komt van een fork. Fork-PR's krijgen geen secrets, dus \`CLAUDE_CODE_OAUTH_TOKEN\` ontbreekt en \`${CHECK_NAME}\` draait daar niet. Review deze wijziging met de hand voordat je merget."
+if [ "$IS_CROSS_REPO" = "true" ]; then
+  not_applicable "Deze PR komt uit een andere repository (een fork). Zulke PR's krijgen geen secrets, dus \`CLAUDE_CODE_OAUTH_TOKEN\` ontbreekt en \`${JOB_NAME}\` draait daar niet. Review deze wijziging met de hand voordat je merget."
 fi
 
 if [ "$IS_DRAFT" = "true" ]; then
-  not_applicable "Deze PR staat op draft. \`${CHECK_NAME}\` draait pas bij \"ready for review\", en een draft is niet mergebaar."
+  not_applicable "Deze PR staat op draft. \`${JOB_NAME}\` draait pas bij \"ready for review\", en een draft is niet mergebaar."
 fi
 
 if [ "$PR_AUTHOR" = "dependabot[bot]" ]; then
-  not_applicable "Deze PR komt van dependabot. Die loopt via de \`claude-dependabot\`-workflow, niet via \`${CHECK_NAME}\`."
+  not_applicable "Deze PR komt van dependabot. Die loopt via de \`claude-dependabot\`-workflow, niet via \`${JOB_NAME}\`."
 fi
 
-echo "Wachten op check-run '${CHECK_NAME}' voor commit ${HEAD_SHA} (max ${MAX_WAIT_SECONDS}s)."
+echo "Wachten op job '${JOB_NAME}' in workflow-run ${RUN_ID} (commit ${HEAD_SHA}, max ${MAX_WAIT_SECONDS}s)."
 deadline=$(($(date +%s) + MAX_WAIT_SECONDS))
+job=''
+status=''
 
 while :; do
-  if ! response=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?check_name=${CHECK_NAME}&per_page=100" 2>&1); then
+  if ! response=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs?per_page=100" 2>&1); then
     echo "API-aanroep mislukt, opnieuw proberen: ${response}"
-    response='{"check_runs":[]}'
+    response='{"jobs":[]}'
   fi
 
-  total=$(jq '.check_runs | length' <<<"$response" 2>/dev/null || echo 0)
-  unfinished=$(jq '[.check_runs[] | select(.status != "completed")] | length' <<<"$response" 2>/dev/null || echo 1)
+  job=$(jq -c --arg name "$JOB_NAME" '[.jobs[] | select(.name == $name)] | last // empty' <<<"$response" 2>/dev/null)
+  status=''
+  [ -n "$job" ] && status=$(jq -r '.status // ""' <<<"$job" 2>/dev/null)
 
-  if [ "$total" -gt 0 ] && [ "$unfinished" -eq 0 ]; then
+  if [ "$status" = "completed" ]; then
     break
   fi
 
   if [ "$(date +%s)" -ge "$deadline" ]; then
-    if [ "$total" -eq 0 ]; then
-      blocked "Na ${MAX_WAIT_SECONDS}s bestaat er geen check-run \`${CHECK_NAME}\` voor commit \`${HEAD_SHA}\`. De review is niet gestart; start de workflow opnieuw via de Actions-tab."
+    if [ -z "$job" ]; then
+      blocked "Na ${MAX_WAIT_SECONDS}s zit er geen job \`${JOB_NAME}\` in workflow-run ${RUN_ID}. De review is niet gestart; start de workflow opnieuw via de Actions-tab."
     fi
-    blocked "Na ${MAX_WAIT_SECONDS}s is \`${CHECK_NAME}\` voor commit \`${HEAD_SHA}\` nog niet klaar. Draai deze job opnieuw zodra de review af is."
+    blocked "Na ${MAX_WAIT_SECONDS}s is \`${JOB_NAME}\` nog niet klaar (status \`${status}\`). Draai deze job opnieuw zodra de review af is."
   fi
 
-  echo "Nog niet klaar (${total} check-run(s), waarvan ${unfinished} bezig). Volgende poging over ${POLL_SECONDS}s."
+  echo "Nog niet klaar (status '${status:-geen job gevonden}'). Volgende poging over ${POLL_SECONDS}s."
   sleep "$POLL_SECONDS"
 done
 
-# Na een re-run staan er meerdere check-runs met dezelfde naam op dezelfde sha;
-# de hoogste id is de meest recente.
-latest=$(jq -c '.check_runs | sort_by(.id) | last' <<<"$response")
-conclusion=$(jq -r '.conclusion // "none"' <<<"$latest")
-url=$(jq -r '.html_url // ""' <<<"$latest")
+conclusion=$(jq -r '.conclusion // "none"' <<<"$job")
+url=$(jq -r '.html_url // ""' <<<"$job")
+started_at=$(jq -r '.started_at // ""' <<<"$job")
 
-started_at=$(jq -r '.started_at // ""' <<<"$latest")
-
-# Een groene check-run is niet genoeg. De claude-code-action stapt uit met
-# conclusie `success` zonder ook maar iets te reviewen zodra het workflowbestand
-# afwijkt van dat op de default branch ("Exiting due to workflow validation
-# skip"). Gemeten op PR 1157: veertien seconden, groen, geen review. Eis daarom
-# ook een spoor van de review zelf, geplaatst na de start van deze run. Dat is
-# geen comment-telling vooraf — de status zegt of hij klaar is, dit zegt of hij
-# iets heeft opgeleverd.
+# Een groene job is niet genoeg. De claude-code-action stapt uit met conclusie
+# `success` zonder ook maar iets te reviewen zodra het workflowbestand afwijkt
+# van dat op de default branch ("Exiting due to workflow validation skip").
+# Gemeten op PR 1157: veertien seconden, groen, geen review. Eis daarom ook een
+# spoor van de review zelf, geplaatst na de start van die job. Dat is geen
+# comment-telling vooraf; de status zegt of hij klaar is, dit zegt of hij iets
+# heeft opgeleverd.
 assert_review_output() {
-  local comments reviews newest
-  comments=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" --paginate 2>/dev/null || echo '[]')
-  reviews=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100" --paginate 2>/dev/null || echo '[]')
-  newest=$(printf '%s\n%s\n' "$comments" "$reviews" |
-    jq -rs '[.[][] | select(.user.login == "claude[bot]") | (.updated_at // .submitted_at)] | map(select(. != null)) | sort | last // ""' 2>/dev/null)
+  if [ -z "$started_at" ]; then
+    blocked "\`${JOB_NAME}\` levert geen \`started_at\`, dus is niet vast te stellen of een spoor van claude[bot] uit deze run komt of van een eerdere. Daar gokt de poort niet op. ${url}"
+  fi
 
-  if [ -z "$newest" ] || { [ -n "$started_at" ] && [[ "$newest" < "$started_at" ]]; }; then
-    blocked "\`${CHECK_NAME}\` meldt \`${conclusion}\` voor commit \`${HEAD_SHA}\`, maar claude[bot] heeft in die run niets geplaatst. De review-actie slaat zichzelf over (met conclusie success) zodra \`.github/workflows/claude-code-review.yml\` afwijkt van de versie op de default branch. Wijzigt deze PR dat bestand, dan is er geen automatische review en moet een mens de wijziging nalopen. ${url}"
+  local endpoint payload stamps='' newest
+  for endpoint in "issues/${PR_NUMBER}/comments" "pulls/${PR_NUMBER}/reviews"; do
+    if ! payload=$(gh api "repos/${REPO}/${endpoint}?per_page=100" --paginate 2>&1); then
+      blocked "\`repos/${REPO}/${endpoint}\` is niet te lezen, dus of claude[bot] iets heeft geplaatst is onbekend. Dat is geen uitspraak over de review zelf; draai deze job opnieuw. Foutmelding: ${payload}"
+    fi
+    stamps+=$(jq -rs '.[] | arrays | .[] | select(.user.login == "claude[bot]") | (.updated_at // .submitted_at) | select(. != null)' <<<"$payload" 2>/dev/null)$'\n'
+  done
+  newest=$(printf '%s' "$stamps" | grep -v '^$' | sort | tail -1)
+
+  if [ -z "$newest" ] || [[ "$newest" < "$started_at" ]]; then
+    blocked "\`${JOB_NAME}\` meldt \`${conclusion}\`, maar claude[bot] heeft in die run niets geplaatst. De review-actie slaat zichzelf over (met conclusie success) zodra \`.github/workflows/claude-code-review.yml\` afwijkt van de versie op de default branch. Wijzigt deze PR dat bestand, dan is er geen automatische review en moet een mens de wijziging nalopen. ${url}"
   fi
 }
 
@@ -114,16 +129,17 @@ success | neutral)
   echo "::notice title=Claude review gate::review afgerond (${conclusion})"
   summary "### Claude review gate: groen"
   summary ""
-  summary "\`${CHECK_NAME}\` is afgerond voor commit \`${HEAD_SHA}\` met conclusie \`${conclusion}\`."
+  summary "\`${JOB_NAME}\` is afgerond voor commit \`${HEAD_SHA}\` met conclusie \`${conclusion}\`."
   summary ""
   summary "Wat deze check bewijst: de review is gedraaid, klaar voor precies deze commit, en heeft daadwerkelijk iets geplaatst. Wat hij niet bewijst: dat de bevindingen deugen of dat ze zijn verwerkt. Dat blijft mensenwerk."
   summary ""
   summary "[Bekijk de review-run](${url})"
+  exit 0
   ;;
 skipped)
-  blocked "\`${CHECK_NAME}\` is overgeslagen voor commit \`${HEAD_SHA}\`, terwijl deze PR geen fork, geen draft en niet van dependabot is. Er is dus geen review. Zoek uit waarom de job is overgeslagen: ${url}"
+  blocked "\`${JOB_NAME}\` is overgeslagen, terwijl deze PR geen fork, geen draft en niet van dependabot is. Er is dus geen review. Zoek uit waarom de job is overgeslagen: ${url}"
   ;;
 *)
-  blocked "\`${CHECK_NAME}\` eindigde op \`${conclusion}\` voor commit \`${HEAD_SHA}\`. Er is geen bruikbare review. Draai hem opnieuw: ${url}"
+  blocked "\`${JOB_NAME}\` eindigde op \`${conclusion}\`. Er is geen bruikbare review. Draai hem opnieuw: ${url}"
   ;;
 esac

--- a/script/await-claude-review.sh
+++ b/script/await-claude-review.sh
@@ -67,14 +67,22 @@ echo "Wachten op job '${JOB_NAME}' in workflow-run ${RUN_ID} (commit ${HEAD_SHA}
 deadline=$(($(date +%s) + MAX_WAIT_SECONDS))
 job=''
 status=''
+last_error=''
 
+# `filter=all` is essentieel: het run-id blijft gelijk over attempts heen, dus na
+# "Re-run this job" op alleen de poort zit `claude-review` niet in de joblijst van
+# de nieuwste attempt. Over meerdere attempts is de volgorde niet gespecificeerd,
+# vandaar `max_by(.id)`.
 while :; do
-  if ! response=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs?per_page=100" 2>&1); then
-    echo "API-aanroep mislukt, opnieuw proberen: ${response}"
+  if response=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs?filter=all&per_page=100" 2>/dev/null); then
+    last_error=''
+  else
+    last_error="de jobs van workflow-run ${RUN_ID} waren niet op te halen"
+    echo "API-aanroep mislukt, opnieuw proberen."
     response='{"jobs":[]}'
   fi
 
-  job=$(jq -c --arg name "$JOB_NAME" '[.jobs[] | select(.name == $name)] | last // empty' <<<"$response" 2>/dev/null)
+  job=$(jq -c --arg name "$JOB_NAME" '[.jobs[] | select(.name == $name)] | max_by(.id) // empty' <<<"$response" 2>/dev/null)
   status=''
   [ -n "$job" ] && status=$(jq -r '.status // ""' <<<"$job" 2>/dev/null)
 
@@ -83,8 +91,11 @@ while :; do
   fi
 
   if [ "$(date +%s)" -ge "$deadline" ]; then
+    if [ -n "$last_error" ]; then
+      blocked "Na ${MAX_WAIT_SECONDS}s is nog steeds niet vast te stellen of \`${JOB_NAME}\` klaar is: ${last_error}. Dat is geen uitspraak over de review zelf; draai deze job opnieuw."
+    fi
     if [ -z "$job" ]; then
-      blocked "Na ${MAX_WAIT_SECONDS}s zit er geen job \`${JOB_NAME}\` in workflow-run ${RUN_ID}. De review is niet gestart; start de workflow opnieuw via de Actions-tab."
+      blocked "Na ${MAX_WAIT_SECONDS}s zit er geen job \`${JOB_NAME}\` in workflow-run ${RUN_ID}. De review is niet gestart; start de hele workflow opnieuw via de Actions-tab (\"Re-run all jobs\")."
     fi
     blocked "Na ${MAX_WAIT_SECONDS}s is \`${JOB_NAME}\` nog niet klaar (status \`${status}\`). Draai deze job opnieuw zodra de review af is."
   fi
@@ -109,12 +120,18 @@ assert_review_output() {
     blocked "\`${JOB_NAME}\` levert geen \`started_at\`, dus is niet vast te stellen of een spoor van claude[bot] uit deze run komt of van een eerdere. Daar gokt de poort niet op. ${url}"
   fi
 
-  local endpoint payload stamps='' newest
+  # stderr apart houden: een waarschuwing van `gh` op een verder geslaagde
+  # aanroep zou de payload anders onparseerbaar maken, en dat kwam dan als
+  # "geen review" naar buiten in plaats van als leesprobleem.
+  local endpoint payload found stamps='' newest
   for endpoint in "issues/${PR_NUMBER}/comments" "pulls/${PR_NUMBER}/reviews"; do
-    if ! payload=$(gh api "repos/${REPO}/${endpoint}?per_page=100" --paginate 2>&1); then
-      blocked "\`repos/${REPO}/${endpoint}\` is niet te lezen, dus of claude[bot] iets heeft geplaatst is onbekend. Dat is geen uitspraak over de review zelf; draai deze job opnieuw. Foutmelding: ${payload}"
+    if ! payload=$(gh api "repos/${REPO}/${endpoint}?per_page=100" --paginate 2>"${TMPDIR:-/tmp}/gate-stderr"); then
+      blocked "\`repos/${REPO}/${endpoint}\` is niet te lezen, dus of claude[bot] iets heeft geplaatst is onbekend. Dat is geen uitspraak over de review zelf; draai deze job opnieuw. Foutmelding: $(cat "${TMPDIR:-/tmp}/gate-stderr")"
     fi
-    stamps+=$(jq -rs '.[] | arrays | .[] | select(.user.login == "claude[bot]") | (.updated_at // .submitted_at) | select(. != null)' <<<"$payload" 2>/dev/null)$'\n'
+    if ! found=$(jq -rs '.[] | arrays | .[] | select(.user.login == "claude[bot]") | (.updated_at // .submitted_at) | select(. != null)' <<<"$payload"); then
+      blocked "Het antwoord van \`repos/${REPO}/${endpoint}\` is geen bruikbare JSON, dus of claude[bot] iets heeft geplaatst is onbekend. Dat is geen uitspraak over de review zelf; draai deze job opnieuw."
+    fi
+    stamps+="${found}"$'\n'
   done
   newest=$(printf '%s' "$stamps" | grep -v '^$' | sort | tail -1)
 

--- a/script/await-claude-review.sh
+++ b/script/await-claude-review.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Merge gate: block until the Claude review check-run for this commit is done.
+#
+# Zero review comments is not evidence of "no findings" — it is equally
+# consistent with "the review is still running". So this gate reads the status
+# of the check-run, never the comments.
+#
+# It exits 0 only when the review demonstrably ran to completion for this exact
+# commit, or when the review demonstrably cannot apply (fork, draft, dependabot).
+# Those reasons are read off the pull request itself, not off the review's own
+# result, so a review that ran and failed can never pass as one that was never
+# meant to run.
+set -uo pipefail
+
+: "${REPO:?REPO is verplicht}"
+: "${HEAD_SHA:?HEAD_SHA is verplicht}"
+
+IS_FORK="${IS_FORK:-false}"
+IS_DRAFT="${IS_DRAFT:-false}"
+PR_AUTHOR="${PR_AUTHOR:-}"
+CHECK_NAME="${CHECK_NAME:-claude-review}"
+MAX_WAIT_SECONDS="${MAX_WAIT_SECONDS:-2100}"
+POLL_SECONDS="${POLL_SECONDS:-20}"
+GITHUB_STEP_SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+summary() { printf '%s\n' "$1" >>"$GITHUB_STEP_SUMMARY"; }
+
+not_applicable() {
+  echo "::notice title=Claude review gate::niet van toepassing — $1"
+  summary "### Claude review gate: niet van toepassing"
+  summary ""
+  summary "$1"
+  exit 0
+}
+
+blocked() {
+  echo "::error title=Claude review gate::$1"
+  summary "### Claude review gate: geblokkeerd"
+  summary ""
+  summary "$1"
+  exit 1
+}
+
+if [ "$IS_FORK" = "true" ]; then
+  not_applicable "Deze PR komt van een fork. Fork-PR's krijgen geen secrets, dus \`CLAUDE_CODE_OAUTH_TOKEN\` ontbreekt en \`${CHECK_NAME}\` draait daar niet. Review deze wijziging met de hand voordat je merget."
+fi
+
+if [ "$IS_DRAFT" = "true" ]; then
+  not_applicable "Deze PR staat op draft. \`${CHECK_NAME}\` draait pas bij \"ready for review\", en een draft is niet mergebaar."
+fi
+
+if [ "$PR_AUTHOR" = "dependabot[bot]" ]; then
+  not_applicable "Deze PR komt van dependabot. Die loopt via de \`claude-dependabot\`-workflow, niet via \`${CHECK_NAME}\`."
+fi
+
+echo "Wachten op check-run '${CHECK_NAME}' voor commit ${HEAD_SHA} (max ${MAX_WAIT_SECONDS}s)."
+deadline=$(($(date +%s) + MAX_WAIT_SECONDS))
+
+while :; do
+  if ! response=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?check_name=${CHECK_NAME}&per_page=100" 2>&1); then
+    echo "API-aanroep mislukt, opnieuw proberen: ${response}"
+    response='{"check_runs":[]}'
+  fi
+
+  total=$(jq '.check_runs | length' <<<"$response" 2>/dev/null || echo 0)
+  unfinished=$(jq '[.check_runs[] | select(.status != "completed")] | length' <<<"$response" 2>/dev/null || echo 1)
+
+  if [ "$total" -gt 0 ] && [ "$unfinished" -eq 0 ]; then
+    break
+  fi
+
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    if [ "$total" -eq 0 ]; then
+      blocked "Na ${MAX_WAIT_SECONDS}s bestaat er geen check-run \`${CHECK_NAME}\` voor commit \`${HEAD_SHA}\`. De review is niet gestart; start de workflow opnieuw via de Actions-tab."
+    fi
+    blocked "Na ${MAX_WAIT_SECONDS}s is \`${CHECK_NAME}\` voor commit \`${HEAD_SHA}\` nog niet klaar. Draai deze job opnieuw zodra de review af is."
+  fi
+
+  echo "Nog niet klaar (${total} check-run(s), waarvan ${unfinished} bezig). Volgende poging over ${POLL_SECONDS}s."
+  sleep "$POLL_SECONDS"
+done
+
+# Na een re-run staan er meerdere check-runs met dezelfde naam op dezelfde sha;
+# de hoogste id is de meest recente.
+latest=$(jq -c '.check_runs | sort_by(.id) | last' <<<"$response")
+conclusion=$(jq -r '.conclusion // "none"' <<<"$latest")
+url=$(jq -r '.html_url // ""' <<<"$latest")
+
+case "$conclusion" in
+success | neutral)
+  echo "::notice title=Claude review gate::review afgerond (${conclusion})"
+  summary "### Claude review gate: groen"
+  summary ""
+  summary "\`${CHECK_NAME}\` is afgerond voor commit \`${HEAD_SHA}\` met conclusie \`${conclusion}\`."
+  summary ""
+  summary "Wat deze check bewijst: de review is gedraaid en klaar voor precies deze commit. Wat hij niet bewijst: dat de bevindingen deugen of dat ze zijn verwerkt. Dat blijft mensenwerk."
+  summary ""
+  summary "[Bekijk de review-run](${url})"
+  ;;
+skipped)
+  blocked "\`${CHECK_NAME}\` is overgeslagen voor commit \`${HEAD_SHA}\`, terwijl deze PR geen fork, geen draft en niet van dependabot is. Er is dus geen review. Zoek uit waarom de job is overgeslagen: ${url}"
+  ;;
+*)
+  blocked "\`${CHECK_NAME}\` eindigde op \`${conclusion}\` voor commit \`${HEAD_SHA}\`. Er is geen bruikbare review. Draai hem opnieuw: ${url}"
+  ;;
+esac

--- a/script/await-claude-review.test.sh
+++ b/script/await-claude-review.test.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # Tests voor script/await-claude-review.sh.
 #
-# `gh` wordt vervangen door een stub die een vast JSON-antwoord teruggeeft, of
-# een reeks antwoorden (één per regel-index) om een lopende review te simuleren
-# die later klaar is. Zo is elk pad deterministisch te bewijzen zonder GitHub.
+# `gh` wordt vervangen door een stub die per endpoint antwoordt: check-runs uit
+# een reeks (één antwoord per aanroep, zodat een lopende review die later klaar
+# is te simuleren valt), comments en reviews uit vaste fixtures. Zo is elk pad
+# deterministisch te bewijzen zonder GitHub.
 set -uo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -15,20 +16,33 @@ trap 'rm -rf "$WORK"' EXIT
 mkdir -p "${WORK}/bin"
 cat >"${WORK}/bin/gh" <<'STUB'
 #!/usr/bin/env bash
-# Geeft het n-de antwoord uit $STUB_RESPONSES terug en telt de aanroepen.
-n=$(cat "$STUB_COUNTER")
-echo $((n + 1)) >"$STUB_COUNTER"
-mapfile -t responses <"$STUB_RESPONSES"
-idx=$n
-if [ "$idx" -ge "${#responses[@]}" ]; then
-  idx=$((${#responses[@]} - 1))
-fi
-line="${responses[$idx]}"
-if [ "$line" = "ERROR" ]; then
-  echo "gh: simulated API failure" >&2
+# Routeert op URL. Check-runs komen uit $STUB_RESPONSES, één antwoord per
+# aanroep, zodat een nog lopende review die later klaar is te simuleren is.
+# Comments en reviews komen uit vaste bestanden.
+url="$2"
+case "$url" in
+*check-runs*)
+  n=$(cat "$STUB_COUNTER")
+  echo $((n + 1)) >"$STUB_COUNTER"
+  mapfile -t responses <"$STUB_RESPONSES"
+  idx=$n
+  if [ "$idx" -ge "${#responses[@]}" ]; then
+    idx=$((${#responses[@]} - 1))
+  fi
+  line="${responses[$idx]}"
+  if [ "$line" = "ERROR" ]; then
+    echo "gh: simulated API failure" >&2
+    exit 1
+  fi
+  printf '%s\n' "$line"
+  ;;
+*/comments*) cat "$STUB_COMMENTS" ;;
+*/reviews*) cat "$STUB_REVIEWS" ;;
+*)
+  echo "gh: onverwachte URL: $url" >&2
   exit 1
-fi
-printf '%s\n' "$line"
+  ;;
+esac
 STUB
 chmod +x "${WORK}/bin/gh"
 export PATH="${WORK}/bin:${PATH}"
@@ -43,16 +57,23 @@ run() {
 
   export STUB_COUNTER="${WORK}/counter"
   export STUB_RESPONSES="${WORK}/responses"
+  export STUB_COMMENTS="${WORK}/comments"
+  export STUB_REVIEWS="${WORK}/reviews"
   echo 0 >"$STUB_COUNTER"
+  [ -f "$STUB_COMMENTS" ] || echo '[]' >"$STUB_COMMENTS"
+  [ -f "$STUB_REVIEWS" ] || echo '[]' >"$STUB_REVIEWS"
 
   local out code
   out=$(env "$@" \
     REPO='example-org/example-repo' \
     HEAD_SHA='0000000000000000000000000000000000000000' \
+    PR_NUMBER='1' \
     POLL_SECONDS=0 \
     GITHUB_STEP_SUMMARY="${WORK}/summary.md" \
     STUB_COUNTER="$STUB_COUNTER" \
     STUB_RESPONSES="$STUB_RESPONSES" \
+    STUB_COMMENTS="$STUB_COMMENTS" \
+    STUB_REVIEWS="$STUB_REVIEWS" \
     "$GATE" 2>&1)
   code=$?
 
@@ -73,15 +94,26 @@ run() {
 }
 
 responses() { printf '%s\n' "$@" >"${WORK}/responses"; }
+comments() { printf '%s\n' "$1" >"${WORK}/comments"; }
+reviews() { printf '%s\n' "$1" >"${WORK}/reviews"; }
 
-RUNNING='{"check_runs":[{"id":1,"status":"in_progress","conclusion":null,"html_url":"http://example.invalid/1"}]}'
-DONE_OK='{"check_runs":[{"id":1,"status":"completed","conclusion":"success","html_url":"http://example.invalid/1"}]}'
-DONE_FAIL='{"check_runs":[{"id":1,"status":"completed","conclusion":"failure","html_url":"http://example.invalid/1"}]}'
-DONE_CANCELLED='{"check_runs":[{"id":1,"status":"completed","conclusion":"cancelled","html_url":"http://example.invalid/1"}]}'
-DONE_SKIPPED='{"check_runs":[{"id":1,"status":"completed","conclusion":"skipped","html_url":"http://example.invalid/1"}]}'
+RUNNING='{"check_runs":[{"id":1,"status":"in_progress","conclusion":null,"started_at":"2026-01-01T12:00:00Z","html_url":"http://example.invalid/1"}]}'
+DONE_OK='{"check_runs":[{"id":1,"status":"completed","conclusion":"success","started_at":"2026-01-01T12:00:00Z","html_url":"http://example.invalid/1"}]}'
+DONE_FAIL='{"check_runs":[{"id":1,"status":"completed","conclusion":"failure","started_at":"2026-01-01T12:00:00Z","html_url":"http://example.invalid/1"}]}'
+DONE_CANCELLED='{"check_runs":[{"id":1,"status":"completed","conclusion":"cancelled","started_at":"2026-01-01T12:00:00Z","html_url":"http://example.invalid/1"}]}'
+DONE_SKIPPED='{"check_runs":[{"id":1,"status":"completed","conclusion":"skipped","started_at":"2026-01-01T12:00:00Z","html_url":"http://example.invalid/1"}]}'
 EMPTY='{"check_runs":[]}'
 # Re-run: oude gefaalde run met lage id, nieuwe geslaagde run met hoge id.
-RERUN='{"check_runs":[{"id":1,"status":"completed","conclusion":"failure","html_url":"http://example.invalid/1"},{"id":9,"status":"completed","conclusion":"success","html_url":"http://example.invalid/9"}]}'
+RERUN='{"check_runs":[{"id":1,"status":"completed","conclusion":"failure","started_at":"2026-01-01T11:00:00Z","html_url":"http://example.invalid/1"},{"id":9,"status":"completed","conclusion":"success","started_at":"2026-01-01T12:00:00Z","html_url":"http://example.invalid/9"}]}'
+
+NONE='[]'
+STICKY='[{"user":{"login":"claude[bot]"},"created_at":"2026-01-01T12:00:30Z","updated_at":"2026-01-01T12:00:30Z"}]'
+STICKY_STALE='[{"user":{"login":"claude[bot]"},"created_at":"2026-01-01T09:00:00Z","updated_at":"2026-01-01T09:00:00Z"}]'
+HUMAN_ONLY='[{"user":{"login":"someone"},"created_at":"2026-01-01T12:00:30Z","updated_at":"2026-01-01T12:00:30Z"}]'
+CLAUDE_REVIEW='[{"user":{"login":"claude[bot]"},"state":"COMMENTED","submitted_at":"2026-01-01T12:00:40Z"}]'
+
+comments "$STICKY"
+reviews "$NONE"
 
 echo "== niet van toepassing =="
 responses "$EMPTY"
@@ -101,9 +133,29 @@ run "review geannuleerd: rood" 1 "eindigde op \`cancelled\`" -- MAX_WAIT_SECONDS
 responses "$DONE_SKIPPED"
 run "review overgeslagen zonder geldige reden: rood" 1 "is overgeslagen" -- MAX_WAIT_SECONDS=0
 
-echo "== de poort opent =="
+echo "== groen vraagt ook een spoor van de review zelf =="
+# De claude-code-action stapt uit met conclusie success, zonder te reviewen en
+# zonder iets te plaatsen, zodra het workflowbestand afwijkt van de default
+# branch. Een groene check-run alleen is dus geen bewijs.
 responses "$DONE_OK"
-run "review afgerond: groen" 0 "review afgerond (success)" -- MAX_WAIT_SECONDS=0
+comments "$NONE"
+reviews "$NONE"
+run "groen zonder enig spoor van claude[bot]: rood" 1 "heeft in die run niets geplaatst" -- MAX_WAIT_SECONDS=0
+comments "$HUMAN_ONLY"
+run "alleen comments van mensen: rood" 1 "heeft in die run niets geplaatst" -- MAX_WAIT_SECONDS=0
+comments "$STICKY_STALE"
+run "spoor van vóór deze run telt niet: rood" 1 "heeft in die run niets geplaatst" -- MAX_WAIT_SECONDS=0
+
+echo "== de poort opent =="
+comments "$STICKY"
+reviews "$NONE"
+responses "$DONE_OK"
+run "review afgerond met sticky comment: groen" 0 "review afgerond (success)" -- MAX_WAIT_SECONDS=0
+comments "$NONE"
+reviews "$CLAUDE_REVIEW"
+run "een geplaatste review telt ook als spoor: groen" 0 "review afgerond (success)" -- MAX_WAIT_SECONDS=0
+comments "$STICKY"
+reviews "$NONE"
 responses "$RERUN"
 run "na re-run telt de nieuwste check-run" 0 "review afgerond (success)" -- MAX_WAIT_SECONDS=0
 responses "$RUNNING" "$RUNNING" "$DONE_OK"

--- a/script/await-claude-review.test.sh
+++ b/script/await-claude-review.test.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 # Tests voor script/await-claude-review.sh.
 #
-# `gh` wordt vervangen door een stub die per endpoint antwoordt: check-runs uit
-# een reeks (één antwoord per aanroep, zodat een lopende review die later klaar
-# is te simuleren valt), comments en reviews uit vaste fixtures. Zo is elk pad
-# deterministisch te bewijzen zonder GitHub.
+# `gh` wordt vervangen door een stub die per endpoint antwoordt: de jobs van de
+# workflow-run uit een reeks (één antwoord per aanroep, zodat een lopende review
+# die later klaar is te simuleren valt), comments en reviews uit fixtures. Zo is
+# elk pad deterministisch te bewijzen zonder GitHub.
 set -uo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -16,15 +16,12 @@ trap 'rm -rf "$WORK"' EXIT
 mkdir -p "${WORK}/bin"
 cat >"${WORK}/bin/gh" <<'STUB'
 #!/usr/bin/env bash
-# Routeert op URL. Check-runs komen uit $STUB_RESPONSES, één antwoord per
-# aanroep, zodat een nog lopende review die later klaar is te simuleren is.
-# Comments en reviews komen uit vaste bestanden.
 url="$2"
 case "$url" in
-*check-runs*)
+*/actions/runs/*/jobs*)
   n=$(cat "$STUB_COUNTER")
   echo $((n + 1)) >"$STUB_COUNTER"
-  mapfile -t responses <"$STUB_RESPONSES"
+  mapfile -t responses <"$STUB_JOBS"
   idx=$n
   if [ "$idx" -ge "${#responses[@]}" ]; then
     idx=$((${#responses[@]} - 1))
@@ -36,8 +33,20 @@ case "$url" in
   fi
   printf '%s\n' "$line"
   ;;
-*/comments*) cat "$STUB_COMMENTS" ;;
-*/reviews*) cat "$STUB_REVIEWS" ;;
+*/comments*)
+  if [ "$(cat "$STUB_COMMENTS")" = "ERROR" ]; then
+    echo "gh: HTTP 403" >&2
+    exit 1
+  fi
+  cat "$STUB_COMMENTS"
+  ;;
+*/reviews*)
+  if [ "$(cat "$STUB_REVIEWS")" = "ERROR" ]; then
+    echo "gh: HTTP 403" >&2
+    exit 1
+  fi
+  cat "$STUB_REVIEWS"
+  ;;
 *)
   echo "gh: onverwachte URL: $url" >&2
   exit 1
@@ -47,44 +56,78 @@ STUB
 chmod +x "${WORK}/bin/gh"
 export PATH="${WORK}/bin:${PATH}"
 
+export STUB_COUNTER="${WORK}/counter"
+export STUB_JOBS="${WORK}/jobs"
+export STUB_COMMENTS="${WORK}/comments"
+export STUB_REVIEWS="${WORK}/reviews"
+
+STARTED='2026-01-01T12:00:00Z'
+
+job() {
+  printf '{"jobs":[{"name":"claude-review","status":"%s","conclusion":%s,"started_at":%s,"html_url":"http://example.invalid/job"}]}\n' \
+    "$1" "$2" "${3:-\"$STARTED\"}"
+}
+
+RUNNING=$(job in_progress null)
+DONE_OK=$(job completed '"success"')
+DONE_NEUTRAL=$(job completed '"neutral"')
+DONE_FAIL=$(job completed '"failure"')
+DONE_CANCELLED=$(job completed '"cancelled"')
+DONE_SKIPPED=$(job completed '"skipped"')
+DONE_NO_START=$(job completed '"success"' null)
+NO_JOB='{"jobs":[{"name":"iets-anders","status":"completed","conclusion":"success"}]}'
+
+NONE='[]'
+STICKY='[{"user":{"login":"claude[bot]"},"created_at":"2026-01-01T12:00:30Z","updated_at":"2026-01-01T12:00:30Z"}]'
+STICKY_STALE='[{"user":{"login":"claude[bot]"},"created_at":"2026-01-01T09:00:00Z","updated_at":"2026-01-01T09:00:00Z"}]'
+HUMAN_ONLY='[{"user":{"login":"someone"},"created_at":"2026-01-01T12:00:30Z","updated_at":"2026-01-01T12:00:30Z"}]'
+CLAUDE_REVIEW='[{"user":{"login":"claude[bot]"},"state":"COMMENTED","submitted_at":"2026-01-01T12:00:40Z"}]'
+
 passed=0
 failed=0
 
-# run <naam> <verwachte exitcode> <verwachte tekst in output> -- env=waarde...
-run() {
-  local name="$1" want_code="$2" want_text="$3"
-  shift 4  # naam, code, tekst, "--"
+jobs_are() { printf '%s\n' "$@" >"$STUB_JOBS"; }
+comments_are() { printf '%s\n' "$1" >"$STUB_COMMENTS"; }
+reviews_are() { printf '%s\n' "$1" >"$STUB_REVIEWS"; }
 
-  export STUB_COUNTER="${WORK}/counter"
-  export STUB_RESPONSES="${WORK}/responses"
-  export STUB_COMMENTS="${WORK}/comments"
-  export STUB_REVIEWS="${WORK}/reviews"
+# Elke test start van dezelfde grond: één afgeronde geslaagde review met een
+# verse sticky comment. Een test zet alleen wat hij zelf wil bewijzen en kan niet
+# per ongeluk slagen op de fixtures van zijn voorganger.
+reset_fixtures() {
+  jobs_are "$DONE_OK"
+  comments_are "$STICKY"
+  reviews_are "$NONE"
   echo 0 >"$STUB_COUNTER"
-  [ -f "$STUB_COMMENTS" ] || echo '[]' >"$STUB_COMMENTS"
-  [ -f "$STUB_REVIEWS" ] || echo '[]' >"$STUB_REVIEWS"
+  : >"${WORK}/summary.md"
+}
+
+# check <naam> <exitcode> <tekst in de output> <tekst in de step summary> -- env=waarde...
+check() {
+  local name="$1" want_code="$2" want_text="$3" want_summary="$4"
+  shift 5
 
   local out code
   out=$(env "$@" \
     REPO='example-org/example-repo' \
-    HEAD_SHA='0000000000000000000000000000000000000000' \
+    RUN_ID='42' \
     PR_NUMBER='1' \
+    HEAD_SHA='0000000000000000000000000000000000000000' \
     POLL_SECONDS=0 \
     GITHUB_STEP_SUMMARY="${WORK}/summary.md" \
-    STUB_COUNTER="$STUB_COUNTER" \
-    STUB_RESPONSES="$STUB_RESPONSES" \
-    STUB_COMMENTS="$STUB_COMMENTS" \
-    STUB_REVIEWS="$STUB_REVIEWS" \
     "$GATE" 2>&1)
   code=$?
 
+  local problem=''
   if [ "$code" -ne "$want_code" ]; then
-    echo "FAIL ${name}: exitcode ${code}, verwacht ${want_code}"
-    printf '%s\n' "$out" | sed 's/^/     | /'
-    failed=$((failed + 1))
-    return
+    problem="exitcode ${code}, verwacht ${want_code}"
+  elif ! grep -qF -- "$want_text" <<<"$out"; then
+    problem="output mist \"${want_text}\""
+  elif ! grep -qF -- "$want_summary" "${WORK}/summary.md"; then
+    problem="step summary mist \"${want_summary}\""
   fi
-  if ! grep -qF -- "$want_text" <<<"$out"; then
-    echo "FAIL ${name}: output mist \"${want_text}\""
+
+  if [ -n "$problem" ]; then
+    echo "FAIL ${name}: ${problem}"
     printf '%s\n' "$out" | sed 's/^/     | /'
     failed=$((failed + 1))
     return
@@ -93,84 +136,74 @@ run() {
   passed=$((passed + 1))
 }
 
-responses() { printf '%s\n' "$@" >"${WORK}/responses"; }
-comments() { printf '%s\n' "$1" >"${WORK}/comments"; }
-reviews() { printf '%s\n' "$1" >"${WORK}/reviews"; }
-
-RUNNING='{"check_runs":[{"id":1,"status":"in_progress","conclusion":null,"started_at":"2026-01-01T12:00:00Z","html_url":"http://example.invalid/1"}]}'
-DONE_OK='{"check_runs":[{"id":1,"status":"completed","conclusion":"success","started_at":"2026-01-01T12:00:00Z","html_url":"http://example.invalid/1"}]}'
-DONE_FAIL='{"check_runs":[{"id":1,"status":"completed","conclusion":"failure","started_at":"2026-01-01T12:00:00Z","html_url":"http://example.invalid/1"}]}'
-DONE_CANCELLED='{"check_runs":[{"id":1,"status":"completed","conclusion":"cancelled","started_at":"2026-01-01T12:00:00Z","html_url":"http://example.invalid/1"}]}'
-DONE_SKIPPED='{"check_runs":[{"id":1,"status":"completed","conclusion":"skipped","started_at":"2026-01-01T12:00:00Z","html_url":"http://example.invalid/1"}]}'
-EMPTY='{"check_runs":[]}'
-# Re-run: oude gefaalde run met lage id, nieuwe geslaagde run met hoge id.
-RERUN='{"check_runs":[{"id":1,"status":"completed","conclusion":"failure","started_at":"2026-01-01T11:00:00Z","html_url":"http://example.invalid/1"},{"id":9,"status":"completed","conclusion":"success","started_at":"2026-01-01T12:00:00Z","html_url":"http://example.invalid/9"}]}'
-
-NONE='[]'
-STICKY='[{"user":{"login":"claude[bot]"},"created_at":"2026-01-01T12:00:30Z","updated_at":"2026-01-01T12:00:30Z"}]'
-STICKY_STALE='[{"user":{"login":"claude[bot]"},"created_at":"2026-01-01T09:00:00Z","updated_at":"2026-01-01T09:00:00Z"}]'
-HUMAN_ONLY='[{"user":{"login":"someone"},"created_at":"2026-01-01T12:00:30Z","updated_at":"2026-01-01T12:00:30Z"}]'
-CLAUDE_REVIEW='[{"user":{"login":"claude[bot]"},"state":"COMMENTED","submitted_at":"2026-01-01T12:00:40Z"}]'
-
-comments "$STICKY"
-reviews "$NONE"
-
 echo "== niet van toepassing =="
-responses "$EMPTY"
-run "fork-PR wacht niet en blokkeert niet" 0 "niet van toepassing" -- IS_FORK=true MAX_WAIT_SECONDS=0
-run "draft-PR wacht niet en blokkeert niet" 0 "niet van toepassing" -- IS_DRAFT=true MAX_WAIT_SECONDS=0
-run "dependabot-PR wacht niet en blokkeert niet" 0 "niet van toepassing" -- PR_AUTHOR='dependabot[bot]' MAX_WAIT_SECONDS=0
+# De review draait hier nog; de poort mag daar niet op gaan wachten.
+reset_fixtures
+jobs_are "$RUNNING"
+check "cross-repo-PR wacht niet en blokkeert niet" 0 "niet van toepassing" "andere repository" -- IS_CROSS_REPO=true MAX_WAIT_SECONDS=0
+reset_fixtures
+jobs_are "$RUNNING"
+check "draft-PR wacht niet en blokkeert niet" 0 "niet van toepassing" "draft" -- IS_DRAFT=true MAX_WAIT_SECONDS=0
+reset_fixtures
+jobs_are "$RUNNING"
+check "dependabot-PR wacht niet en blokkeert niet" 0 "niet van toepassing" "dependabot" -- PR_AUTHOR='dependabot[bot]' MAX_WAIT_SECONDS=0
 
 echo "== de poort sluit =="
-responses "$RUNNING"
-run "review loopt nog bij deadline: rood" 1 "nog niet klaar" -- MAX_WAIT_SECONDS=0
-responses "$EMPTY"
-run "review nooit gestart: rood" 1 "bestaat er geen check-run" -- MAX_WAIT_SECONDS=0
-responses "$DONE_FAIL"
-run "review gefaald: rood" 1 "eindigde op \`failure\`" -- MAX_WAIT_SECONDS=0
-responses "$DONE_CANCELLED"
-run "review geannuleerd: rood" 1 "eindigde op \`cancelled\`" -- MAX_WAIT_SECONDS=0
-responses "$DONE_SKIPPED"
-run "review overgeslagen zonder geldige reden: rood" 1 "is overgeslagen" -- MAX_WAIT_SECONDS=0
+reset_fixtures
+jobs_are "$RUNNING"
+check "review loopt nog bij deadline: rood" 1 "nog niet klaar" "geblokkeerd" -- MAX_WAIT_SECONDS=0
+reset_fixtures
+jobs_are "$NO_JOB"
+check "review-job zit niet in de run: rood" 1 "zit er geen job" "geblokkeerd" -- MAX_WAIT_SECONDS=0
+reset_fixtures
+jobs_are "$DONE_FAIL"
+check "review gefaald: rood" 1 'eindigde op `failure`' "geblokkeerd" -- MAX_WAIT_SECONDS=0
+reset_fixtures
+jobs_are "$DONE_CANCELLED"
+check "review geannuleerd: rood" 1 'eindigde op `cancelled`' "geblokkeerd" -- MAX_WAIT_SECONDS=0
+reset_fixtures
+jobs_are "$DONE_SKIPPED"
+check "review overgeslagen zonder geldige reden: rood" 1 "is overgeslagen" "geblokkeerd" -- MAX_WAIT_SECONDS=0
 
 echo "== groen vraagt ook een spoor van de review zelf =="
 # De claude-code-action stapt uit met conclusie success, zonder te reviewen en
 # zonder iets te plaatsen, zodra het workflowbestand afwijkt van de default
-# branch. Een groene check-run alleen is dus geen bewijs.
-responses "$DONE_OK"
-comments "$NONE"
-reviews "$NONE"
-run "groen zonder enig spoor van claude[bot]: rood" 1 "heeft in die run niets geplaatst" -- MAX_WAIT_SECONDS=0
-comments "$HUMAN_ONLY"
-run "alleen comments van mensen: rood" 1 "heeft in die run niets geplaatst" -- MAX_WAIT_SECONDS=0
-comments "$STICKY_STALE"
-run "spoor van vóór deze run telt niet: rood" 1 "heeft in die run niets geplaatst" -- MAX_WAIT_SECONDS=0
+# branch. Een groene job alleen is dus geen bewijs.
+reset_fixtures
+comments_are "$NONE"
+check "groen zonder enig spoor van claude[bot]: rood" 1 "niets geplaatst" "geblokkeerd" -- MAX_WAIT_SECONDS=0
+reset_fixtures
+comments_are "$HUMAN_ONLY"
+check "alleen comments van mensen: rood" 1 "niets geplaatst" "geblokkeerd" -- MAX_WAIT_SECONDS=0
+reset_fixtures
+comments_are "$STICKY_STALE"
+check "spoor van vóór deze run telt niet: rood" 1 "niets geplaatst" "geblokkeerd" -- MAX_WAIT_SECONDS=0
+reset_fixtures
+jobs_are "$DONE_NO_START"
+check "job zonder started_at: rood, want versheid is onbepaalbaar" 1 'geen `started_at`' "geblokkeerd" -- MAX_WAIT_SECONDS=0
+reset_fixtures
+comments_are ERROR
+check "comments-API onleesbaar: rood, niet als 'geen review' gemeld" 1 "is niet te lezen" "geblokkeerd" -- MAX_WAIT_SECONDS=0
+reset_fixtures
+reviews_are ERROR
+check "reviews-API onleesbaar: rood, niet als 'geen review' gemeld" 1 "is niet te lezen" "geblokkeerd" -- MAX_WAIT_SECONDS=0
 
 echo "== de poort opent =="
-comments "$STICKY"
-reviews "$NONE"
-responses "$DONE_OK"
-run "review afgerond met sticky comment: groen" 0 "review afgerond (success)" -- MAX_WAIT_SECONDS=0
-comments "$NONE"
-reviews "$CLAUDE_REVIEW"
-run "een geplaatste review telt ook als spoor: groen" 0 "review afgerond (success)" -- MAX_WAIT_SECONDS=0
-comments "$STICKY"
-reviews "$NONE"
-responses "$RERUN"
-run "na re-run telt de nieuwste check-run" 0 "review afgerond (success)" -- MAX_WAIT_SECONDS=0
-responses "$RUNNING" "$RUNNING" "$DONE_OK"
-run "wacht door tot de review klaar is" 0 "review afgerond (success)" -- MAX_WAIT_SECONDS=60
-responses "ERROR" "$DONE_OK"
-run "API-fout is geen conclusie, er wordt doorgepolld" 0 "review afgerond (success)" -- MAX_WAIT_SECONDS=60
-
-echo "== eerlijkheid over wat de check bewijst =="
-if grep -qF 'Wat hij niet bewijst' "${WORK}/summary.md"; then
-  echo "ok   groene samenvatting zegt erbij wat hij niet bewijst"
-  passed=$((passed + 1))
-else
-  echo "FAIL groene samenvatting claimt te veel"
-  failed=$((failed + 1))
-fi
+reset_fixtures
+check "review afgerond met sticky comment: groen" 0 "review afgerond (success)" "Wat hij niet bewijst" -- MAX_WAIT_SECONDS=0
+reset_fixtures
+jobs_are "$DONE_NEUTRAL"
+check "conclusie neutral telt als afgerond: groen" 0 "review afgerond (neutral)" "groen" -- MAX_WAIT_SECONDS=0
+reset_fixtures
+comments_are "$NONE"
+reviews_are "$CLAUDE_REVIEW"
+check "een geplaatste review telt ook als spoor: groen" 0 "review afgerond (success)" "groen" -- MAX_WAIT_SECONDS=0
+reset_fixtures
+jobs_are "$RUNNING" "$RUNNING" "$DONE_OK"
+check "wacht door tot de review klaar is" 0 "review afgerond (success)" "groen" -- MAX_WAIT_SECONDS=60
+reset_fixtures
+jobs_are ERROR "$DONE_OK"
+check "API-fout op de jobs is geen conclusie, er wordt doorgepolld" 0 "review afgerond (success)" "groen" -- MAX_WAIT_SECONDS=60
 
 echo
 echo "${passed} geslaagd, ${failed} gefaald"

--- a/script/await-claude-review.test.sh
+++ b/script/await-claude-review.test.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Tests voor script/await-claude-review.sh.
+#
+# `gh` wordt vervangen door een stub die een vast JSON-antwoord teruggeeft, of
+# een reeks antwoorden (één per regel-index) om een lopende review te simuleren
+# die later klaar is. Zo is elk pad deterministisch te bewijzen zonder GitHub.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GATE="${HERE}/await-claude-review.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+mkdir -p "${WORK}/bin"
+cat >"${WORK}/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+# Geeft het n-de antwoord uit $STUB_RESPONSES terug en telt de aanroepen.
+n=$(cat "$STUB_COUNTER")
+echo $((n + 1)) >"$STUB_COUNTER"
+mapfile -t responses <"$STUB_RESPONSES"
+idx=$n
+if [ "$idx" -ge "${#responses[@]}" ]; then
+  idx=$((${#responses[@]} - 1))
+fi
+line="${responses[$idx]}"
+if [ "$line" = "ERROR" ]; then
+  echo "gh: simulated API failure" >&2
+  exit 1
+fi
+printf '%s\n' "$line"
+STUB
+chmod +x "${WORK}/bin/gh"
+export PATH="${WORK}/bin:${PATH}"
+
+passed=0
+failed=0
+
+# run <naam> <verwachte exitcode> <verwachte tekst in output> -- env=waarde...
+run() {
+  local name="$1" want_code="$2" want_text="$3"
+  shift 4  # naam, code, tekst, "--"
+
+  export STUB_COUNTER="${WORK}/counter"
+  export STUB_RESPONSES="${WORK}/responses"
+  echo 0 >"$STUB_COUNTER"
+
+  local out code
+  out=$(env "$@" \
+    REPO='example-org/example-repo' \
+    HEAD_SHA='0000000000000000000000000000000000000000' \
+    POLL_SECONDS=0 \
+    GITHUB_STEP_SUMMARY="${WORK}/summary.md" \
+    STUB_COUNTER="$STUB_COUNTER" \
+    STUB_RESPONSES="$STUB_RESPONSES" \
+    "$GATE" 2>&1)
+  code=$?
+
+  if [ "$code" -ne "$want_code" ]; then
+    echo "FAIL ${name}: exitcode ${code}, verwacht ${want_code}"
+    printf '%s\n' "$out" | sed 's/^/     | /'
+    failed=$((failed + 1))
+    return
+  fi
+  if ! grep -qF -- "$want_text" <<<"$out"; then
+    echo "FAIL ${name}: output mist \"${want_text}\""
+    printf '%s\n' "$out" | sed 's/^/     | /'
+    failed=$((failed + 1))
+    return
+  fi
+  echo "ok   ${name}"
+  passed=$((passed + 1))
+}
+
+responses() { printf '%s\n' "$@" >"${WORK}/responses"; }
+
+RUNNING='{"check_runs":[{"id":1,"status":"in_progress","conclusion":null,"html_url":"http://example.invalid/1"}]}'
+DONE_OK='{"check_runs":[{"id":1,"status":"completed","conclusion":"success","html_url":"http://example.invalid/1"}]}'
+DONE_FAIL='{"check_runs":[{"id":1,"status":"completed","conclusion":"failure","html_url":"http://example.invalid/1"}]}'
+DONE_CANCELLED='{"check_runs":[{"id":1,"status":"completed","conclusion":"cancelled","html_url":"http://example.invalid/1"}]}'
+DONE_SKIPPED='{"check_runs":[{"id":1,"status":"completed","conclusion":"skipped","html_url":"http://example.invalid/1"}]}'
+EMPTY='{"check_runs":[]}'
+# Re-run: oude gefaalde run met lage id, nieuwe geslaagde run met hoge id.
+RERUN='{"check_runs":[{"id":1,"status":"completed","conclusion":"failure","html_url":"http://example.invalid/1"},{"id":9,"status":"completed","conclusion":"success","html_url":"http://example.invalid/9"}]}'
+
+echo "== niet van toepassing =="
+responses "$EMPTY"
+run "fork-PR wacht niet en blokkeert niet" 0 "niet van toepassing" -- IS_FORK=true MAX_WAIT_SECONDS=0
+run "draft-PR wacht niet en blokkeert niet" 0 "niet van toepassing" -- IS_DRAFT=true MAX_WAIT_SECONDS=0
+run "dependabot-PR wacht niet en blokkeert niet" 0 "niet van toepassing" -- PR_AUTHOR='dependabot[bot]' MAX_WAIT_SECONDS=0
+
+echo "== de poort sluit =="
+responses "$RUNNING"
+run "review loopt nog bij deadline: rood" 1 "nog niet klaar" -- MAX_WAIT_SECONDS=0
+responses "$EMPTY"
+run "review nooit gestart: rood" 1 "bestaat er geen check-run" -- MAX_WAIT_SECONDS=0
+responses "$DONE_FAIL"
+run "review gefaald: rood" 1 "eindigde op \`failure\`" -- MAX_WAIT_SECONDS=0
+responses "$DONE_CANCELLED"
+run "review geannuleerd: rood" 1 "eindigde op \`cancelled\`" -- MAX_WAIT_SECONDS=0
+responses "$DONE_SKIPPED"
+run "review overgeslagen zonder geldige reden: rood" 1 "is overgeslagen" -- MAX_WAIT_SECONDS=0
+
+echo "== de poort opent =="
+responses "$DONE_OK"
+run "review afgerond: groen" 0 "review afgerond (success)" -- MAX_WAIT_SECONDS=0
+responses "$RERUN"
+run "na re-run telt de nieuwste check-run" 0 "review afgerond (success)" -- MAX_WAIT_SECONDS=0
+responses "$RUNNING" "$RUNNING" "$DONE_OK"
+run "wacht door tot de review klaar is" 0 "review afgerond (success)" -- MAX_WAIT_SECONDS=60
+responses "ERROR" "$DONE_OK"
+run "API-fout is geen conclusie, er wordt doorgepolld" 0 "review afgerond (success)" -- MAX_WAIT_SECONDS=60
+
+echo "== eerlijkheid over wat de check bewijst =="
+if grep -qF 'Wat hij niet bewijst' "${WORK}/summary.md"; then
+  echo "ok   groene samenvatting zegt erbij wat hij niet bewijst"
+  passed=$((passed + 1))
+else
+  echo "FAIL groene samenvatting claimt te veel"
+  failed=$((failed + 1))
+fi
+
+echo
+echo "${passed} geslaagd, ${failed} gefaald"
+[ "$failed" -eq 0 ]

--- a/script/await-claude-review.test.sh
+++ b/script/await-claude-review.test.sh
@@ -38,12 +38,24 @@ case "$url" in
     echo "gh: HTTP 403" >&2
     exit 1
   fi
+  # WARN: geslaagde aanroep die ook naar stderr schrijft.
+  if [ "$(cat "$STUB_COMMENTS")" = "WARN" ]; then
+    echo "gh: warning: this API is deprecated" >&2
+    cat "$STUB_WARN_BODY"
+    exit 0
+  fi
   cat "$STUB_COMMENTS"
   ;;
 */reviews*)
   if [ "$(cat "$STUB_REVIEWS")" = "ERROR" ]; then
     echo "gh: HTTP 403" >&2
     exit 1
+  fi
+  # WARN: geslaagde aanroep die ook naar stderr schrijft.
+  if [ "$(cat "$STUB_REVIEWS")" = "WARN" ]; then
+    echo "gh: warning: this API is deprecated" >&2
+    cat "$STUB_WARN_BODY"
+    exit 0
   fi
   cat "$STUB_REVIEWS"
   ;;
@@ -60,6 +72,7 @@ export STUB_COUNTER="${WORK}/counter"
 export STUB_JOBS="${WORK}/jobs"
 export STUB_COMMENTS="${WORK}/comments"
 export STUB_REVIEWS="${WORK}/reviews"
+export STUB_WARN_BODY="${WORK}/warn-body"
 
 STARTED='2026-01-01T12:00:00Z'
 
@@ -76,6 +89,11 @@ DONE_CANCELLED=$(job completed '"cancelled"')
 DONE_SKIPPED=$(job completed '"skipped"')
 DONE_NO_START=$(job completed '"success"' null)
 NO_JOB='{"jobs":[{"name":"iets-anders","status":"completed","conclusion":"success"}]}'
+# Na "Re-run this job" op de poort staan er meerdere attempts van dezelfde job
+# op één run-id; de hoogste id is de meest recente.
+ATTEMPTS='{"jobs":[{"name":"claude-review","status":"completed","conclusion":"success","started_at":"2026-01-01T12:00:00Z","id":9,"html_url":"http://example.invalid/9"},{"name":"claude-review","status":"completed","conclusion":"failure","started_at":"2026-01-01T10:00:00Z","id":1,"html_url":"http://example.invalid/1"}]}'
+GARBAGE='dit is geen JSON'
+
 
 NONE='[]'
 STICKY='[{"user":{"login":"claude[bot]"},"created_at":"2026-01-01T12:00:30Z","updated_at":"2026-01-01T12:00:30Z"}]'
@@ -97,6 +115,7 @@ reset_fixtures() {
   jobs_are "$DONE_OK"
   comments_are "$STICKY"
   reviews_are "$NONE"
+  printf '%s\n' "$STICKY" >"$STUB_WARN_BODY"
   echo 0 >"$STUB_COUNTER"
   : >"${WORK}/summary.md"
 }
@@ -151,19 +170,19 @@ check "dependabot-PR wacht niet en blokkeert niet" 0 "niet van toepassing" "depe
 echo "== de poort sluit =="
 reset_fixtures
 jobs_are "$RUNNING"
-check "review loopt nog bij deadline: rood" 1 "nog niet klaar" "geblokkeerd" -- MAX_WAIT_SECONDS=0
+check "review loopt nog bij deadline: rood" 1 "nog niet klaar" "nog niet klaar" -- MAX_WAIT_SECONDS=0
 reset_fixtures
 jobs_are "$NO_JOB"
-check "review-job zit niet in de run: rood" 1 "zit er geen job" "geblokkeerd" -- MAX_WAIT_SECONDS=0
+check "review-job zit niet in de run: rood" 1 "zit er geen job" "zit er geen job" -- MAX_WAIT_SECONDS=0
 reset_fixtures
 jobs_are "$DONE_FAIL"
-check "review gefaald: rood" 1 'eindigde op `failure`' "geblokkeerd" -- MAX_WAIT_SECONDS=0
+check "review gefaald: rood" 1 'eindigde op `failure`' 'eindigde op `failure`' -- MAX_WAIT_SECONDS=0
 reset_fixtures
 jobs_are "$DONE_CANCELLED"
-check "review geannuleerd: rood" 1 'eindigde op `cancelled`' "geblokkeerd" -- MAX_WAIT_SECONDS=0
+check "review geannuleerd: rood" 1 'eindigde op `cancelled`' 'eindigde op `cancelled`' -- MAX_WAIT_SECONDS=0
 reset_fixtures
 jobs_are "$DONE_SKIPPED"
-check "review overgeslagen zonder geldige reden: rood" 1 "is overgeslagen" "geblokkeerd" -- MAX_WAIT_SECONDS=0
+check "review overgeslagen zonder geldige reden: rood" 1 "is overgeslagen" "is overgeslagen" -- MAX_WAIT_SECONDS=0
 
 echo "== groen vraagt ook een spoor van de review zelf =="
 # De claude-code-action stapt uit met conclusie success, zonder te reviewen en
@@ -171,22 +190,28 @@ echo "== groen vraagt ook een spoor van de review zelf =="
 # branch. Een groene job alleen is dus geen bewijs.
 reset_fixtures
 comments_are "$NONE"
-check "groen zonder enig spoor van claude[bot]: rood" 1 "niets geplaatst" "geblokkeerd" -- MAX_WAIT_SECONDS=0
+check "groen zonder enig spoor van claude[bot]: rood" 1 "niets geplaatst" "niets geplaatst" -- MAX_WAIT_SECONDS=0
 reset_fixtures
 comments_are "$HUMAN_ONLY"
-check "alleen comments van mensen: rood" 1 "niets geplaatst" "geblokkeerd" -- MAX_WAIT_SECONDS=0
+check "alleen comments van mensen: rood" 1 "niets geplaatst" "niets geplaatst" -- MAX_WAIT_SECONDS=0
 reset_fixtures
 comments_are "$STICKY_STALE"
-check "spoor van vóór deze run telt niet: rood" 1 "niets geplaatst" "geblokkeerd" -- MAX_WAIT_SECONDS=0
+check "spoor van vóór deze run telt niet: rood" 1 "niets geplaatst" "niets geplaatst" -- MAX_WAIT_SECONDS=0
 reset_fixtures
 jobs_are "$DONE_NO_START"
-check "job zonder started_at: rood, want versheid is onbepaalbaar" 1 'geen `started_at`' "geblokkeerd" -- MAX_WAIT_SECONDS=0
+check "job zonder started_at: rood, want versheid is onbepaalbaar" 1 'geen `started_at`' 'geen `started_at`' -- MAX_WAIT_SECONDS=0
 reset_fixtures
 comments_are ERROR
-check "comments-API onleesbaar: rood, niet als 'geen review' gemeld" 1 "is niet te lezen" "geblokkeerd" -- MAX_WAIT_SECONDS=0
+check "comments-API onleesbaar: rood, niet als 'geen review' gemeld" 1 "is niet te lezen" "is niet te lezen" -- MAX_WAIT_SECONDS=0
 reset_fixtures
 reviews_are ERROR
-check "reviews-API onleesbaar: rood, niet als 'geen review' gemeld" 1 "is niet te lezen" "geblokkeerd" -- MAX_WAIT_SECONDS=0
+check "reviews-API onleesbaar: rood, niet als 'geen review' gemeld" 1 "is niet te lezen" "is niet te lezen" -- MAX_WAIT_SECONDS=0
+reset_fixtures
+comments_are "$GARBAGE"
+check "onparseerbaar antwoord: rood met een eigen melding" 1 "geen bruikbare JSON" "geen bruikbare JSON" -- MAX_WAIT_SECONDS=0
+reset_fixtures
+jobs_are ERROR
+check "jobs-API blijft onleesbaar tot de deadline: rood, niet als 'job ontbreekt'" 1 "niet op te halen" "niet op te halen" -- MAX_WAIT_SECONDS=0
 
 echo "== de poort opent =="
 reset_fixtures
@@ -198,6 +223,12 @@ reset_fixtures
 comments_are "$NONE"
 reviews_are "$CLAUDE_REVIEW"
 check "een geplaatste review telt ook als spoor: groen" 0 "review afgerond (success)" "groen" -- MAX_WAIT_SECONDS=0
+reset_fixtures
+comments_are WARN
+check "waarschuwing op stderr bederft een geslaagde aanroep niet: groen" 0 "review afgerond (success)" "groen" -- MAX_WAIT_SECONDS=0
+reset_fixtures
+jobs_are "$ATTEMPTS"
+check "meerdere attempts: de nieuwste job telt" 0 "review afgerond (success)" "groen" -- MAX_WAIT_SECONDS=0
 reset_fixtures
 jobs_are "$RUNNING" "$RUNNING" "$DONE_OK"
 check "wacht door tot de review klaar is" 0 "review afgerond (success)" "groen" -- MAX_WAIT_SECONDS=60


### PR DESCRIPTION
De `claude-review`-workflow duurt ongeveer tien minuten en is geen verplichte check, terwijl de vijf verplichte checks in vier tot zes minuten klaar zijn. Daardoor is er twee keer gemerged voordat de review binnen was; bij PR 1147 kwamen vier Significant-bevindingen enkele minuten ná de merge binnen en die staan nu op main.

De nieuwe job `review-gate` wacht op de status van de `claude-review`-job in zijn eigen workflow-run en slaagt pas als die `completed` is met `success` of `neutral`. Hij eist daarbovenop een spoor van claude[bot] van ná de start van die job, omdat de actie met conclusie `success` uitstapt zodra het workflowbestand afwijkt van main. Hij zoekt de job via het run-id in plaats van via de head-sha, want bij `ready_for_review` en `reopened` blijft de sha gelijk. En hij draait zijn script uit de base-branch, zodat een PR de poort niet naar `exit 0` kan wijzigen.

`claude-review` zelf verplicht maken kan niet: op een fork-PR draait die workflow niet, en een verplichte check die nooit rapporteert blokkeert zo'n PR voorgoed. De poort draait daarom altijd en leidt "niet van toepassing" af uit de PR zelf. Hij garandeert dat de review gedraaid is voor deze commit en iets heeft opgeleverd. Of de bevindingen deugen en verwerkt zijn kan een machine niet vaststellen.

`Claude review completed` moet nog aan de verplichte checks worden toegevoegd; branch protection staat niet in deze repo. Deze PR vraagt zelf een menselijke review en een admin-merge, omdat de poort hier terecht rood blijft.