### PR TITLE
fix: security-headers en een csp die er echt is, op elk domein

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,8 +297,11 @@ jobs:
       # die van eigenaar wisselt kan een component stil buiten de deploy laten
       # vallen. Die test hoort in een required check, en deze baan heeft cargo
       # al staan; `cargo metadata` bouwt niets en kost seconden.
+      # Ongegate: de security-headers-guard verderop bewaakt bestanden
+      # (deploy/nginx, de twee nginx.conf's, het Grafana-Dockerfile) die niet
+      # onder het `ci`-filter vallen. Gegate zou hij precies de wijzigingen
+      # missen waarvoor hij bestaat.
       - name: Setup Node.js
-        if: needs.changes.outputs.ci == 'true'
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
         with:
           node-version: '22'
@@ -310,6 +313,9 @@ jobs:
       - name: Check asset precompression
         if: needs.changes.outputs.ci == 'true'
         run: just precompress-test
+
+      - name: Check security headers
+        run: just security-headers-test
 
       # Leak-guard laag 2: voorzie het git-ignored aanvulbestand met de casus-/
       # sector-specifieke patronen uit een secret, zodat de skills-no-casus hook in

--- a/Justfile
+++ b/Justfile
@@ -86,11 +86,18 @@ deploy-filters-test:
 precompress-test:
     node --test frontend/scripts/precompress.test.mjs
 
+# Holds the Rust services, the nginx images and Grafana to the same header
+# set. Same reasoning as deploy-filters-test: node's built-in runner, no
+# dependency.
+[doc("Check that every domain sends the same security headers")]
+security-headers-test:
+    node --test script/security-headers.test.mjs
+
 # Run all quality checks, exactly what CI runs. Needs Docker for the
 # container-backed suites; on a machine without a daemon, swap `test` for
 # `test-no-docker`.
 [doc("Run all quality checks, exactly what CI runs (needs Docker)")]
-check: format lint build-check validate validate-annotations deploy-filters-test precompress-test test
+check: format lint build-check validate validate-annotations deploy-filters-test precompress-test security-headers-test test
 
 # --- Tests ---
 

--- a/deploy/nginx/security-headers.conf
+++ b/deploy/nginx/security-headers.conf
@@ -1,0 +1,25 @@
+# The security headers every nginx-served RegelRecht site sends.
+#
+# `include` this from every `location` that returns content. nginx does not
+# inherit `add_header` into a block that declares one of its own, so a nested
+# location (the long-cache asset block, say) drops the whole set the moment it
+# adds a `Cache-Control` — which is how the same five headers ended up written
+# out four times across two files.
+#
+# The values are transcribed from `packages/auth/src/security_headers.rs`,
+# where the Axum services take them from. `script/security-headers.test.mjs`
+# fails the build when the two stop agreeing.
+#
+# `$csp` is deliberately not set here: the policy describes one particular
+# document, so each server block sets it before including this file. A
+# variable that no block sets at all is an nginx startup error; one that
+# another block sets is merely empty here, and nginx then omits the header.
+# `script/security-headers.test.mjs` is what holds every server block to
+# setting its own.
+
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-Frame-Options "DENY" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+add_header Permissions-Policy "geolocation=(), camera=(), microphone=()" always;
+add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+add_header Content-Security-Policy $csp always;

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -21,6 +21,7 @@ RUN npm run build
 # Stage 2: Production (unprivileged nginx for Kubernetes/OpenShift)
 FROM nginxinc/nginx-unprivileged:1.27-alpine@sha256:65e3e85dbaed8ba248841d9d58a899b6197106c23cb0ff1a132b7bfe0547e4c0
 COPY docs/nginx.conf /etc/nginx/conf.d/default.conf
+COPY deploy/nginx/security-headers.conf /etc/nginx/security-headers.conf
 COPY --from=builder /app/dist /usr/share/nginx/html
 EXPOSE 8000
 CMD ["nginx", "-g", "daemon off;"]

