### PR TITLE
chore(docs): haal de overbodige declaratie van @astrojs/markdown-remark weg

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,7 +8,6 @@
       "name": "regelrecht-docs",
       "version": "1.0.0",
       "dependencies": {
-        "@astrojs/markdown-remark": "^7.2.2",
         "@astrojs/mdx": "^7.0.5",
         "@nldd/design-system": "^0.8.78",
         "astro": "^7.1.6",

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,6 @@
     "nldd:check": "node ../script/check-nldd-imports.mjs src src/nldd-components.js"
   },
   "dependencies": {
-    "@astrojs/markdown-remark": "^7.2.2",
     "@astrojs/mdx": "^7.0.5",
     "@nldd/design-system": "^0.8.78",
     "astro": "^7.1.6",


### PR DESCRIPTION
`docs/package.json` declareerde `@astrojs/markdown-remark` zelf, terwijl geen enkel bestand in `docs/` het pakket importeert. Astro eist het als peer op exact 7.2.2 en `@astrojs/mdx` hangt er op dezelfde versie aan, dus de eigen declaratie installeerde niets extra; wat ze wel deed was een caret-bereik naast een exacte pin zetten, zodat een volgende update stil kon wegdrijven van de versie die Astro verwacht. Na verwijderen zit het pakket nog via Astro en mdx in de boom en draait de docs-build ongewijzigd.

Geen `--omit=dev` in de frontend-Docker-builds: `vite` en `@vitejs/plugin-vue` staan zelf in `devDependencies` en zijn nodig om te bouwen, dus die vlag zou de build breken.