### PR TITLE
docs: bezette rfc-nummers als stub op main

### DIFF
--- a/docs/src/content/rfcs/rfc-031.md
+++ b/docs/src/content/rfcs/rfc-031.md
@@ -1,0 +1,17 @@
+---
+title: "RFC-031: Markeringen en open normen"
+status: Draft
+implementation: Not implemented
+date: '2026-08-02'
+authors:
+  - Eelco Hotting
+short_title: Markeringen
+---
+
+## Context
+
+Dit nummer is gereserveerd. Vier velden die hetzelfde moment beschreven, het moment waarop een artikel niet in zijn geheel in logica opgaat, worden er twee: een markering die één taalgat aanwijst op een verder uitgewerkt artikel, en een open term voor de norm waarvan de inhoud elders wordt ingevuld.
+
+De uitwerking wordt apart aangeboden en vervangt deze tekst. Tot dat moment
+bestaat er geen vastgesteld ontwerp onder dit nummer, en is de enige uitspraak
+die eruit volgt dat het nummer bezet is.

--- a/docs/src/content/rfcs/rfc-032.md
+++ b/docs/src/content/rfcs/rfc-032.md
@@ -1,0 +1,17 @@
+---
+title: "RFC-032: Datumonderdelen en afkapping"
+status: Draft
+implementation: Not implemented
+date: '2026-08-02'
+authors:
+  - Eelco Hotting
+short_title: Datumonderdelen
+---
+
+## Context
+
+Dit nummer is gereserveerd. De verrijker vroeg over vier ronden om zes verschillende datumbewerkingen die neerkomen op twee functies: een onderdeel uit een datum lezen en een datum afkappen naar het begin van een kalendereenheid. De eenheid staat waar hij in de taal al staat, in het veld `in`.
+
+De uitwerking wordt apart aangeboden en vervangt deze tekst. Tot dat moment
+bestaat er geen vastgesteld ontwerp onder dit nummer, en is de enige uitspraak
+die eruit volgt dat het nummer bezet is.

--- a/docs/src/content/rfcs/rfc-033.md
+++ b/docs/src/content/rfcs/rfc-033.md
@@ -1,0 +1,17 @@
+---
+title: "RFC-033: Het bouwplan van een verrijking"
+status: Draft
+implementation: Not implemented
+date: '2026-08-02'
+authors:
+  - Eelco Hotting
+short_title: Bouwplan
+---
+
+## Context
+
+Dit nummer is gereserveerd. In welke volgorde de artikelen worden aangedaan en wat een venster is. Een venster van N entries uit een omgevingsvariabele snijdt dwars door de afhankelijkheden heen; een venster dat uit de wet volgt is een laag waarvan niets van iets anders in diezelfde laag afhangt.
+
+De uitwerking wordt apart aangeboden en vervangt deze tekst. Tot dat moment
+bestaat er geen vastgesteld ontwerp onder dit nummer, en is de enige uitspraak
+die eruit volgt dat het nummer bezet is.

--- a/docs/src/content/rfcs/rfc-034.md
+++ b/docs/src/content/rfcs/rfc-034.md
@@ -1,0 +1,17 @@
+---
+title: "RFC-034: Concept-anker en blokkerende notitie"
+status: Draft
+implementation: Not implemented
+date: '2026-08-07'
+authors:
+  - Eelco Hotting
+short_title: Concept-anker
+---
+
+## Context
+
+Dit nummer is gereserveerd. Een notitie hangt vandaag aan één vindplaats in één wet, terwijl een begrip als `ingezetene` in meerdere wetten voorkomt en daar niet hetzelfde betekent. Daarnaast bestaat de poort die aftekenen tegenhoudt zolang er zwaarwegende notities open staan alleen in een methodedocument.
+
+De uitwerking wordt apart aangeboden en vervangt deze tekst. Tot dat moment
+bestaat er geen vastgesteld ontwerp onder dit nummer, en is de enige uitspraak
+die eruit volgt dat het nummer bezet is.

--- a/docs/src/content/rfcs/rfc-035.md
+++ b/docs/src/content/rfcs/rfc-035.md
@@ -1,0 +1,20 @@
+---
+title: "RFC-035: Corpus Analysis"
+status: Draft
+implementation: Not implemented
+date: '2026-08-05'
+authors:
+  - humanintheloop25
+short_title: Corpus Analysis
+---
+
+## Context
+
+This number is reserved. How far a traject's translation has come, where it does not hold
+up, and what changed since anyone last looked, answered over the model the engine loads
+rather than over a second reading of the YAML. A headline number is the length of a filter
+over an index, so every number opens as the list behind it.
+
+The design is offered separately and replaces this text. Until then no design has been
+settled under this number, and the only claim that follows from it is that the number is
+taken.


### PR DESCRIPTION
Twee open PR's voegden allebei een `rfc-031.md` toe. Zo'n botsing is pas zichtbaar als beide branches er al zijn, want een RFC-nummer wordt nergens vastgelegd voordat de uitwerking landt.

Deze PR zet elk nummer dat vandaag door een open PR geclaimd is als stub op `main`, in de vorm die 026 tot en met 030 al hebben: frontmatter met titel, auteur en datum van het origineel, en een alinea context die zegt waar het nummer over gaat en dat de uitwerking apart wordt aangeboden. Het gaat om 031, 032 en 033 uit PR #1037, 034 uit PR #1155, en 035 uit PR #1115, dat vandaag van 031 naar 035 is hernummerd omdat de RFC in PR #1037 ouder is.

Alleen de twee botsende nummers vastleggen lost de botsing van vandaag op; de hele set vastleggen is wat de volgende voorkomt.
