### PR TITLE
refactor: ruim op wat op twee plekken stond en op één hoort

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,23 +126,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check schema versions registered in schema.rs
-        run: |
-          # Every schema/vX.Y.Z/ directory must appear in the embedded schema table.
-          VALIDATE_RS="packages/engine/src/schema.rs"
-          MISSING=""
-          for dir in schema/v*/; do
-            version=$(basename "$dir")
-            if ! grep -q "\"$version\"" "$VALIDATE_RS"; then
-              MISSING="$MISSING  $version\n"
-            fi
-          done
-          if [ -n "$MISSING" ]; then
-            echo "ERROR: Schema versions not registered in schema.rs:"
-            printf "$MISSING"
-            exit 1
-          fi
-          echo "All schema versions registered in schema.rs"
+      # Schema versions are no longer grepped here: config::with_schema_versions!
+      # is the single list, and the tests in packages/engine/src/config.rs hold
+      # it against schema/ and against the Cargo.toml metadata.
 
       - name: Check corpus schema references
         run: |

--- a/.github/workflows/scheduled-cleanup.yml
+++ b/.github/workflows/scheduled-cleanup.yml
@@ -46,7 +46,7 @@ jobs:
           # Get open PR numbers to avoid deleting active preview images
           OPEN_PRS=$(gh pr list --repo "${ORG}/regelrecht" --state open --json number --jq '.[].number') || { echo 'Failed to list open PRs, skipping cleanup'; exit 0; }
 
-          for PACKAGE in regelrecht-editor regelrecht-admin regelrecht-harvester-worker regelrecht-enrich-worker regelrecht-lawmaking regelrecht-docs; do
+          for PACKAGE in regelrecht-editor regelrecht-admin regelrecht-harvester-worker regelrecht-enrich-worker regelrecht-pipeline-api regelrecht-grafana regelrecht-lawmaking regelrecht-docs; do
             echo "Checking stale images for $PACKAGE..."
             gh api --paginate \
               "/orgs/${ORG}/packages/container/${PACKAGE}/versions" \

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,6 +78,13 @@ repos:
         pass_filenames: false
         files: ^script/await-claude-review(\.test)?\.sh$
 
+      - id: ghcr-packages
+        name: GHCR-packagelijst gelijk in beide opruimingen
+        entry: script/check-ghcr-packages.sh
+        language: system
+        pass_filenames: false
+        files: ^\.github/workflows/(deploy|scheduled-cleanup)\.yml$
+
       - id: skills-no-casus
         name: Skills blijven dossier-agnostisch (geen casus-inhoud)
         entry: script/check-skills-no-casus.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,6 +272,7 @@ decides green versus red; the tests run as a pre-commit hook.
 | harvester-admin | `regelrecht-admin` | `harvester-admin.regelrecht.rijks.app` |
 | harvester-worker | `regelrecht-harvester-worker` | (no web UI) |
 | enrichworker | `regelrecht-enrich-worker` | (no web UI) |
+| pipelineapi | `regelrecht-pipeline-api` | (no public domain, by design) |
 | lawmaking | `regelrecht-lawmaking` | `lawmaking.regelrecht.rijks.app` |
 | docs | `regelrecht-docs` | `docs.regelrecht.rijks.app` + `regelrecht.rijks.app` (landing) |
 | grafana | `regelrecht-grafana` | `grafana.regelrecht.rijks.app` |

