### PR TITLE
fix(engine): een korte tabelrij valt stil weg in rust en wordt undefined in js

### DIFF
--- a/frontend/src/gherkin/actions.js
+++ b/frontend/src/gherkin/actions.js
@@ -43,14 +43,25 @@ export function parseValue(str) {
  * Parse a data table into record objects using the header row.
  * Values are auto-typed via parseValue() so the engine receives correctly
  * typed numbers, booleans, and nulls.
+ *
+ * A row that does not match the header row is rejected rather than filled with
+ * undefined: today the Gherkin parser already rejects a varying cell count, but
+ * that guarantee lives in a dependency we bump, and the Rust mirror
+ * (`rows_to_records`) leans on a different parser. The explicit check keeps
+ * both sides failing the same way if either parser ever loosens.
  */
 export function tableToRecords(dataTable) {
   if (!dataTable || dataTable.length < 2) return [];
   const headers = dataTable[0];
-  return dataTable.slice(1).map((row) => {
+  return dataTable.slice(1).map((row, rowIndex) => {
+    if (row.length !== headers.length) {
+      throw new Error(
+        `data table row ${rowIndex + 1} has ${row.length} cells, header row has ${headers.length}`,
+      );
+    }
     const record = {};
     headers.forEach((h, i) => {
-      record[h] = parseValue(row[i] || '');
+      record[h] = parseValue(row[i]);
     });
     return record;
   });

--- a/frontend/src/gherkin/actions.test.js
+++ b/frontend/src/gherkin/actions.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { tableToRecords } from './actions.js';
+
+describe('tableToRecords', () => {
+  it('builds one typed record per data row from the header row', () => {
+    const records = tableToRecords([
+      ['naam', 'leeftijd', 'verzekerd'],
+      ['Jansen', '30', 'true'],
+    ]);
+
+    expect(records).toEqual([{ naam: 'Jansen', leeftijd: 30, verzekerd: true }]);
+  });
+
+  it('returns nothing for a table without data rows', () => {
+    expect(tableToRecords([['naam', 'leeftijd']])).toEqual([]);
+    expect(tableToRecords(null)).toEqual([]);
+  });
+
+  // Mirror of the Rust `rows_to_records` check: a short row must fail loudly
+  // instead of yielding undefined for the missing column.
+  it('rejects a row that is shorter than the header row', () => {
+    expect(() =>
+      tableToRecords([
+        ['naam', 'leeftijd', 'verzekerd'],
+        ['Jansen', '30'],
+      ]),
+    ).toThrow('data table row 1 has 2 cells, header row has 3');
+  });
+
+  it('rejects a row that is longer than the header row', () => {
+    expect(() =>
+      tableToRecords([
+        ['naam', 'leeftijd', 'verzekerd'],
+        ['Jansen', '30', 'true'],
+        ['De Vries', '40', 'false', 'extra'],
+      ]),
+    ).toThrow('data table row 2 has 4 cells, header row has 3');
+  });
+});

--- a/packages/engine/tests/bdd/dispatch.rs
+++ b/packages/engine/tests/bdd/dispatch.rs
@@ -6,13 +6,14 @@
 //! live here — codegen carries no per-action knowledge. Bodies are ported from
 //! the hand-written `steps/{given,when,then,notes}.rs`.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 
 use regelrecht_engine::{
     annotation, Article, OutputProvenance, SelectorHint, TextQuoteSelector, Value,
 };
 use rust_decimal::Decimal;
 
+use crate::helpers::table::{rows_to_params, rows_to_records, Rows};
 use crate::helpers::value_conversion::{convert_gherkin_value, values_equal_with_tolerance};
 use crate::world::RegelrechtWorld;
 
@@ -46,10 +47,6 @@ impl ArgValue {
         }
     }
 }
-
-/// Table rows come straight from cucumber's `gherkin::Step.table.rows`:
-/// `Vec<Vec<String>>` where `row[0]` is the header row.
-type Rows = Vec<Vec<String>>;
 
 impl RegelrechtWorld {
     /// Execute one canonical grammar action. Panics (test assertion) on any
@@ -421,36 +418,6 @@ fn num_to_value(n: f64) -> Value {
                 .expect("numeric literal parses as Decimal"),
         )
     }
-}
-
-/// Parse a two-column key/value parameter table.
-fn rows_to_params(rows: &Rows) -> BTreeMap<String, Value> {
-    let mut params = BTreeMap::new();
-    for row in rows {
-        if row.len() >= 2 {
-            params.insert(row[0].trim().to_string(), convert_gherkin_value(&row[1]));
-        }
-    }
-    params
-}
-
-/// Parse a header-row table into a list of records (one per data row).
-fn rows_to_records(rows: &Rows) -> Vec<BTreeMap<String, Value>> {
-    if rows.len() < 2 {
-        return Vec::new();
-    }
-    let headers: Vec<String> = rows[0].iter().map(|s| s.trim().to_string()).collect();
-    let mut records = Vec::new();
-    for row in rows.iter().skip(1) {
-        let mut record = BTreeMap::new();
-        for (i, cell) in row.iter().enumerate() {
-            if let Some(header) = headers.get(i) {
-                record.insert(header.clone(), convert_gherkin_value(cell));
-            }
-        }
-        records.push(record);
-    }
-    records
 }
 
 /// Parse the untranslatable mode string into the engine enum. From `given.rs`.

--- a/packages/engine/tests/bdd/helpers/mod.rs
+++ b/packages/engine/tests/bdd/helpers/mod.rs
@@ -4,4 +4,5 @@
 #![allow(unused_imports)]
 
 pub mod regulation_loader;
+pub mod table;
 pub mod value_conversion;

--- a/packages/engine/tests/bdd/helpers/table.rs
+++ b/packages/engine/tests/bdd/helpers/table.rs
@@ -1,0 +1,59 @@
+//! Gherkin data-table shapes shared by the BDD step dispatch.
+//!
+//! Lives in its own module so a plain `cargo test` target can exercise it: the
+//! `bdd` test target runs `harness = false` with `test = false`, so a
+//! `#[cfg(test)]` block next to the dispatch code would never run.
+
+use std::collections::BTreeMap;
+
+use regelrecht_engine::Value;
+
+use super::value_conversion::convert_gherkin_value;
+
+/// Table rows straight from cucumber's `gherkin::Step.table.rows`. Whether
+/// `row[0]` is a header depends on the step: a data-source table has one, a
+/// parameter table does not.
+pub type Rows = Vec<Vec<String>>;
+
+/// Parse a two-column key/value parameter table.
+pub fn rows_to_params(rows: &Rows) -> BTreeMap<String, Value> {
+    let mut params = BTreeMap::new();
+    for row in rows {
+        if row.len() >= 2 {
+            params.insert(row[0].trim().to_string(), convert_gherkin_value(&row[1]));
+        }
+    }
+    params
+}
+
+/// Parse a header-row table into a list of records (one per data row).
+///
+/// A row whose width differs from the header row is rejected instead of
+/// silently truncated. Today no such row reaches here, because the Gherkin
+/// parser refuses a table with a varying cell count. That guarantee sits in a
+/// dependency we bump, though, and the editor's `tableToRecords` leans on a
+/// different parser with a different fallback. The explicit check makes both
+/// sides fail identically and loudly if either parser ever loosens.
+pub fn rows_to_records(rows: &Rows) -> Vec<BTreeMap<String, Value>> {
+    if rows.len() < 2 {
+        return Vec::new();
+    }
+    let headers: Vec<String> = rows[0].iter().map(|s| s.trim().to_string()).collect();
+    let mut records = Vec::new();
+    for (row_index, row) in rows.iter().enumerate().skip(1) {
+        assert!(
+            row.len() == headers.len(),
+            "data table row {row_index} has {} cells, header row has {}",
+            row.len(),
+            headers.len()
+        );
+        records.push(
+            headers
+                .iter()
+                .zip(row)
+                .map(|(header, cell)| (header.clone(), convert_gherkin_value(cell)))
+                .collect(),
+        );
+    }
+    records
+}

--- a/packages/engine/tests/bdd_table.rs
+++ b/packages/engine/tests/bdd_table.rs
@@ -1,0 +1,55 @@
+//! Unit tests for the BDD data-table parsing shared with the editor's JS
+//! mirror (`frontend/src/gherkin/actions.js`). The `bdd` target itself runs
+//! `harness = false` with `test = false`, so these live in their own target.
+
+#![allow(dead_code, clippy::panic, clippy::expect_used, clippy::unwrap_used)]
+
+#[path = "bdd/helpers/value_conversion.rs"]
+mod value_conversion;
+
+#[path = "bdd/helpers/table.rs"]
+mod table;
+
+use regelrecht_engine::Value;
+use table::{rows_to_records, Rows};
+
+fn rows(raw: &[&[&str]]) -> Rows {
+    raw.iter()
+        .map(|row| row.iter().map(|c| (*c).to_string()).collect())
+        .collect()
+}
+
+#[test]
+fn records_use_the_header_row() {
+    let records = rows_to_records(&rows(&[
+        &["naam", "leeftijd", "verzekerd"],
+        &["Jansen", "30", "true"],
+    ]));
+
+    assert_eq!(records.len(), 1);
+    assert_eq!(
+        records[0].get("naam"),
+        Some(&Value::String("Jansen".to_string()))
+    );
+    assert_eq!(records[0].get("leeftijd"), Some(&Value::Int(30)));
+    assert_eq!(records[0].get("verzekerd"), Some(&Value::Bool(true)));
+}
+
+#[test]
+#[should_panic(expected = "data table row 1 has 2 cells, header row has 3")]
+fn a_short_row_is_rejected_instead_of_dropping_a_column() {
+    rows_to_records(&rows(&[
+        &["naam", "leeftijd", "verzekerd"],
+        &["Jansen", "30"],
+    ]));
+}
+
+#[test]
+#[should_panic(expected = "data table row 2 has 4 cells, header row has 3")]
+fn a_long_row_is_rejected_too() {
+    rows_to_records(&rows(&[
+        &["naam", "leeftijd", "verzekerd"],
+        &["Jansen", "30", "true"],
+        &["De Vries", "40", "false", "extra"],
+    ]));
+}


### PR DESCRIPTION
`rows_to_records` in de Rust-stapdefinities liep over de cellen van een rij, `tableToRecords` in de editor over de kopregel. Bij een rij die korter is dan de kopregel liet Rust de laatste kolom stil vallen en gaf JavaScript `undefined` terug. Beide controleren nu dat de rij evenveel cellen heeft als de kopregel, en falen anders met dezelfde melding.

Het verschil is latent, want beide Gherkin-parsers weigeren vandaag al een tabel met wisselend kolomaantal. Het wordt toch opgelost omdat die garantie in twee dependencies zit die we bumpen, terwijl aan onze kant niets de aanname vasthield. De tabelfuncties verhuizen naar `packages/engine/tests/bdd/helpers/table.rs`: het `bdd`-target draait met `test = false`, dus een `#[cfg(test)]`-blok naast de dispatch zou nooit lopen.