--- a/docs/nginx.conf
+++ b/docs/nginx.conf
@@ -10,10 +10,11 @@ server {
     # send clients to a port they cannot reach behind the ingress.
     absolute_redirect off;
 
-    # Security headers
+    # The policy for this site; the header set that carries it lives in
+    # /etc/nginx/security-headers.conf.
     #
-    # CSP keeps 'unsafe-inline' on script-src and style-src; closing those is
-    # a separate effort that we intentionally do NOT do here:
+    # It keeps 'unsafe-inline' on script-src and style-src, and closing
+    # those is a separate effort that we intentionally do NOT do here:
     #
     # - script-src 'unsafe-inline': Base.astro emits two inline scripts that a
     #   CSP hash could cover in principle — the pre-paint theme bootstrap
@@ -29,15 +30,7 @@ server {
     # base-uri 'none' and form-action 'self' close internet.nl recommendations
     # #2 and #5: no <base> tag is used; the signup form posts via fetch, not
     # an HTML <form action="...">.
-    #
-    # HSTS includes `preload` so the domain is eligible for browser preload
-    # lists once submitted to hstspreload.org.
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-Frame-Options "DENY" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' blob:; worker-src 'self' blob:; child-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://digilab.overheid.nl; frame-ancestors 'none'; base-uri 'none'; form-action 'self'" always;
-    add_header Permissions-Policy "geolocation=(), camera=(), microphone=()" always;
-    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+    set $csp "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' blob:; worker-src 'self' blob:; child-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://digilab.overheid.nl; object-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'";
 
     gzip on;
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml;
@@ -52,11 +45,15 @@ server {
     # → the `error_page` below returns the static 404 page with a real
     # 404 status (not the soft-404 homepage the old SPA fallback gave).
     location / {
+        include /etc/nginx/security-headers.conf;
         try_files $uri $uri.html $uri/index.html $uri/ =404;
     }
 
     error_page 404 /404.html;
+    # The internal redirect lands here, so this block — not the one that
+    # produced the 404 — decides the response headers.
     location = /404.html {
+        include /etc/nginx/security-headers.conf;
         internal;
     }
 
@@ -66,21 +63,18 @@ server {
     # legacy fallback we also handle so old scanners pointed there still
     # resolve. 302 is what the policy prescribes.
     location = /.well-known/security.txt {
+        include /etc/nginx/security-headers.conf;
         return 302 https://www.ncsc.nl/.well-known/security.txt;
     }
     location = /security.txt {
+        include /etc/nginx/security-headers.conf;
         return 302 https://www.ncsc.nl/.well-known/security.txt;
     }
 
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header X-Frame-Options "DENY" always;
-        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' blob:; worker-src 'self' blob:; child-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://digilab.overheid.nl; frame-ancestors 'none'; base-uri 'none'; form-action 'self'" always;
-        add_header Permissions-Policy "geolocation=(), camera=(), microphone=()" always;
-        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+        include /etc/nginx/security-headers.conf;
     }
 
     location /health {

--- a/frontend-lawmaking/Dockerfile
+++ b/frontend-lawmaking/Dockerfile
@@ -17,6 +17,7 @@ RUN npm run build -w frontend-lawmaking
 # Stage 2: Production (unprivileged nginx for Kubernetes/OpenShift)
 FROM nginxinc/nginx-unprivileged:1.27-alpine@sha256:65e3e85dbaed8ba248841d9d58a899b6197106c23cb0ff1a132b7bfe0547e4c0
 COPY frontend-lawmaking/nginx.conf /etc/nginx/conf.d/default.conf
+COPY deploy/nginx/security-headers.conf /etc/nginx/security-headers.conf
 COPY --from=builder /app/frontend-lawmaking/dist /usr/share/nginx/html
 EXPOSE 8000
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend-lawmaking/nginx.conf
+++ b/frontend-lawmaking/nginx.conf
@@ -5,13 +5,15 @@ server {
     index index.html;
     server_tokens off;
 
-    # Security headers
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-Frame-Options "DENY" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'" always;
-    add_header Permissions-Policy "geolocation=(), camera=(), microphone=()" always;
-    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+    # The policy for this site; the header set that carries it lives in
+    # /etc/nginx/security-headers.conf. Nothing here loads from another
+    # origin, so every fetching directive stays on 'self'.
+    #
+    # style-src keeps 'unsafe-inline': the NDD components build a <style>
+    # element and assign its textContent, which CSP counts as an inline
+    # style. script-src needs no such allowance — Vue runs runtime-only and
+    # index.html carries no inline script.
+    set $csp "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; object-src 'none'; frame-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'";
 
     gzip on;
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml;
@@ -19,25 +21,23 @@ server {
     # security.txt — redirect to the central NCSC file per the Rijksoverheid
     # CVD policy (https://www.ncsc.nl/.well-known/security.txt).
     location = /.well-known/security.txt {
+        include /etc/nginx/security-headers.conf;
         return 302 https://www.ncsc.nl/.well-known/security.txt;
     }
     location = /security.txt {
+        include /etc/nginx/security-headers.conf;
         return 302 https://www.ncsc.nl/.well-known/security.txt;
     }
 
     location / {
+        include /etc/nginx/security-headers.conf;
         try_files $uri $uri/ /index.html;
     }
 
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header X-Frame-Options "DENY" always;
-        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'" always;
-        add_header Permissions-Policy "geolocation=(), camera=(), microphone=()" always;
-        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+        include /etc/nginx/security-headers.conf;
     }
 
     location /health {

--- a/packages/admin/src/main.rs
+++ b/packages/admin/src/main.rs
@@ -226,7 +226,9 @@ async fn main() {
             middleware::refresh_session_token::<AppState>,
         ))
         .layer(session_layer)
-        .layer(axum_middleware::from_fn(middleware::security_headers))
+        .layer(axum_middleware::from_fn(middleware::security_headers(
+            middleware::API_CSP,
+        )))
         .layer(TraceLayer::new_for_http());
     // API-only service: the harvester-admin dashboard UI now lives in the
     // editor (frontend/src/harvester), which reaches this API through the

--- a/packages/admin/src/middleware.rs
+++ b/packages/admin/src/middleware.rs
@@ -10,7 +10,8 @@ use sha2::{Digest, Sha256};
 use subtle::ConstantTimeEq;
 use tower_sessions::Session;
 
-pub use regelrecht_auth::middleware::{refresh_session_token, security_headers};
+pub use regelrecht_auth::middleware::refresh_session_token;
+pub use regelrecht_auth::security_headers::{security_headers, API_CSP};
 use regelrecht_auth::{check_session_role, RoleCheck};
 
 use crate::error::ApiError;
@@ -215,30 +216,6 @@ mod tests {
             ))
             .with_state(state)
             .layer(session_layer)
-    }
-
-    #[tokio::test]
-    async fn security_headers_are_set() {
-        let app = Router::new()
-            .route("/test", get(|| async { "ok" }))
-            .layer(axum_middleware::from_fn(security_headers));
-
-        let response = app
-            .oneshot(
-                axum::http::Request::builder()
-                    .uri("/test")
-                    .body(Body::empty())
-                    .expect("request"),
-            )
-            .await
-            .expect("response");
-
-        assert_eq!(response.status(), StatusCode::OK);
-        assert_eq!(
-            response.headers().get("x-content-type-options").unwrap(),
-            "nosniff"
-        );
-        assert_eq!(response.headers().get("x-frame-options").unwrap(), "DENY");
     }
 
     #[tokio::test]

--- a/packages/auth/src/lib.rs
+++ b/packages/auth/src/lib.rs
@@ -9,6 +9,7 @@ pub mod config;
 pub mod handlers;
 pub mod middleware;
 pub mod oidc;
+pub mod security_headers;
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;
@@ -19,10 +20,13 @@ pub use handlers::{
     SESSION_KEY_EMAIL_VERIFIED, SESSION_KEY_NAME, SESSION_KEY_ROLES, SESSION_KEY_SUB,
 };
 pub use middleware::{
-    check_session_role, refresh_session_token, require_role, require_session_auth,
-    security_headers, RoleCheck,
+    check_session_role, refresh_session_token, require_role, require_session_auth, RoleCheck,
 };
 pub use oidc::{discover_client, ConfiguredClient, DiscoveryResult};
+// De middleware zelf wordt bewust niet hier heruitgevoerd: hij heet net als
+// zijn module, en dan wordt `regelrecht_auth::security_headers::…` een
+// dubbelzinnig pad.
+pub use security_headers::{API_CSP, EDITOR_CSP};
 
 /// Install aws-lc-rs as the process-wide rustls crypto provider.
 ///

--- a/packages/auth/src/middleware.rs
+++ b/packages/auth/src/middleware.rs
@@ -2,8 +2,7 @@ use std::future::Future;
 use std::pin::Pin;
 
 use axum::extract::{Request, State};
-use axum::http::header;
-use axum::http::{HeaderValue, StatusCode};
+use axum::http::StatusCode;
 use axum::middleware::Next;
 use axum::response::Response;
 use openidconnect::core::CoreErrorResponseType;
@@ -80,35 +79,6 @@ pub async fn check_session_role(session: &Session, required_role: &str) -> RoleC
             }
         }
     }