--- a/frontend/e2e/helpers-corpus.js
+++ b/frontend/e2e/helpers-corpus.js
@@ -31,6 +31,32 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 export const CORPUS_ROOT = resolve(__dirname, '../../corpus/regulation/nl');
 
 /**
+ * Recursively walk a corpus directory, parsing every YAML that carries an
+ * `$id`, and hand each one to `onLaw({ lawId, content, path, pubDate })`.
+ * The two loaders below differ only in what they do with that call.
+ */
+function walkCorpus(rootDir, onLaw) {
+  for (const entry of readdirSync(rootDir)) {
+    const full = resolve(rootDir, entry);
+    if (statSync(full).isDirectory()) {
+      walkCorpus(full, onLaw);
+      continue;
+    }
+    if (!entry.endsWith('.yaml')) continue;
+    const content = readFileSync(full, 'utf-8');
+    const idMatch = content.match(/^\$id:\s*['"]?([^'"\n]+)['"]?$/m);
+    if (!idMatch) continue;
+    const pubMatch = content.match(/^publication_date:\s*['"]?([^'"\n]+)['"]?$/m);
+    onLaw({
+      lawId: idMatch[1].trim(),
+      content,
+      path: full,
+      pubDate: pubMatch ? pubMatch[1].trim() : '',
+    });
+  }
+}
+
+/**
  * Recursively walk a corpus directory and pick one YAML per `$id`,
  * preferring the latest publication date. Returns a Map<lawId,
  * { content, path, pubDate }>.
@@ -46,28 +72,12 @@ export const CORPUS_ROOT = resolve(__dirname, '../../corpus/regulation/nl');
  */
 export function loadCorpus(rootDir = CORPUS_ROOT) {
   const byId = new Map();
-
-  function visit(dir) {
-    for (const entry of readdirSync(dir)) {
-      const full = resolve(dir, entry);
-      if (statSync(full).isDirectory()) {
-        visit(full);
-      } else if (entry.endsWith('.yaml')) {
-        const content = readFileSync(full, 'utf-8');
-        const idMatch = content.match(/^\$id:\s*['"]?([^'"\n]+)['"]?$/m);
-        if (!idMatch) continue;
-        const lawId = idMatch[1].trim();
-        const pubMatch = content.match(/^publication_date:\s*['"]?([^'"\n]+)['"]?$/m);
-        const pubDate = pubMatch ? pubMatch[1].trim() : '';
-        const existing = byId.get(lawId);
-        if (!existing || pubDate > existing.pubDate) {
-          byId.set(lawId, { content, path: full, pubDate });
-        }
-      }
+  walkCorpus(rootDir, ({ lawId, content, path, pubDate }) => {
+    const existing = byId.get(lawId);
+    if (!existing || pubDate > existing.pubDate) {
+      byId.set(lawId, { content, path, pubDate });
     }
-  }
-
-  visit(rootDir);
+  });
   return byId;
 }
 
@@ -83,27 +93,11 @@ export function loadCorpus(rootDir = CORPUS_ROOT) {
  */
 export function loadCorpusVersions(rootDir = CORPUS_ROOT) {
   const byId = new Map();
-
-  function visit(dir) {
-    for (const entry of readdirSync(dir)) {
-      const full = resolve(dir, entry);
-      if (statSync(full).isDirectory()) {
-        visit(full);
-      } else if (entry.endsWith('.yaml')) {
-        const content = readFileSync(full, 'utf-8');
-        const idMatch = content.match(/^\$id:\s*['"]?([^'"\n]+)['"]?$/m);
-        if (!idMatch) continue;
-        const lawId = idMatch[1].trim();
-        const pubMatch = content.match(/^publication_date:\s*['"]?([^'"\n]+)['"]?$/m);
-        const pubDate = pubMatch ? pubMatch[1].trim() : '';
-        const list = byId.get(lawId) ?? [];
-        list.push({ content, pubDate });
-        byId.set(lawId, list);
-      }
-    }
-  }
-
-  visit(rootDir);
+  walkCorpus(rootDir, ({ lawId, content, pubDate }) => {
+    const list = byId.get(lawId) ?? [];
+    list.push({ content, pubDate });
+    byId.set(lawId, list);
+  });
   // Newest-first, matching the editor-api `/versions` contract.
   for (const [id, list] of byId) {
     list.sort((a, b) => (a.pubDate < b.pubDate ? 1 : a.pubDate > b.pubDate ? -1 : 0));

--- a/frontend/src/lib/apiFetch.test.js
+++ b/frontend/src/lib/apiFetch.test.js
@@ -1,119 +1,18 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
-import { apiFetch, apiFetchJson, apiFetchText, ApiError } from './apiFetch.js';
+import { describe, it, expect } from 'vitest';
 
-function mockResponse({ status = 200, body = '', contentType = null, json = undefined } = {}) {
-  const headers = new Headers();
-  if (contentType) headers.set('content-type', contentType);
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    headers,
-    text: async () => body,
-    json: async () => (json !== undefined ? json : JSON.parse(body)),
-  };
-}
+import * as shared from '@regelrecht/frontend-shared';
 
-const realFetch = globalThis.fetch;
-afterEach(() => {
-  globalThis.fetch = realFetch;
-});
+import * as reexport from './apiFetch.js';
 
-describe('apiFetch', () => {
-  it('resolves with the raw Response on ok so headers stay readable', async () => {
-    const res = mockResponse({ status: 200, body: 'x' });
-    res.headers.set('ETag', '"abc"');
-    globalThis.fetch = vi.fn().mockResolvedValue(res);
-
-    const out = await apiFetch('/api/thing');
-    expect(out).toBe(res);
-    expect(out.headers.get('ETag')).toBe('"abc"');
-  });
-
-  it('strips wrapper options before calling fetch', async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse());
-    await apiFetch('/api/thing', {
-      method: 'PUT',
-      allowStatuses: [404],
-      errorMessage: 'nope',
-    });
-    const [, init] = globalThis.fetch.mock.calls[0];
-    expect(init).toEqual({ method: 'PUT' });
-  });
-
-  it('throws ApiError with status, body and contentType on non-ok', async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue(
-      mockResponse({ status: 403, body: 'geen schrijfrechten', contentType: 'text/plain; charset=utf-8' }),
-    );
-    const err = await apiFetch('/api/thing').catch((e) => e);
-    expect(err).toBeInstanceOf(ApiError);
-    expect(err.status).toBe(403);
-    expect(err.body).toBe('geen schrijfrechten');
-    expect(err.contentType).toBe('text/plain; charset=utf-8');
-    expect(err.message).toBe('geen schrijfrechten');
-  });
-
-  it('falls back to "HTTP <status>" when the body is empty', async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse({ status: 500 }));
-    const err = await apiFetch('/api/thing').catch((e) => e);
-    expect(err.message).toBe('HTTP 500');
-    expect(err.body).toBe('');
-  });
-
-  it('falls back to "HTTP <status>" when the body read throws', async () => {
-    const res = mockResponse({ status: 502 });
-    res.text = async () => {
-      throw new Error('stream gone');
-    };
-    globalThis.fetch = vi.fn().mockResolvedValue(res);
-    const err = await apiFetch('/api/thing').catch((e) => e);
-    expect(err.message).toBe('HTTP 502');
-  });
-
-  it('resolves allowStatuses statuses instead of throwing', async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse({ status: 404 }));
-    const res = await apiFetch('/api/thing', { allowStatuses: [404] });
-    expect(res.status).toBe(404);
-  });
-
-  it('supports a static errorMessage', async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse({ status: 500, body: 'boom' }));
-    const err = await apiFetch('/api/thing', { errorMessage: 'Kon niet laden' }).catch((e) => e);
-    expect(err.message).toBe('Kon niet laden');
-    expect(err.body).toBe('boom');
-  });
-
-  it('supports an errorMessage function receiving status, body and contentType', async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue(
-      mockResponse({ status: 503, body: 'b', contentType: 'text/plain' }),
-    );
-    const err = await apiFetch('/api/thing', {
-      errorMessage: (status, body, contentType) => `mislukt: ${status} (${body}, ${contentType})`,
-    }).catch((e) => e);
-    expect(err.message).toBe('mislukt: 503 (b, text/plain)');
-  });
-
-  it('lets network errors propagate unchanged', async () => {
-    const netErr = new TypeError('Failed to fetch');
-    globalThis.fetch = vi.fn().mockRejectedValue(netErr);
-    await expect(apiFetch('/api/thing')).rejects.toBe(netErr);
-  });
-});
-
-describe('apiFetchJson / apiFetchText', () => {
-  it('apiFetchJson parses the body', async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse({ json: [{ a: 1 }] }));
-    expect(await apiFetchJson('/api/list')).toEqual([{ a: 1 }]);
-  });
-
-  it('apiFetchText returns the body text', async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse({ body: 'yaml: 1' }));
-    expect(await apiFetchText('/api/law')).toBe('yaml: 1');
-  });
-
-  it('both throw ApiError on non-ok', async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse({ status: 404 }));
-    await expect(apiFetchJson('/api/list')).rejects.toBeInstanceOf(ApiError);
-    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse({ status: 404 }));
-    await expect(apiFetchText('/api/law')).rejects.toBeInstanceOf(ApiError);
-  });
+// The behaviour of apiFetch is proven once, in
+// packages/frontend-shared/src/apiFetch.test.js. The editor owns no
+// implementation, only the re-export that keeps ~25 call sites importing from
+// './lib/apiFetch.js'. What can break here is the re-export losing a name.
+describe('lib/apiFetch re-export', () => {
+  it.each(['apiFetch', 'apiFetchJson', 'apiFetchText', 'ApiError'])(
+    're-exports %s from the shared package',
+    (name) => {
+      expect(reexport[name]).toBe(shared[name]);
+    },
+  );
 });

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -4279,6 +4279,7 @@ dependencies = [
  "ratatui",
  "regelrecht-engine",
  "regelrecht-law-model",
+ "tempfile",
  "tokio",
  "tracing",
  "walkdir",

--- a/packages/corpus/src/backend.rs
+++ b/packages/corpus/src/backend.rs
@@ -461,7 +461,13 @@ async fn walk_local_tree(
 }
 
 /// Reject paths that are absolute or contain `..` components.
-fn validate_relative_path(path: &Path) -> Result<()> {
+///
+/// Every `RepoBackend` implementation guards on this one, including the
+/// GitHub API backend in a sibling module — hence `pub(crate)`. A backend that
+/// rewrites separators must normalise *before* calling this: on Linux a
+/// backslash is an ordinary character, so `..\..\etc` passes as a single
+/// component and only becomes a traversal after the rewrite.
+pub(crate) fn validate_relative_path(path: &Path) -> Result<()> {
     if path.is_absolute() {
         return Err(CorpusError::Config(format!(
             "path must be relative: {}",

--- a/packages/corpus/src/github.rs
+++ b/packages/corpus/src/github.rs
@@ -294,14 +294,16 @@ fn group_best_versions(
             }
         }
 
-        let filename = parts[parts.len() - 1];
-        let new_date = filename.strip_suffix(".yaml");
+        let new_date = crate::source_map::extract_date_from_path(path);
 
         if let Some(existing) = best_per_law.get(law_id) {
-            let existing_filename = existing.path.rsplit('/').next().unwrap_or("");
-            let existing_date = existing_filename.strip_suffix(".yaml");
+            let existing_date = crate::source_map::extract_date_from_path(&existing.path);
 
-            let new_wins = crate::source_map::pick_best_version(existing_date, new_date, &today);
+            let new_wins = crate::source_map::pick_best_version(
+                existing_date.as_deref(),
+                new_date.as_deref(),
+                &today,
+            );
 
             if new_wins {
                 best_per_law.insert(law_id.to_string(), file.clone());
@@ -395,6 +397,52 @@ mod tests {
         assert!(
             !best.contains_key("zorgtoeslagwet"),
             "annotation file was mis-indexed as law 'zorgtoeslagwet'"
+        );
+    }
+
+    // Version selection compares filename stems as strings, so a stem that is
+    // not a date sorts against real dates as if it were one:
+    // "2025-01-01-concept" > "2025-01-01". Only the tree indexer saw such a
+    // stem — `SourceMap` rejects it — so the same repo answered differently
+    // depending on which path filled the cache.
+    #[test]
+    fn a_non_date_filename_never_beats_a_dated_version() {
+        let paths = vec![
+            TreeFile {
+                path: "wet/wet_op_de_zorgtoeslag/2025-01-01.yaml".to_string(),
+                sha: Some("real".to_string()),
+            },
+            TreeFile {
+                path: "wet/wet_op_de_zorgtoeslag/2025-01-01-concept.yaml".to_string(),
+                sha: Some("concept".to_string()),
+            },
+        ];
+        let best = group_best_versions(&paths, "", None);
+        assert_eq!(
+            best["wet_op_de_zorgtoeslag"].path,
+            "wet/wet_op_de_zorgtoeslag/2025-01-01.yaml"
+        );
+    }
+
+    // Insertion order must not decide the outcome: the first file seen is
+    // inserted unconditionally, so a leading non-date stem has to be displaced
+    // by the dated file that follows it.
+    #[test]
+    fn a_dated_version_displaces_a_non_date_filename_seen_first() {
+        let paths = vec![
+            TreeFile {
+                path: "wet/wet_op_de_zorgtoeslag/draft.yaml".to_string(),
+                sha: Some("draft".to_string()),
+            },
+            TreeFile {
+                path: "wet/wet_op_de_zorgtoeslag/2025-01-01.yaml".to_string(),
+                sha: Some("real".to_string()),
+            },
+        ];
+        let best = group_best_versions(&paths, "", None);
+        assert_eq!(
+            best["wet_op_de_zorgtoeslag"].path,
+            "wet/wet_op_de_zorgtoeslag/2025-01-01.yaml"
         );
     }
 }

--- a/packages/corpus/src/github_api_backend.rs
+++ b/packages/corpus/src/github_api_backend.rs
@@ -53,7 +53,10 @@ use tokio::sync::Mutex;
 
 use regelrecht_github::{Committer, GithubClient, GithubError};
 
-use crate::backend::{FileEntry, PersistOutcome, RecursiveFileEntry, RepoBackend, WriteContext};
+use crate::backend::{
+    validate_relative_path, FileEntry, PersistOutcome, RecursiveFileEntry, RepoBackend,
+    WriteContext,
+};
 use crate::error::{CorpusError, Result};
 use crate::models::GitHubSource;
 use crate::timing;
@@ -172,14 +175,18 @@ impl GitHubApiBackend {
     /// Resolve a source-relative path to the in-repo path the GitHub API
     /// expects (with `sub_path` prefix). Forward slashes always — GitHub
     /// is OS-agnostic.
+    ///
+    /// The traversal guard runs on the *rewritten* path: the rewrite is what
+    /// turns a backslash into a separator, so validating the input first would
+    /// wave `..\..\etc` through.
     fn api_path(&self, relative: &Path) -> Result<String> {
-        validate_relative(relative)?;
         let rel = relative
             .to_str()
             .ok_or_else(|| {
                 CorpusError::Config(format!("path is not valid UTF-8: {}", relative.display()))
             })?
             .replace('\\', "/");
+        validate_relative_path(Path::new(&rel))?;
         Ok(match &self.sub_path {
             Some(sub) if !sub.is_empty() => format!("{}/{}", sub.trim_end_matches('/'), rel),
             _ => rel,
@@ -408,24 +415,6 @@ impl GitHubApiBackend {
     }
 }
 
-fn validate_relative(path: &Path) -> Result<()> {
-    if path.is_absolute() {
-        return Err(CorpusError::Config(format!(
-            "path must be relative: {}",
-            path.display()
-        )));
-    }
-    for component in path.components() {
-        if matches!(component, std::path::Component::ParentDir) {
-            return Err(CorpusError::Config(format!(
-                "path must not contain '..': {}",
-                path.display()
-            )));
-        }
-    }
-    Ok(())
-}
-
 #[async_trait]
 impl RepoBackend for GitHubApiBackend {
     #[tracing::instrument(name = "gh_read_file", skip_all, fields(path = %relative_path.display()))]
@@ -539,7 +528,7 @@ impl RepoBackend for GitHubApiBackend {
     // and the override only becomes visible at `persist`. Buffer now;
     // `persist` refuses with `ReadOnly` when neither token is present.
     async fn write_file(&self, relative_path: &Path, content: &str) -> Result<()> {
-        validate_relative(relative_path)?;
+        validate_relative_path(relative_path)?;
         let mut inner = self.inner.lock().await;
         let base_sha = inner.sha_cache.get(relative_path).cloned();
         let read_saw_absence = inner.absent_reads.contains(relative_path);
@@ -556,7 +545,7 @@ impl RepoBackend for GitHubApiBackend {
 
     // Same stance as `write_file`: token enforcement lives in `persist`.
     async fn delete_file(&self, relative_path: &Path) -> Result<()> {
-        validate_relative(relative_path)?;
+        validate_relative_path(relative_path)?;
         let mut inner = self.inner.lock().await;
         let base_sha = inner.sha_cache.get(relative_path).cloned();
         inner.pending.push((
@@ -1154,6 +1143,35 @@ mod tests {
             path: Some("regulation/nl".to_string()),
             git_ref: None,
         }
+    }
+
+    // `api_path` rewrites backslashes to forward slashes because GitHub only
+    // speaks forward slashes. On Linux a backslash is an ordinary filename
+    // character, so `Path::components()` sees `..\..\etc\passwd` as one
+    // component and the traversal guard has nothing to reject — the rewrite
+    // then produces the escape. Validation must therefore run on the rewritten
+    // path, not the input.
+    #[test]
+    fn backslash_traversal_is_rejected_after_separator_rewrite() {
+        let backend = GitHubApiBackend::new(&nl_source(), Some("main".to_string()), None).unwrap();
+        let err = backend
+            .api_path(std::path::Path::new(r"..\..\etc\passwd"))
+            .unwrap_err();
+        assert!(
+            err.to_string().contains(".."),
+            "expected a traversal rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn api_path_keeps_prefixing_ordinary_paths() {
+        let backend = GitHubApiBackend::new(&nl_source(), Some("main".to_string()), None).unwrap();
+        assert_eq!(
+            backend
+                .api_path(std::path::Path::new("wet/foo/2025-01-01.yaml"))
+                .unwrap(),
+            "regulation/nl/wet/foo/2025-01-01.yaml"
+        );
     }
 
     fn backend_at(server: &MockServer) -> GitHubApiBackend {

--- a/packages/corpus/src/source_map.rs
+++ b/packages/corpus/src/source_map.rs
@@ -521,7 +521,7 @@ impl Default for SourceMap {
 /// Extract a YYYY-MM-DD date from the filename component of a path.
 ///
 /// Matches the convention `…/law_id/2025-01-01.yaml`.
-fn extract_date_from_path(path: &str) -> Option<String> {
+pub(crate) fn extract_date_from_path(path: &str) -> Option<String> {
     let filename = path.rsplit('/').next().unwrap_or(path);
     let stem = filename.strip_suffix(".yaml")?;
     // Validate YYYY-MM-DD pattern

--- a/packages/editor-api/tests/list_scenarios_test.rs
+++ b/packages/editor-api/tests/list_scenarios_test.rs
@@ -141,11 +141,12 @@ async fn session_for(sub: &str) -> Session {
     session
 }
 
-/// Build the URL-form traject ref used in path parameters.
-/// The resolver matches on `left(id::text, 8)` (first 8 hex chars of the
-/// hyphenated UUID), so `t-{8hex}` is a valid ref (slug="t", suffix=8hex).
+/// URL form of a traject reference, via the production helper. Rebuilding
+/// the shape by hand here would keep passing after a contract change,
+/// because `resolve_traject_ref` only reads the trailing eight hex chars.
+/// All trajects in this file are named `Test`.
 fn traject_ref(id: Uuid) -> String {
-    format!("t-{}", &id.to_string()[..8])
+    regelrecht_editor_api::trajects::traject_ref("Test", id)
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/editor-api/tests/promote_law_test.rs
+++ b/packages/editor-api/tests/promote_law_test.rs
@@ -123,8 +123,12 @@ async fn seeded_traject(
     traject_id
 }
 
+/// URL form of a traject reference, via the production helper. Rebuilding
+/// the shape by hand here would keep passing after a contract change,
+/// because `resolve_traject_ref` only reads the trailing eight hex chars.
+/// All trajects in this file are named `Test`.
 fn traject_ref(traject_id: Uuid) -> String {
-    format!("test-{}", &traject_id.to_string()[..8])
+    regelrecht_editor_api::trajects::traject_ref("Test", traject_id)
 }
 
 async fn session_for(sub: &str) -> Session {

--- a/packages/editor-api/tests/promote_user_token_write_test.rs
+++ b/packages/editor-api/tests/promote_user_token_write_test.rs
@@ -135,8 +135,12 @@ async fn seeded_traject(pool: &PgPool, owner_id: Uuid, seed_dir: &std::path::Pat
     traject_id
 }
 
+/// URL form of a traject reference, via the production helper. Rebuilding
+/// the shape by hand here would keep passing after a contract change,
+/// because `resolve_traject_ref` only reads the trailing eight hex chars.
+/// All trajects in this file are named `Test`.
 fn traject_ref(traject_id: Uuid) -> String {
-    format!("test-{}", &traject_id.to_string()[..8])
+    regelrecht_editor_api::trajects::traject_ref("Test", traject_id)
 }
 
 async fn session_for(sub: &str) -> Session {

--- a/packages/editor-api/tests/service_token_write_precedence_test.rs
+++ b/packages/editor-api/tests/service_token_write_precedence_test.rs
@@ -161,8 +161,12 @@ async fn seeded_traject(
     traject_id
 }
 
+/// URL form of a traject reference, via the production helper. Rebuilding
+/// the shape by hand here would keep passing after a contract change,
+/// because `resolve_traject_ref` only reads the trailing eight hex chars.
+/// All trajects in this file are named `Test`.
 fn traject_ref(traject_id: Uuid) -> String {
-    format!("test-{}", &traject_id.to_string()[..8])
+    regelrecht_editor_api::trajects::traject_ref("Test", traject_id)
 }
 
 async fn session_for(sub: &str) -> Session {

--- a/packages/editor-api/tests/traject_harvest_request_test.rs
+++ b/packages/editor-api/tests/traject_harvest_request_test.rs
@@ -100,8 +100,12 @@ async fn local_traject(pool: &PgPool, owner_id: Uuid, corpus_dir: &std::path::Pa
     traject_id
 }
 
+/// URL form of a traject reference, via the production helper. Rebuilding
+/// the shape by hand here would keep passing after a contract change,
+/// because `resolve_traject_ref` only reads the trailing eight hex chars.
+/// All trajects in this file are named `Test`.
 fn traject_ref(traject_id: Uuid) -> String {
-    format!("test-{}", &traject_id.to_string()[..8])
+    regelrecht_editor_api::trajects::traject_ref("Test", traject_id)
 }
 
 async fn session_for(sub: &str) -> Session {

--- a/packages/editor-api/tests/traject_index_user_token_test.rs
+++ b/packages/editor-api/tests/traject_index_user_token_test.rs
@@ -168,8 +168,12 @@ async fn add_member(pool: &PgPool, traject_id: Uuid, account_id: Uuid) {
     .unwrap();
 }
 
+/// URL form of a traject reference, via the production helper. Rebuilding
+/// the shape by hand here would keep passing after a contract change,
+/// because `resolve_traject_ref` only reads the trailing eight hex chars.
+/// All trajects in this file are named `Test`.
 fn traject_ref(traject_id: Uuid) -> String {
-    format!("test-{}", &traject_id.to_string()[..8])
+    regelrecht_editor_api::trajects::traject_ref("Test", traject_id)
 }
 
 async fn session_for(sub: &str, email: &str) -> Session {

--- a/packages/editor-api/tests/traject_own_index_test.rs
+++ b/packages/editor-api/tests/traject_own_index_test.rs
@@ -154,8 +154,12 @@ async fn seeded_traject(
     traject_id
 }
 
+/// URL form of a traject reference, via the production helper. Rebuilding
+/// the shape by hand here would keep passing after a contract change,
+/// because `resolve_traject_ref` only reads the trailing eight hex chars.
+/// All trajects in this file are named `Test`.
 fn traject_ref(traject_id: Uuid) -> String {
-    format!("test-{}", &traject_id.to_string()[..8])
+    regelrecht_editor_api::trajects::traject_ref("Test", traject_id)
 }
 
 async fn session_for(sub: &str) -> Session {

--- a/packages/editor-api/tests/traject_reads_test.rs
+++ b/packages/editor-api/tests/traject_reads_test.rs
@@ -132,10 +132,12 @@ async fn local_traject(pool: &PgPool, owner_id: Uuid, corpus_dir: &std::path::Pa
     traject_id
 }
 
-/// URL form of a traject reference: `{slug}-{first 8 hex of the UUID}`
-/// (see `trajects::resolve_traject_ref`).
+/// URL form of a traject reference, via the production helper. Rebuilding
+/// the shape by hand here would keep passing after a contract change,
+/// because `resolve_traject_ref` only reads the trailing eight hex chars.
+/// All trajects in this file are named `Test`.
 fn traject_ref(traject_id: Uuid) -> String {
-    format!("test-{}", &traject_id.to_string()[..8])
+    regelrecht_editor_api::trajects::traject_ref("Test", traject_id)
 }
 
 /// A session with a verified editor identity — the save handlers

--- a/packages/editor-api/tests/traject_user_token_reads_test.rs
+++ b/packages/editor-api/tests/traject_user_token_reads_test.rs
@@ -152,8 +152,12 @@ async fn seeded_traject(pool: &PgPool, owner_id: Uuid, seed_dir: &std::path::Pat
     traject_id
 }
 
+/// URL form of a traject reference, via the production helper. Rebuilding
+/// the shape by hand here would keep passing after a contract change,
+/// because `resolve_traject_ref` only reads the trailing eight hex chars.
+/// All trajects in this file are named `Test`.
 fn traject_ref(traject_id: Uuid) -> String {
-    format!("test-{}", &traject_id.to_string()[..8])
+    regelrecht_editor_api::trajects::traject_ref("Test", traject_id)
 }
 
 async fn session_for(sub: &str) -> Session {

--- a/packages/engine/src/config.rs
+++ b/packages/engine/src/config.rs
@@ -55,15 +55,35 @@ pub const MAX_CROSS_LAW_DEPTH: usize = 20;
 /// 100 levels is sufficient for complex calculations while preventing abuse.
 pub const MAX_OPERATION_DEPTH: usize = 100;
 
+/// The schema versions this engine knows about, in one place.
+///
+/// `include_str!` needs a literal path, so the embedded-schema table in
+/// [`crate::schema`] can't read a runtime array — it takes the list from this
+/// macro instead. [`SUPPORTED_SCHEMAS`] is built from the same expansion, and
+/// the tests below hold it against the `schema/` directories and the
+/// `supported-schemas` metadata in Cargo.toml. Adding a schema version is a
+/// one-line change here.
+macro_rules! with_schema_versions {
+    ($callback:ident) => {
+        $callback! {
+            "v0.2.0", "v0.3.0", "v0.3.1", "v0.3.2", "v0.4.0", "v0.5.0",
+            "v0.5.1", "v0.5.2", "v0.5.3", "v0.5.4", "v0.5.5", "v0.5.6",
+        }
+    };
+}
+// Its only consumer, `crate::schema`, is behind the `validate` feature.
+#[allow(unused_imports)]
+pub(crate) use with_schema_versions;
+
+macro_rules! as_slice {
+    ($($version:literal),* $(,)?) => { &[$($version),*] };
+}
+
 /// Schema versions supported by this engine version (RFC-013).
 ///
-/// A regulation referencing a schema version outside this list will be
-/// rejected at load time. This list must match the `supported-schemas`
-/// metadata in Cargo.toml.
-pub const SUPPORTED_SCHEMAS: &[&str] = &[
-    "v0.2.0", "v0.3.0", "v0.3.1", "v0.3.2", "v0.4.0", "v0.5.0", "v0.5.1", "v0.5.2", "v0.5.3",
-    "v0.5.4", "v0.5.5", "v0.5.6",
-];
+/// A regulation referencing a schema version outside this list is rejected at
+/// load time.
+pub const SUPPORTED_SCHEMAS: &[&str] = with_schema_versions!(as_slice);
 
 /// Maximum recursion depth for dot notation property access.
 ///
@@ -95,5 +115,52 @@ mod tests {
 
         assert!(MAX_PROPERTY_DEPTH >= 10, "Should allow nested objects");
         assert!(MAX_PROPERTY_DEPTH <= 100, "Should limit extreme depth");
+    }
+
+    /// A schema version that exists on disk but not here validates green with
+    /// `just validate` and is then refused by `Article::load` — officially
+    /// valid, not executable. The `schema/` tree is the ground truth.
+    #[test]
+    fn supported_schemas_covers_every_schema_directory() {
+        let schema_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../schema");
+        let mut on_disk: Vec<String> = std::fs::read_dir(&schema_root)
+            .expect("schema/ directory must be readable")
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().is_dir())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|name| name.starts_with('v'))
+            .collect();
+        on_disk.sort();
+
+        let mut supported: Vec<String> = SUPPORTED_SCHEMAS.iter().map(|s| s.to_string()).collect();
+        supported.sort();
+
+        assert_eq!(
+            supported, on_disk,
+            "SUPPORTED_SCHEMAS and schema/ have diverged; update with_schema_versions! in config.rs"
+        );
+    }
+
+    /// The `supported-schemas` metadata is the crate's published claim about
+    /// which contracts it honours. Nothing reads it at runtime, so only a test
+    /// keeps it honest.
+    #[test]
+    fn cargo_metadata_matches_supported_schemas() {
+        let manifest = include_str!("../Cargo.toml");
+        let line = manifest
+            .lines()
+            .find(|l| l.trim_start().starts_with("supported-schemas"))
+            .expect("Cargo.toml must declare supported-schemas metadata");
+        let declared: Vec<&str> = line
+            .split_once('[')
+            .and_then(|(_, rest)| rest.split_once(']'))
+            .expect("supported-schemas must be a single-line array")
+            .0
+            .split(',')
+            .map(|s| s.trim().trim_matches('"'))
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        assert_eq!(declared, SUPPORTED_SCHEMAS);
     }
 }

--- a/packages/engine/src/schema.rs
+++ b/packages/engine/src/schema.rs
@@ -2,30 +2,15 @@
 //! and the schema↔model conformance test suite.
 //!
 //! Only compiled with the `validate` feature (which pulls in `jsonschema`).
-//! Keeping the schema-loading list and version detection here means there is a
-//! single copy of the 12-version `include_str!` table — see the CI guard
-//! "Check schema versions registered in schema.rs" which greps this file.
+//! The version list itself lives in [`crate::config`], which is compiled
+//! unconditionally, so the embedded-schema table here and the
+//! `SUPPORTED_SCHEMAS` the loader rejects on cannot drift apart.
 
 use std::collections::HashMap;
 
 use jsonschema::Validator;
 
-/// Single source of truth for the embedded schema versions.
-///
-/// `include_str!` requires a literal path, so the version list can't be a
-/// runtime array — it lives here as a macro that hands the list to a callback
-/// macro. `load_schemas` and `detect_version` are both driven from it, so
-/// adding a schema version is a one-line change. The individual `"vX.Y.Z"`
-/// string literals also satisfy the CI guard "Check schema versions registered
-/// in schema.rs", which greps this file for each `schema/vX.Y.Z/` directory.
-macro_rules! with_schema_versions {
-    ($callback:ident) => {
-        $callback! {
-            "v0.2.0", "v0.3.0", "v0.3.1", "v0.3.2", "v0.4.0", "v0.5.0",
-            "v0.5.1", "v0.5.2", "v0.5.3", "v0.5.4", "v0.5.5", "v0.5.6",
-        }
-    };
-}
+use crate::config::with_schema_versions;
 
 /// Embedded schemas keyed by their `$id` URL suffix (version path).
 ///

--- a/packages/pipeline/src/law_convert.rs
+++ b/packages/pipeline/src/law_convert.rs
@@ -139,6 +139,46 @@ const SOURCE_TEXT_FILE: &str = "source.md";
 /// follows works on the same version).
 const SCHEMA_URL: &str = "https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.6/schema/v0.5.6/schema.json";
 
+/// The regulatory layers offered to the model, each with the English gloss
+/// that tells it which one to pick. Keyed on the enum rather than on a bare
+/// string so a rename cannot silently produce a value the deserializer
+/// rejects; `every_regulatory_layer_is_offered_to_the_model` covers
+/// completeness.
+const LAYER_DESCRIPTIONS: &[(RegulatoryLayer, &str)] = &[
+    (RegulatoryLayer::Grondwet, "constitutional law"),
+    (RegulatoryLayer::Wet, "a formal law (wet in formele zin)"),
+    (RegulatoryLayer::Amvb, "algemene maatregel van bestuur"),
+    (RegulatoryLayer::KoninklijkBesluit, "koninklijk besluit"),
+    (
+        RegulatoryLayer::MinisterieleRegeling,
+        "ministeriële regeling",
+    ),
+    (
+        RegulatoryLayer::Beleidsregel,
+        "beleidsregel (policy rule of an bestuursorgaan)",
+    ),
+    (
+        RegulatoryLayer::Uitvoeringsbeleid,
+        "uitvoeringsbeleid, werkinstructies or other internal implementation policy of a \
+         ministry or organisation — the default for internal documents",
+    ),
+    (RegulatoryLayer::EuVerordening, "EU regulation"),
+    (RegulatoryLayer::EuRichtlijn, "EU directive"),
+    (RegulatoryLayer::Verdrag, "international treaty"),
+    (
+        RegulatoryLayer::GemeentelijkeVerordening,
+        "municipal ordinance",
+    ),
+    (
+        RegulatoryLayer::ProvincialeVerordening,
+        "provincial ordinance",
+    ),
+    (
+        RegulatoryLayer::WaterschapsVerordening,
+        "water board ordinance",
+    ),
+];
+
 /// Sanitize the uploaded filename into something safe for the synthetic
 /// `upload://` source-URL (schema `url` is `format: uri`, so no spaces).
 fn sanitize_for_url(filename: &str) -> String {
@@ -177,32 +217,11 @@ fn build_structure_prompt(source_file: &str, source_is_text: bool, source_url: &
              access. If no tool fits, read and transcribe it directly."
         )
     };
-    let layers = [
-        ("GRONDWET", "constitutional law"),
-        ("WET", "a formal law (wet in formele zin)"),
-        ("AMVB", "algemene maatregel van bestuur"),
-        ("KONINKLIJK_BESLUIT", "koninklijk besluit"),
-        ("MINISTERIELE_REGELING", "ministeriële regeling"),
-        (
-            "BELEIDSREGEL",
-            "beleidsregel (policy rule of an bestuursorgaan)",
-        ),
-        (
-            "UITVOERINGSBELEID",
-            "uitvoeringsbeleid, werkinstructies or other internal implementation policy of a \
-             ministry or organisation — the default for internal documents",
-        ),
-        ("EU_VERORDENING", "EU regulation"),
-        ("EU_RICHTLIJN", "EU directive"),
-        ("VERDRAG", "international treaty"),
-        ("GEMEENTELIJKE_VERORDENING", "municipal ordinance"),
-        ("PROVINCIALE_VERORDENING", "provincial ordinance"),
-        ("WATERSCHAPS_VERORDENING", "water board ordinance"),
-    ]
-    .into_iter()
-    .map(|(k, v)| format!("   - `{k}`: {v}"))
-    .collect::<Vec<_>>()
-    .join("\n");
+    let layers = LAYER_DESCRIPTIONS
+        .iter()
+        .map(|(layer, description)| format!("   - `{}`: {description}", layer.as_str()))
+        .collect::<Vec<_>>()
+        .join("\n");
     let today = Utc::now().format("%Y-%m-%d");
     format!(
         "You are converting a source document into a regelrecht base-law YAML file — the same \
@@ -525,6 +544,24 @@ pub async fn finish_law_convert_job(
 mod tests {
     use super::*;
     use crate::enrich::LlmProvider;
+
+    /// A layer the prompt does not name is a layer the model cannot pick, so
+    /// it lands on the documented default (`UITVOERINGSBELEID`) and the
+    /// document is misclassified without anything failing. The compiler forces
+    /// an arm in `as_dir_name`; nothing forced this list.
+    #[test]
+    fn every_regulatory_layer_is_offered_to_the_model() {
+        let offered: Vec<RegulatoryLayer> = LAYER_DESCRIPTIONS.iter().map(|(l, _)| *l).collect();
+
+        for layer in RegulatoryLayer::ALL_VARIANTS {
+            assert!(
+                offered.contains(layer),
+                "{} is missing from the conversion prompt",
+                layer.as_str()
+            );
+        }
+        assert_eq!(offered.len(), RegulatoryLayer::ALL_VARIANTS.len());
+    }
 
     fn test_config() -> EnrichConfig {
         EnrichConfig::for_test(LlmProvider::Claude {

--- a/packages/shared/src/regulatory_layer.rs
+++ b/packages/shared/src/regulatory_layer.rs
@@ -65,6 +65,26 @@ pub enum RegulatoryLayer {
 }
 
 impl RegulatoryLayer {
+    /// Every variant, for callers that must enumerate the whole set rather
+    /// than match on one — the document-conversion prompt in
+    /// `regelrecht-pipeline` is the live case. Add a variant above and add it
+    /// here too; `all_variants_is_exhaustive` below fails otherwise.
+    pub const ALL_VARIANTS: &'static [Self] = &[
+        Self::Grondwet,
+        Self::Wet,
+        Self::Amvb,
+        Self::MinisterieleRegeling,
+        Self::Beleidsregel,
+        Self::KoninklijkBesluit,
+        Self::EuVerordening,
+        Self::EuRichtlijn,
+        Self::Verdrag,
+        Self::Uitvoeringsbeleid,
+        Self::GemeentelijkeVerordening,
+        Self::ProvincialeVerordening,
+        Self::WaterschapsVerordening,
+    ];
+
     /// Get the string value for YAML/JSON output.
     #[must_use]
     pub fn as_str(&self) -> &'static str {
@@ -109,6 +129,40 @@ impl RegulatoryLayer {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The enum declaration is the ground truth: every variant carries a
+    /// `#[serde(rename = …)]`, so counting those in this file's own source
+    /// catches a variant that was added to the enum and forgotten in
+    /// `ALL_VARIANTS`. A `match` cannot do that — the compiler forces an arm,
+    /// not a list entry.
+    #[test]
+    fn all_variants_lists_every_variant() {
+        let source = include_str!("regulatory_layer.rs");
+        let body = source
+            .split_once("pub enum RegulatoryLayer {")
+            .expect("enum declaration must be present")
+            .1
+            .split_once("\n}")
+            .expect("enum declaration must be closed")
+            .0;
+        let declared = body.matches("#[serde(rename = ").count();
+
+        assert_eq!(
+            RegulatoryLayer::ALL_VARIANTS.len(),
+            declared,
+            "the enum declares {declared} variants, ALL_VARIANTS lists {}",
+            RegulatoryLayer::ALL_VARIANTS.len()
+        );
+
+        let mut names: Vec<&str> = RegulatoryLayer::ALL_VARIANTS
+            .iter()
+            .map(RegulatoryLayer::as_str)
+            .collect();
+        names.sort_unstable();
+        let unique = names.len();
+        names.dedup();
+        assert_eq!(names.len(), unique, "ALL_VARIANTS contains a duplicate");
+    }
 
     #[test]
     fn test_as_str() {

--- a/packages/tui/Cargo.toml
+++ b/packages/tui/Cargo.toml
@@ -35,5 +35,8 @@ chrono.workspace = true
 # Logging
 tracing.workspace = true
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [lints]
 workspace = true

--- a/packages/tui/src/backend/corpus_scanner.rs
+++ b/packages/tui/src/backend/corpus_scanner.rs
@@ -55,7 +55,11 @@ pub fn extract_metadata(content: &str) -> LawMetadata {
 }
 
 /// Find the corpus regulation directory by checking common locations.
-fn find_regulation_dir(project_root: &Path) -> Option<PathBuf> {
+///
+/// The engine backend loads from the same tree, so both go through this one
+/// list: a fifth candidate added to only one of them would show laws in the
+/// corpus browser that the engine never loaded.
+pub fn find_regulation_dir(project_root: &Path) -> Option<PathBuf> {
     let candidates = [
         project_root.join("corpus/regulation/nl"),
         project_root.join("corpus/regulation"),
@@ -72,7 +76,6 @@ fn find_regulation_dir(project_root: &Path) -> Option<PathBuf> {
 }
 
 /// Get all YAML file paths from the corpus.
-#[allow(dead_code)]
 pub fn corpus_yaml_files(project_root: &Path) -> Vec<PathBuf> {
     let regulation_dir = match find_regulation_dir(project_root) {
         Some(d) => d,
@@ -91,4 +94,47 @@ pub fn corpus_yaml_files(project_root: &Path) -> Vec<PathBuf> {
         })
         .map(|e| e.path().to_path_buf())
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(path: &Path, body: &str) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, body).unwrap();
+    }
+
+    #[test]
+    fn corpus_yaml_files_finds_both_yaml_spellings_under_the_first_candidate() {
+        let root = tempfile::tempdir().unwrap();
+        let nl = root.path().join("corpus/regulation/nl");
+        write(&nl.join("wet/foo/2025-01-01.yaml"), "$id: foo\n");
+        write(&nl.join("wet/bar/2025-01-01.yml"), "$id: bar\n");
+        write(&nl.join("wet/foo/README.md"), "not a law\n");
+
+        let found = corpus_yaml_files(root.path());
+
+        assert_eq!(found.len(), 2, "found: {found:?}");
+        assert!(found.iter().all(|p| p.starts_with(&nl)));
+    }
+
+    #[test]
+    fn find_regulation_dir_prefers_the_nl_subtree_over_its_parent() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("corpus/regulation/nl")).unwrap();
+
+        assert_eq!(
+            find_regulation_dir(root.path()),
+            Some(root.path().join("corpus/regulation/nl"))
+        );
+    }
+
+    #[test]
+    fn a_project_without_a_corpus_yields_no_files() {
+        let root = tempfile::tempdir().unwrap();
+
+        assert!(find_regulation_dir(root.path()).is_none());
+        assert!(corpus_yaml_files(root.path()).is_empty());
+    }
 }

--- a/packages/tui/src/backend/engine_backend.rs
+++ b/packages/tui/src/backend/engine_backend.rs
@@ -2,7 +2,6 @@ use regelrecht_engine::{ArticleResult, LawExecutionService, LawInfo, PathNode, V
 use std::collections::BTreeMap;
 use std::path::Path;
 use tokio::sync::mpsc;
-use walkdir::WalkDir;
 
 /// Commands sent to the engine thread.
 pub enum EngineCommand {
@@ -122,31 +121,13 @@ fn engine_thread(
 }
 
 fn load_corpus(service: &mut LawExecutionService, project_root: &Path) -> usize {
-    let candidates = [
-        project_root.join("corpus/regulation/nl"),
-        project_root.join("corpus/regulation"),
-        project_root.join("corpus/central/nl"),
-        project_root.join("corpus/central"),
-    ];
-
-    let corpus_dir = candidates.iter().find(|p| p.is_dir());
-    let corpus_dir = match corpus_dir {
-        Some(d) => d,
-        None => return 0,
-    };
-
     let mut count = 0;
-    for entry in WalkDir::new(corpus_dir).into_iter().flatten().filter(|e| {
-        e.file_type().is_file()
-            && e.path()
-                .extension()
-                .is_some_and(|ext| ext == "yaml" || ext == "yml")
-    }) {
-        if let Ok(content) = std::fs::read_to_string(entry.path()) {
+    for path in super::corpus_scanner::corpus_yaml_files(project_root) {
+        if let Ok(content) = std::fs::read_to_string(&path) {
             match service.load_law(&content) {
                 Ok(_) => count += 1,
                 Err(e) => {
-                    tracing::warn!("Failed to load {}: {}", entry.path().display(), e);
+                    tracing::warn!("Failed to load {}: {}", path.display(), e);
                 }
             }
         }

--- a/script/check-ghcr-packages.sh
+++ b/script/check-ghcr-packages.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# De PR-opruiming en de nachtelijke opruiming lopen over dezelfde
+# GHCR-namespace en horen dus dezelfde packagelijst te gebruiken. Uiteenlopen
+# is stil: een image van een package dat alleen de ene lijst kent, blijft
+# liggen zonder dat iets faalt.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+files=(.github/workflows/deploy.yml .github/workflows/scheduled-cleanup.yml)
+reference=""
+reference_file=""
+status=0
+
+for f in "${files[@]}"; do
+    packages=$(grep -oE 'for PACKAGE in [^;]+' "$f" |
+        sed 's/^for PACKAGE in //' |
+        tr ' ' '\n' | grep -v '^$' | sort -u)
+    if [ -z "$packages" ]; then
+        echo "FOUT: $f heeft geen 'for PACKAGE in'-lus" >&2
+        status=1
+        continue
+    fi
+    if [ -z "$reference" ]; then
+        reference="$packages"
+        reference_file="$f"
+    elif [ "$packages" != "$reference" ]; then
+        echo "FOUT: de packagelijst in $f wijkt af van die in $reference_file:" >&2
+        diff <(echo "$reference") <(echo "$packages") >&2 || true
+        status=1
+    fi
+done
+
+if [ "$status" -eq 0 ]; then
+    echo "GHCR-packagelijst is gelijk in ${#files[@]} workflows"
+fi
+exit "$status"


### PR DESCRIPTION
Ruimt de eenvoudige gevallen op uit #1182 en #1183: mechanisch, met een test die het vastlegt, en zonder ontwerpkeuze eraan vast. Eén commit per bevinding, zodat één ding terug kan zonder de rest. Erin zitten onder meer de boomindexering die kale bestandsnaamstammen vergeleek terwijl de `SourceMap` een gevalideerde datum las, de lijst met ondersteunde schemaversies die drie keer met de hand stond, de traversal-guard in de GitHub-API-backend die backslashes pas ná de controle omschreef, en de dertien regulatory layers in de conversieprompt zonder exhaustiviteitstest.

Elke gedragswijziging heeft een test die zonder de fix rood is, gemeten door de fix terug te draaien. Voor de twee pure dedups geldt dat niet; daar staan nieuwe unittests en een vergelijking over het echte corpus tegenover.

De rest blijft liggen omdat er een keuze aan vastzit: welke tijdzone geldt, welke van twee onverenigbare definities van "dit is een bedrag" wint, welk theme-vocabulaire wint, en of de corpusscanners één contract moeten krijgen. Punt 1.25 hield bij verificatie geen stand en is vervallen.

Closes niets: #1182 en #1183 blijven open met de afgevinkte regels.