### PR TITLE
fix(deps): mermaid naar 11.16.1 tegen vijf openstaande adviezen

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -7713,9 +7713,9 @@
       "license": "MIT"
     },
     "node_modules/mermaid": {
-      "version": "11.16.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.0.tgz",
-      "integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
+      "version": "11.16.1",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.1.tgz",
+      "integrity": "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==",
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.2",


### PR DESCRIPTION
Vijf dependabot-alerts staan open op mermaid 11.16.0 in `docs/package-lock.json`, alle vijf opgelost in 11.16.1: DoS in xy- en radardiagrammen, prototype pollution in architectuurdiagrammen en in de config-API, en css-injectie naar zusterelementen van het diagram.

Mermaid komt binnen via `rehype-mermaid` en rendert tijdens de build tot inline SVG, niet in de browser. De blootstelling loopt dus via onze eigen docs-bronnen en niet via een bezoeker. Dat maakt het minder dringend dan de meldingen suggereren, en het blijft een patchbump zonder gedragsverandering.

Gecontroleerd: de docs-build slaagt, 89 pagina's, en de negen mermaid-diagrammen komen als inline SVG in de output zonder achtergebleven `language-mermaid`-blok.