-}
-
-pub async fn security_headers(request: Request, next: Next) -> Response {
-    let mut response = next.run(request).await;
-    let headers = response.headers_mut();
-    headers.insert(
-        header::X_CONTENT_TYPE_OPTIONS,
-        HeaderValue::from_static("nosniff"),
-    );
-    headers.insert(header::X_FRAME_OPTIONS, HeaderValue::from_static("DENY"));
-    headers.insert(
-        header::REFERRER_POLICY,
-        HeaderValue::from_static("strict-origin-when-cross-origin"),
-    );
-    headers.insert(
-        "content-security-policy",
-        HeaderValue::from_static(
-            "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'",
-        ),
-    );
-    headers.insert(
-        "permissions-policy",
-        HeaderValue::from_static("geolocation=(), camera=(), microphone=()"),
-    );
-    headers.insert(
-        header::STRICT_TRANSPORT_SECURITY,
-        HeaderValue::from_static("max-age=31536000; includeSubDomains"),
-    );
-    response
 }
 
 /// Session-based authentication middleware.
@@ -449,55 +419,6 @@ mod tests {
             ))
             .with_state(state)
             .layer(session_layer)
-    }
-
-    #[tokio::test]
-    async fn security_headers_are_set() {
-        let app = Router::new()
-            .route("/test", get(|| async { "ok" }))
-            .layer(axum_middleware::from_fn(security_headers));
-
-        let response = app
-            .oneshot(
-                axum::http::Request::builder()
-                    .uri("/test")
-                    .body(Body::empty())
-                    .expect("request"),
-            )
-            .await
-            .expect("response");
-
-        assert_eq!(response.status(), StatusCode::OK);
-        assert_eq!(
-            response.headers().get("x-content-type-options").unwrap(),
-            "nosniff"
-        );
-        assert_eq!(response.headers().get("x-frame-options").unwrap(), "DENY");
-        assert_eq!(
-            response.headers().get("referrer-policy").unwrap(),
-            "strict-origin-when-cross-origin"
-        );
-        assert!(response
-            .headers()
-            .get("content-security-policy")
-            .unwrap()
-            .to_str()
-            .unwrap()
-            .contains("default-src 'self'"));
-        assert!(response
-            .headers()
-            .get("permissions-policy")
-            .unwrap()
-            .to_str()
-            .unwrap()
-            .contains("geolocation=()"));
-        assert!(response
-            .headers()
-            .get("strict-transport-security")
-            .unwrap()
-            .to_str()
-            .unwrap()
-            .contains("max-age="));
     }
 
     #[tokio::test]

--- a/packages/auth/src/security_headers.rs
+++ b/packages/auth/src/security_headers.rs
@@ -1,0 +1,250 @@
+//! The single definition of the HTTP security headers every RegelRecht
+//! service sends.
+//!
+//! Two kinds of server answer on a `*.regelrecht.rijks.app` host: the Axum
+//! binaries in this workspace (editor-api, harvester-admin) and the nginx
+//! images that serve the pre-built sites (docs, lawmaking). Those cannot
+//! share code, so they share values instead: the constants below are the
+//! source, `deploy/nginx/security-headers.conf` is the nginx transcription,
+//! and `script/security-headers.test.mjs` fails the build when the two drift
+//! apart. Grafana is the third kind — it renders its own headers from
+//! `GF_SECURITY_*` and is configured in `packages/grafana/Dockerfile`.
+//!
+//! Everything except the CSP is identical everywhere. The CSP is not: it
+//! describes what one particular document is allowed to load, so it is
+//! chosen per application from the constants below.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use axum::extract::Request;
+use axum::http::header;
+use axum::http::HeaderValue;
+use axum::middleware::Next;
+use axum::response::Response;
+
+/// `preload` keeps the domain eligible for the browser preload list, which
+/// only accepts it with `includeSubDomains` and a year or more.
+pub const STRICT_TRANSPORT_SECURITY: &str = "max-age=31536000; includeSubDomains; preload";
+
+pub const X_CONTENT_TYPE_OPTIONS: &str = "nosniff";
+
+pub const X_FRAME_OPTIONS: &str = "DENY";
+
+pub const REFERRER_POLICY: &str = "strict-origin-when-cross-origin";
+
+pub const PERMISSIONS_POLICY: &str = "geolocation=(), camera=(), microphone=()";
+
+/// CSP for a service that only ever answers JSON and redirects.
+///
+/// `default-src 'none'` is the correct policy for a document that is never
+/// rendered: nothing may be loaded because nothing is meant to be. The three
+/// directives after it do not fall back to `default-src` and have to be
+/// spelled out.
+pub const API_CSP: &str =
+    "default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'";
+
+/// CSP for the editor SPA, which `editor-api` serves itself.
+///
+/// Two allowances are load-bearing and neither is `unsafe-eval`:
+///
+/// * `'wasm-unsafe-eval'` — the law engine is a WebAssembly module, and
+///   instantiating one counts as compiling code. This grants exactly that
+///   and nothing else; `'unsafe-eval'` would additionally hand out
+///   `eval()` and `new Function()`.
+/// * `blob:` in `script-src` — `useEngine.js` fetches the wasm-bindgen glue
+///   from this origin, wraps it in a `Blob` and `import()`s the resulting
+///   URL. A blob URL inherits the origin that created it, so the code still
+///   comes from us; without the scheme the import is blocked.
+///
+/// `style-src 'unsafe-inline'` is unavoidable: the NDD web components build
+/// a `<style>` element and assign its `textContent`, and several templates
+/// carry a `style="…"` attribute. `script-src` gets no such allowance —
+/// the built bundle has no inline script, and Vue runs runtime-only, so
+/// nothing needs `'unsafe-eval'` either.
+///
+/// `worker-src 'self'` is spelled out because it would otherwise fall back
+/// to `script-src` (not to `default-src`) and inherit the `blob:` above.
+/// Nothing in the bundle starts a worker, so the blob allowance stays
+/// confined to the one import that needs it.
+///
+/// GitHub and wetten.overheid.nl are absent from `connect-src`: that traffic
+/// runs through `editor-api`, so the browser only ever talks to its own
+/// origin.
+pub const EDITOR_CSP: &str = "default-src 'self'; \
+     script-src 'self' 'wasm-unsafe-eval' blob:; \
+     worker-src 'self'; \
+     style-src 'self' 'unsafe-inline'; \
+     img-src 'self' data:; \
+     font-src 'self'; \
+     connect-src 'self'; \
+     object-src 'none'; \
+     frame-src 'none'; \
+     frame-ancestors 'none'; \
+     base-uri 'none'; \
+     form-action 'self'";
+
+type SecurityHeadersFuture = Pin<Box<dyn Future<Output = Response> + Send>>;
+
+/// Middleware that stamps the security headers onto every response, with
+/// `csp` as the `Content-Security-Policy`.
+///
+/// Apply it as the **outermost** layer, and in particular after any
+/// `fallback_service`: `Router::layer` only wraps the routes and the
+/// fallback that exist at the moment it is called, so a fallback registered
+/// later is served without headers. That is how the editor's static files —
+/// the only documents a browser actually renders — went uncovered.
+pub fn security_headers(
+    csp: &'static str,
+) -> impl Fn(Request, Next) -> SecurityHeadersFuture + Clone + Send + Sync + 'static {
+    move |request: Request, next: Next| {
+        Box::pin(async move {
+            let mut response = next.run(request).await;
+            let headers = response.headers_mut();
+            headers.insert(
+                header::X_CONTENT_TYPE_OPTIONS,
+                HeaderValue::from_static(X_CONTENT_TYPE_OPTIONS),
+            );
+            headers.insert(
+                header::X_FRAME_OPTIONS,
+                HeaderValue::from_static(X_FRAME_OPTIONS),
+            );
+            headers.insert(
+                header::REFERRER_POLICY,
+                HeaderValue::from_static(REFERRER_POLICY),
+            );
+            headers.insert(
+                header::CONTENT_SECURITY_POLICY,
+                HeaderValue::from_static(csp),
+            );
+            headers.insert(
+                "permissions-policy",
+                HeaderValue::from_static(PERMISSIONS_POLICY),
+            );
+            headers.insert(
+                header::STRICT_TRANSPORT_SECURITY,
+                HeaderValue::from_static(STRICT_TRANSPORT_SECURITY),
+            );
+            response
+        })
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::middleware as axum_middleware;
+    use axum::routing::get;
+    use axum::Router;
+    use tower::ServiceExt;
+
+    async fn headers_of(app: Router, uri: &str) -> axum::http::HeaderMap {
+        app.oneshot(
+            axum::http::Request::builder()
+                .uri(uri)
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response")
+        .headers()
+        .clone()
+    }
+
+    #[tokio::test]
+    async fn every_header_is_set() {
+        let app = Router::new()
+            .route("/test", get(|| async { "ok" }))
+            .layer(axum_middleware::from_fn(security_headers(API_CSP)));
+
+        let headers = headers_of(app, "/test").await;
+        assert_eq!(headers["x-content-type-options"], X_CONTENT_TYPE_OPTIONS);
+        assert_eq!(headers["x-frame-options"], X_FRAME_OPTIONS);
+        assert_eq!(headers["referrer-policy"], REFERRER_POLICY);
+        assert_eq!(headers["permissions-policy"], PERMISSIONS_POLICY);
+        assert_eq!(
+            headers["strict-transport-security"],
+            STRICT_TRANSPORT_SECURITY
+        );
+        assert_eq!(headers["content-security-policy"], API_CSP);
+    }
+
+    /// Pins the ordering rule documented on [`security_headers`], in both
+    /// directions. It fails silently in production: every API route still
+    /// answers with headers, and only the rendered document does not.
+    #[tokio::test]
+    async fn a_fallback_registered_after_the_layer_is_uncovered() {
+        let uncovered = Router::new()
+            .route("/api/thing", get(|| async { "ok" }))
+            .layer(axum_middleware::from_fn(security_headers(EDITOR_CSP)))
+            .fallback(|| async { "index.html" });
+
+        assert!(headers_of(uncovered.clone(), "/api/thing")
+            .await
+            .contains_key("content-security-policy"));
+        assert!(
+            !headers_of(uncovered, "/deep/link")
+                .await
+                .contains_key("content-security-policy"),
+            "if axum ever starts covering a later fallback, drop this test \
+             rather than the layer ordering it guards"
+        );
+
+        let covered = Router::new()
+            .route("/api/thing", get(|| async { "ok" }))
+            .fallback(|| async { "index.html" })
+            .layer(axum_middleware::from_fn(security_headers(EDITOR_CSP)));
+
+        assert_eq!(
+            headers_of(covered, "/deep/link").await["content-security-policy"],
+            EDITOR_CSP
+        );
+    }
+
+    fn directive<'a>(csp: &'a str, name: &str) -> Option<&'a str> {
+        csp.split(';')
+            .map(str::trim)
+            .find(|d| d.split_whitespace().next() == Some(name))
+    }
+
+    /// A CSP that grants `unsafe-eval` or inline script is what an external
+    /// scan reports as "CSP with certain insecure settings". Inline *styles*
+    /// are a separate, unavoidable case and are allowed here.
+    ///
+    /// The check runs over whichever directive actually governs script, so a
+    /// policy that drops `script-src` and widens `default-src` instead is
+    /// caught rather than skipped.
+    #[test]
+    fn no_policy_grants_eval_or_inline_script() {
+        for csp in [API_CSP, EDITOR_CSP] {
+            assert!(!csp.contains("'unsafe-eval'"), "{csp}");
+            let governing = directive(csp, "script-src")
+                .or_else(|| directive(csp, "default-src"))
+                .unwrap_or_else(|| panic!("{csp} governs script through neither directive"));
+            assert!(!governing.contains("'unsafe-inline'"), "{governing}");
+        }
+    }
+
+    /// Directives that do not inherit from `default-src`. Leaving one out is
+    /// the classic hole in an otherwise strict policy, and so is naming one
+    /// with a value that permits everything.
+    #[test]
+    fn every_policy_closes_the_non_inheriting_directives() {
+        for csp in [API_CSP, EDITOR_CSP] {
+            for name in ["frame-ancestors", "base-uri"] {
+                assert_eq!(
+                    directive(csp, name),
+                    Some(format!("{name} 'none'").as_str()),
+                    "in {csp}"
+                );
+            }
+            let form_action = directive(csp, "form-action").expect("form-action");
+            assert!(
+                form_action == "form-action 'none'" || form_action == "form-action 'self'",
+                "{form_action}"
+            );
+        }
+    }
+}

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -648,9 +648,8 @@ async fn main() {
                 middleware::refresh_session_token::<AppState>,
             ))
             .layer(session_layer)
-            .layer(axum_middleware::from_fn(middleware::security_headers))
-            .layer(TraceLayer::new_for_http())
-            .fallback_service(static_service(&static_dir, &index_file));
+            .layer(TraceLayer::new_for_http());
+        let app = serve_static_and_secure(app, &static_dir, &index_file);
 
         serve(app, Some(deletion_handle)).await;
     } else {
@@ -680,9 +679,8 @@ async fn main() {
             // recorder wraps the routed handlers.
             .layer(axum_middleware::from_fn(middleware::server_timing))
             .layer(session_layer)
-            .layer(axum_middleware::from_fn(middleware::security_headers))
-            .layer(TraceLayer::new_for_http())
-            .fallback_service(static_service(&static_dir, index_file));
+            .layer(TraceLayer::new_for_http());
+        let app = serve_static_and_secure(app, &static_dir, index_file);
 
         serve(app, None).await;
     }
@@ -863,6 +861,26 @@ async fn init_backends(
     }
 
     backends
+}
+
+/// Close the router: hang the SPA off the fallback, then wrap everything in
+/// the security headers.
+///
+/// The order is the point. `Router::layer` covers the routes and fallback
+/// registered before it, so a `fallback_service` added afterwards answers
+/// without any of them — and the fallback is what serves `index.html` and
+/// the bundle, the only responses a browser renders as a document. Doing
+/// both steps here keeps the two calls from drifting apart in the two
+/// (auth-enabled / auth-disabled) router branches.
+fn serve_static_and_secure(
+    app: Router,
+    static_dir: &str,
+    index_file: impl AsRef<std::path::Path>,
+) -> Router {
+    app.fallback_service(static_service(static_dir, index_file))
+        .layer(axum_middleware::from_fn(middleware::security_headers(
+            middleware::EDITOR_CSP,
+        )))
 }
 
 /// Static-file service for the built editor frontend.
@@ -1428,6 +1446,111 @@ mod static_service_tests {
         assert_eq!(
             response.headers()["cache-control"],
             static_cache::REVALIDATE
+        );
+    }
+}
+
+/// Proves the editor ships the headers on the responses that matter. A test
+/// that only hits `/health` cannot: the JSON routes kept their headers the
+/// whole time the rendered document had none.
+#[cfg(test)]
+mod security_header_tests {
+    use super::{middleware, serve_static_and_secure};
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::routing::get;
+    use axum::Router;
+    use tower::ServiceExt;
+
+    /// The router shape both production branches end in: some API routes,
+    /// then `serve_static_and_secure` over a `dist`-like directory.
+    fn app(dir: &tempfile::TempDir) -> Router {
+        let static_dir = dir.path().to_string_lossy().to_string();
+        let index = dir.path().join("index.html");
+        let routes = Router::new().route("/health", get(|| async { "OK" }));
+        serve_static_and_secure(routes, &static_dir, index)
+    }
+
+    fn fixture() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir(dir.path().join("assets")).expect("mkdir");
+        std::fs::write(dir.path().join("assets").join("app-DkX9a2Bc.js"), b"js").expect("write");
+        std::fs::write(dir.path().join("index.html"), b"<!doctype html>").expect("write");
+        dir
+    }
+
+    async fn get_path(dir: &tempfile::TempDir, path: &str) -> axum::http::Response<Body> {
+        app(dir)
+            .oneshot(
+                Request::builder()
+                    .uri(path)
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response")
+    }
+
+    /// `/` and a deep link both resolve through the fallback, which is the
+    /// half that used to escape the middleware. A deep link answers with the
+    /// SPA index under a 404 (see [`static_cache`]); the headers are what
+    /// this asserts, not the status.
+    #[tokio::test]
+    async fn every_response_carries_the_headers() {
+        let dir = fixture();
+        for path in [
+            "/health",
+            "/",
+            "/library/wet_op_de_zorgtoeslag",
+            "/index.html",
+        ] {
+            let response = get_path(&dir, path).await;
+            let headers = response.headers();
+            assert_eq!(
+                headers["content-security-policy"],
+                middleware::EDITOR_CSP,
+                "no CSP on {path}"
+            );
+            assert_eq!(headers["x-frame-options"], "DENY", "{path}");
+            assert_eq!(headers["x-content-type-options"], "nosniff", "{path}");
+            assert_eq!(
+                headers["referrer-policy"], "strict-origin-when-cross-origin",
+                "{path}"
+            );
+            assert!(headers.contains_key("permissions-policy"), "{path}");
+            assert!(headers.contains_key("strict-transport-security"), "{path}");
+        }
+    }
+
+    /// The static layer sets `Cache-Control` from inside the fallback; the
+    /// header layer wraps it from outside. Neither may erase the other.
+    #[tokio::test]
+    async fn the_headers_do_not_displace_the_cache_policy() {
+        let dir = fixture();
+        let response = get_path(&dir, "/assets/app-DkX9a2Bc.js").await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers()["cache-control"],
+            super::static_cache::IMMUTABLE
+        );
+        assert_eq!(
+            response.headers()["content-security-policy"],
+            middleware::EDITOR_CSP
+        );
+    }
+
+    /// A miss inside `/assets/` falls through to the SPA index — a rendered
+    /// document under an unexpected status, so it needs the headers too.
+    #[tokio::test]
+    async fn the_spa_fallback_response_is_covered() {
+        let dir = fixture();
+        let response = get_path(&dir, "/assets/gone-Zz9YxW01.js").await;
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert_eq!(
+            response.headers()["content-security-policy"],
+            middleware::EDITOR_CSP
         );
     }
 }

--- a/packages/editor-api/src/middleware.rs
+++ b/packages/editor-api/src/middleware.rs
@@ -1,4 +1,5 @@
-pub use regelrecht_auth::middleware::{refresh_session_token, require_role, security_headers};
+pub use regelrecht_auth::middleware::{refresh_session_token, require_role};
+pub use regelrecht_auth::security_headers::{security_headers, EDITOR_CSP};
 
 use axum::extract::Request;
 use axum::http::{header::HeaderName, HeaderValue};

--- a/packages/grafana/Dockerfile
+++ b/packages/grafana/Dockerfile
@@ -18,6 +18,34 @@ ENV GF_ANALYTICS_CHECK_FOR_PLUGIN_UPDATES=false
 # Disable anonymous access
 ENV GF_AUTH_ANONYMOUS_ENABLED=false
 
+# Security headers. Grafana renders its own, so this is the third place they
+# are decided next to packages/auth/src/security_headers.rs (the Axum
+# services) and deploy/nginx/security-headers.conf (docs and lawmaking).
+# Grafana ships no setting for Referrer-Policy or Permissions-Policy, so this
+# host sends neither; adding them would take a proxy in front of it.
+#
+# Defaults already cover part of it: x_content_type_options and
+# x_xss_protection are on, and allow_embedding=false yields
+# `X-Frame-Options: deny`. HSTS and CSP are off by default and are what this
+# block turns on.
+ENV GF_SECURITY_STRICT_TRANSPORT_SECURITY=true
+ENV GF_SECURITY_STRICT_TRANSPORT_SECURITY_MAX_AGE_SECONDS=31536000
+ENV GF_SECURITY_STRICT_TRANSPORT_SECURITY_SUBDOMAINS=true
+ENV GF_SECURITY_STRICT_TRANSPORT_SECURITY_PRELOAD=true
+ENV GF_SECURITY_CONTENT_SECURITY_POLICY=true
+# Grafana's own template with `frame-ancestors 'none'` appended. Its
+# `'unsafe-eval'` and `'unsafe-inline'` are upstream's and cannot be removed
+# without breaking the UI; `'strict-dynamic'` plus the per-request $NONCE
+# makes a modern browser ignore the `'unsafe-inline'` anyway. Anything beyond
+# this — a `default-src`, a narrower `img-src` — has to be tried against a
+# running Grafana first, because its panels load workers and images from
+# places the template deliberately leaves open.
+#
+# The `\$` are escaped for the Dockerfile parser, not for Grafana: an
+# unescaped `$NONCE` is expanded at build time and reaches Grafana empty,
+# which drops the nonce that makes `'strict-dynamic'` work.
+ENV GF_SECURITY_CONTENT_SECURITY_POLICY_TEMPLATE="script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' \$NONCE;object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline' blob:;img-src * data:;base-uri 'self';connect-src 'self' grafana.com ws://\$ROOT_PATH wss://\$ROOT_PATH;manifest-src 'self';media-src 'none';form-action 'self';frame-ancestors 'none';"
+
 # Disable local admin account when OIDC is available (set in entrypoint.sh).
 # When OIDC vars are missing, the entrypoint keeps the default admin/admin
 # account as a temporary fallback. Do NOT expose publicly without OIDC.

--- a/script/deploy-filters.mjs
+++ b/script/deploy-filters.mjs
@@ -21,6 +21,11 @@ import { execFileSync } from 'node:child_process';
 import { appendFileSync, readFileSync, realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
+// De nginx-images kopiëren dit bestand alle twee mee. Het valt buiten hun
+// eigen map, dus zonder deze regel levert een aangescherpte header een groene
+// build op die niets uitrolt.
+const NGINX_SHARED = 'deploy/nginx/';
+
 // Per component: de crate waar het image aan hangt (of null), plus de paden
 // buiten de graaf die het image beïnvloeden.
 export const COMPONENTS = {
@@ -52,9 +57,9 @@ export const COMPONENTS = {
   grafana: { crate: null, paths: ['packages/grafana/'] },
   lawmaking: {
     crate: null,
-    paths: ['frontend-lawmaking/', 'packages/frontend-shared/'],
+    paths: ['frontend-lawmaking/', 'packages/frontend-shared/', NGINX_SHARED],
   },
-  docs: { crate: null, paths: ['docs/'] },
+  docs: { crate: null, paths: ['docs/', NGINX_SHARED] },
 };
 
 // Raakt elk component met een Rust-image: de workspace zelf.

--- a/script/deploy-filters.test.mjs
+++ b/script/deploy-filters.test.mjs
@@ -137,6 +137,18 @@ test('de handmatige paden buiten de graaf blijven werken', () => {
   assert.equal(shared.lawmaking, true);
 });
 
+test('de gedeelde nginx-headers raken beide nginx-images', () => {
+  // Het bestand ligt buiten docs/ en frontend-lawmaking/, terwijl beide images
+  // het meekopiëren. Zonder deze regel scherpt iemand een header aan, wordt de
+  // build groen, en rolt er niets uit — precies de stille overslag waarvoor
+  // dit script bestaat.
+  const hit = namesOf(['deploy/nginx/security-headers.conf']);
+  assert.equal(hit.docs, true);
+  assert.equal(hit.lawmaking, true);
+  assert.equal(hit.editor, false);
+  assert.equal(hit.grafana, false);
+});
+
 test('de skills raken alleen de enrich-worker', () => {
   // Drie componenten hangen aan dezelfde crate; alleen de enrich-worker neemt
   // de skills mee in zijn image.

--- a/script/security-headers.test.mjs
+++ b/script/security-headers.test.mjs
@@ -1,0 +1,227 @@
+// Pint vast dat elk RegelRecht-domein dezelfde security-headers stuurt, en dat
+// er geen plek is die ze stilletjes overslaat.
+//
+// De aanleiding: er was een CSP, hij stond netjes in de diff, en de browser
+// kreeg hem nooit — één keer omdat het bestand door geen enkele Dockerfile
+// gelezen werd, één keer omdat de middleware vóór de `fallback_service` hing
+// die de SPA serveert. Zulke fouten maken niets rood. Ze moeten hier rood
+// worden.
+//
+// De drie servertypes lezen elk hun eigen bron: de Axum-diensten
+// `packages/auth/src/security_headers.rs`, de nginx-images
+// `deploy/nginx/security-headers.conf`, Grafana zijn `GF_SECURITY_*`. Deze
+// test is de enige plek waar die drie naast elkaar liggen.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
+
+const root = fileURLToPath(new URL('../', import.meta.url));
+const read = (path) => readFileSync(join(root, path), 'utf8');
+
+const SHARED_PATH = 'deploy/nginx/security-headers.conf';
+const SHARED_TARGET = '/etc/nginx/security-headers.conf';
+
+const RUST = read('packages/auth/src/security_headers.rs');
+const SHARED = read(SHARED_PATH);
+
+// Zoeken in plaats van opsommen: een derde site die zijn eigen nginx.conf
+// meebrengt hoort onder dezelfde eisen te vallen zonder dat iemand hem hier
+// toevoegt.
+function findNginxConfigs(dir = '', found = []) {
+  const skip = new Set(['node_modules', '.git', 'target', 'dist', '.worktrees']);
+  for (const entry of readdirSync(join(root, dir))) {
+    if (skip.has(entry) || entry.startsWith('.')) continue;
+    const rel = dir ? `${dir}/${entry}` : entry;
+    if (statSync(join(root, rel)).isDirectory()) findNginxConfigs(rel, found);
+    else if (entry === 'nginx.conf') found.push(rel);
+  }
+  return found;
+}
+
+const NGINX_SITES = Object.fromEntries(findNginxConfigs().map((p) => [p, read(p)]));
+
+/// De header-naam zoals nginx hem schrijft, gekoppeld aan de Rust-constante.
+/// De CSP staat er niet bij: die beschrijft één document en verschilt per site.
+const SHARED_HEADERS = {
+  'X-Content-Type-Options': 'X_CONTENT_TYPE_OPTIONS',
+  'X-Frame-Options': 'X_FRAME_OPTIONS',
+  'Referrer-Policy': 'REFERRER_POLICY',
+  'Permissions-Policy': 'PERMISSIONS_POLICY',
+  'Strict-Transport-Security': 'STRICT_TRANSPORT_SECURITY',
+};
+
+function rustConstant(name) {
+  const match = RUST.match(new RegExp(`pub const ${name}: &str = "([^"]*)"`));
+  assert.ok(match, `constante ${name} niet gevonden in security_headers.rs`);
+  return match[1];
+}
+
+/// De `\` aan het regeleinde plakt de string in Rust aan elkaar zonder de
+/// witruimte ervoor; hier doen we hetzelfde.
+function rustCsp(name) {
+  const match = RUST.match(new RegExp(`pub const ${name}: &str = "([\\s\\S]*?)";`));
+  assert.ok(match, `constante ${name} niet gevonden in security_headers.rs`);
+  return match[1].replace(/\\\s+/g, '');
+}
+
+/// Splits een config in server-blokken, en elk server-blok in zijn
+/// location-blokken. Beide niveaus zijn nodig: `set $csp` hoort per server,
+/// de include per location.
+function serverBlocks(conf) {
+  const servers = [];
+  const re = /server\s*\{/g;
+  let match;
+  while ((match = re.exec(conf)) !== null) {
+    let depth = 1;
+    let i = re.lastIndex;
+    while (i < conf.length && depth > 0) {
+      if (conf[i] === '{') depth += 1;
+      else if (conf[i] === '}') depth -= 1;
+      i += 1;
+    }
+    servers.push(conf.slice(re.lastIndex, i - 1));
+  }
+  return servers;
+}
+
+function locationBlocks(server) {
+  const blocks = [];
+  const re = /location\s+([^{]+)\{/g;
+  let match;
+  while ((match = re.exec(server)) !== null) {
+    let depth = 1;
+    let i = re.lastIndex;
+    while (i < server.length && depth > 0) {
+      if (server[i] === '{') depth += 1;
+      else if (server[i] === '}') depth -= 1;
+      i += 1;
+    }
+    blocks.push({ selector: match[1].trim(), body: server.slice(re.lastIndex, i - 1) });
+  }
+  return blocks;
+}
+
+function directive(csp, name) {
+  return csp
+    .split(';')
+    .map((d) => d.trim())
+    .find((d) => d.split(/\s+/)[0] === name);
+}
+
+test('er is iets om te vergelijken', () => {
+  // Een lege verzameling zou elke test hieronder leeg laten slagen.
+  assert.ok(Object.keys(NGINX_SITES).length >= 2, Object.keys(NGINX_SITES).join(', '));
+});
+
+test('nginx stuurt exact de waarden die de Rust-diensten sturen', () => {
+  for (const [header, constant] of Object.entries(SHARED_HEADERS)) {
+    const expected = rustConstant(constant);
+    const match = SHARED.match(new RegExp(`add_header ${header} "([^"]*)" always;`));
+    assert.ok(match, `${header} ontbreekt in ${SHARED_PATH}`);
+    assert.equal(match[1], expected, `${header} loopt uiteen tussen nginx en security_headers.rs`);
+  }
+});
+
+test('het gedeelde bestand stuurt ook een CSP', () => {
+  assert.match(SHARED, /add_header Content-Security-Policy \$csp always;/);
+});
+
+test('elk server-blok zet zijn eigen $csp', () => {
+  for (const [name, conf] of Object.entries(NGINX_SITES)) {
+    for (const [index, server] of serverBlocks(conf).entries()) {
+      const match = server.match(/set \$csp "([^"]*)";/);
+      // Zonder eigen `set` erft een tweede server-blok de variabele niet: hij
+      // is dan leeg, en nginx laat de header dan zonder klacht weg.
+      assert.ok(match, `${name}: server-blok ${index} zet geen $csp`);
+      const csp = match[1];
+      for (const [directiveName, allowed] of [
+        ['frame-ancestors', ["'none'"]],
+        ['base-uri', ["'none'"]],
+        ['form-action', ["'none'", "'self'"]],
+      ]) {
+        const found = directive(csp, directiveName);
+        assert.ok(found, `${name}: ${directiveName} ontbreekt in de CSP`);
+        assert.ok(
+          allowed.includes(found.slice(directiveName.length).trim()),
+          `${name}: ${found}`,
+        );
+      }
+      assert.ok(!csp.includes("'unsafe-eval'"), `${name}: 'unsafe-eval' in de CSP`);
+    }
+  }
+});
+
+test('elk location-blok behalve de healthprobe draagt de headers', () => {
+  for (const [name, conf] of Object.entries(NGINX_SITES)) {
+    for (const server of serverBlocks(conf)) {
+      for (const { selector, body } of locationBlocks(server)) {
+        // De healthprobe is de enige uitzondering: geen document, geen
+        // publiek pad. Redirects horen er wél bij — de security.txt-route is
+        // juist het pad dat een scanner aanloopt.
+        if (selector === '/health') continue;
+        assert.ok(
+          body.includes(`include ${SHARED_TARGET};`),
+          `${name}: location ${selector} antwoordt zonder de headers`,
+        );
+      }
+    }
+  }
+});
+
+test('elk nginx-image kopieert het gedeelde bestand mee', () => {
+  for (const site of Object.keys(NGINX_SITES)) {
+    // Zonder de COPY faalt nginx pas bij containerstart op de ontbrekende
+    // include, dus in deploy-preview in plaats van hier.
+    const dockerfile = read(`${site.replace(/\/nginx\.conf$/, '')}/Dockerfile`);
+    assert.ok(
+      dockerfile.includes(`COPY ${SHARED_PATH} ${SHARED_TARGET}`),
+      `${site}: de Dockerfile kopieert ${SHARED_PATH} niet`,
+    );
+  }
+});
+
+test('geen enkele nginx-CSP staat inline script toe, op docs na', () => {
+  // `docs` houdt bewust `script-src 'unsafe-inline'`: Astro emitteert een
+  // pre-paint theme-script en een Pagefind-script waarvan de inhoud per
+  // pagina verschilt, dus één nginx-brede hash volstaat niet.
+  const withInlineScript = ['docs/nginx.conf'];
+  for (const [name, conf] of Object.entries(NGINX_SITES)) {
+    if (withInlineScript.includes(name)) continue;
+    for (const server of serverBlocks(conf)) {
+      const csp = server.match(/set \$csp "([^"]*)";/)[1];
+      const governing = directive(csp, 'script-src') ?? directive(csp, 'default-src');
+      assert.ok(governing, `${name}: script valt onder geen enkele directive`);
+      assert.ok(!governing.includes("'unsafe-inline'"), `${name}: ${governing}`);
+    }
+  }
+});
+
+test('de editor-CSP laat de wasm-engine daadwerkelijk starten', () => {
+  // `useEngine.js` haalt de wasm-bindgen-glue op, stopt hem in een Blob en
+  // `import()`t die URL; de glue roept vervolgens WebAssembly.instantiate aan.
+  // Zonder deze twee waarden start de engine niet, en dat merk je pas in de
+  // browser — geen enkele Rust-test compileert wasm.
+  const scriptSrc = directive(rustCsp('EDITOR_CSP'), 'script-src');
+  assert.ok(scriptSrc, 'EDITOR_CSP heeft geen script-src');
+  assert.ok(scriptSrc.includes("'wasm-unsafe-eval'"), scriptSrc);
+  assert.ok(scriptSrc.includes('blob:'), scriptSrc);
+});
+
+test('grafana zet de headers aan die het kent', () => {
+  const dockerfile = read('packages/grafana/Dockerfile');
+  for (const setting of [
+    'GF_SECURITY_STRICT_TRANSPORT_SECURITY=true',
+    'GF_SECURITY_CONTENT_SECURITY_POLICY=true',
+  ]) {
+    assert.ok(dockerfile.includes(setting), `${setting} ontbreekt`);
+  }
+  // Grafana's eigen template kent geen frame-ancestors; zonder die toevoeging
+  // leunt het embedden-verbod alleen op X-Frame-Options.
+  assert.match(dockerfile, /GF_SECURITY_CONTENT_SECURITY_POLICY_TEMPLATE=.*frame-ancestors 'none'/);
+  // De nonce moet de Dockerfile-parser overleven; ingevuld op buildtijd valt
+  // 'strict-dynamic' terug op niets.
+  assert.match(dockerfile, /\\\$NONCE/);
+});


### PR DESCRIPTION
Een externe scan meldt dat er geen Content-Security-Policy is, of één met onveilige instellingen. Dat klopt voor elk domein, om per domein een andere reden. De editor hing zijn header-middleware vóór de `fallback_service` die `frontend/dist` serveert, dus de API-routes kregen de headers en het enige antwoord dat een browser als document rendert niet. Grafana had HSTS en CSP op de default `false`. Docs en lawmaking stuurden ze wel, maar vier keer uitgeschreven, met de 404-pagina van docs erbuiten.

De vijf gedeelde headers komen nu uit één definitie per servertype. De CSP blijft per applicatie, want die beschrijft één document. De editor krijgt `'wasm-unsafe-eval'` en `blob:` in `script-src`, omdat `useEngine.js` de wasm-glue via een Blob importeert; verder staat geen enkele policy hier `'unsafe-eval'` of inline script toe, behalve die van docs en die van Grafana. Grafana blijft zonder Referrer-Policy en Permissions-Policy, want het kent er geen instelling voor. De headers zijn per pad geverifieerd tegen draaiende images.

Closes #1165