### PR TITLE
fix(ci): de reviewpoort valt niet meer om op een schone review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -106,6 +106,28 @@ jobs:
 
             If there are no issues, say so briefly. Do not pad the review with praise or filler.
 
+      # Het bewijs waar review-gate op afgaat. `execution_file` wijst naar het
+      # uitvoerbestand van Claude en wordt pas gezet nadat de CLI gedraaid heeft;
+      # stapt de actie er eerder uit — de workflow-validation-skip, wanneer dit
+      # bestand afwijkt van de versie op de default branch — dan blijft die
+      # output leeg en wordt deze stap overgeslagen. De poort leest de uitkomst
+      # van deze stap uit de jobs van déze run, dus het bewijs is per constructie
+      # run-gebonden, en het bestaat ook wanneer de review nul bevindingen had.
+      # Hernoem deze stap niet zonder `PROOF_STEP` in review-gate mee te nemen.
+      - name: Record that the review ran
+        if: steps.claude-review.outputs.execution_file != ''
+        env:
+          EXECUTION_FILE: ${{ steps.claude-review.outputs.execution_file }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          echo "De review-actie is uitgevoerd; uitvoerbestand: ${EXECUTION_FILE}"
+          {
+            echo "### Claude review uitgevoerd"
+            echo
+            echo "De review-actie heeft gedraaid voor commit \`${HEAD_SHA}\`."
+            echo "Nul bevindingen is hier een geldige uitkomst; deze stap zegt alleen dat er gereviewd is."
+          } >>"$GITHUB_STEP_SUMMARY"
+
   # The merge gate. Unlike claude-review this job has no `if:` — it must run and
   # report on every PR, cross-repo and dependabot included, because a required
   # check that never reports blocks such a PR forever.
@@ -118,7 +140,6 @@ jobs:
     permissions:
       actions: read
       contents: read
-      issues: read
       pull-requests: read
 
     steps:
@@ -151,16 +172,14 @@ jobs:
           echo "Poort draait de versie van ${BASE_SHA}."
 
       - name: Wait for the Claude review of this commit
+        # Alleen de coördinaten van deze run. Wat de poort als feit behandelt —
+        # fork, draft, auteur, de versie van dit workflowbestand — haalt zij zelf
+        # op, want dit env-blok staat in de PR die gereviewd wordt.
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          IS_CROSS_REPO: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
-          IS_DRAFT: ${{ github.event.pull_request.draft }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          JOB_NAME: claude-review
           MAX_WAIT_SECONDS: '2100'
           POLL_SECONDS: '20'
         run: script/await-claude-review.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,7 +76,7 @@ repos:
         entry: script/await-claude-review.test.sh
         language: system
         pass_filenames: false
-        files: ^script/await-claude-review(\.test)?\.sh$
+        files: ^(script/await-claude-review(\.test)?\.sh|\.github/workflows/claude-code-review\.yml)$
 
       - id: skills-no-casus
         name: Skills blijven dossier-agnostisch (geen casus-inhoud)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,14 +226,16 @@ job up by run id rather than by head SHA, because `ready_for_review` and
 from the previous run.
 
 Drive the wait off the job's `status`, never off the number of review comments —
-zero comments is equally consistent with "still running".
+zero comments is equally consistent with "still running" and with "the review had
+nothing to report".
 
 `claude-review` itself cannot be a required check, because it does not run on
 cross-repo (fork) PRs, where no secrets exist and `CLAUDE_CODE_OAUTH_TOKEN` is
 absent, and a required check that never reports blocks such a PR forever.
 `review-gate` always runs and always reports; it derives "not applicable" from
-the PR itself (cross-repo, draft, dependabot) rather than from `claude-review`'s
-conclusion, so a failed or skipped review can never pass as an inapplicable one.
+the PR as the API describes it (cross-repo, draft, dependabot) rather than from
+`claude-review`'s conclusion, so a failed or skipped review can never pass as an
+inapplicable one.
 
 Dependabot is a deliberate exemption, not an oversight: those PRs go through
 `claude-dependabot.yml`, and that workflow decides for itself whether to merge.
@@ -242,11 +244,55 @@ The gate does not verify that it ran.
 A green job is not enough on its own. `claude-code-action` exits with conclusion
 `success` **without reviewing anything** when the workflow file differs from the
 version on the default branch ("Exiting due to workflow validation skip"). The
-gate used to close that hole by requiring a comment from `claude[bot]` after the
-job started, but a review that finishes with nothing to report posts nothing, so
-every clean PR went red on a cause that had not been established (issue #1178).
-That requirement is gone; until the run-bound replacement lands, a self-skipped
-review passes the gate.
+gate therefore checks two things before it believes a green job.
+
+First it compares `.github/workflows/claude-code-review.yml` as this run has it
+with the copy on the default branch, through the contents API. Differ, and there
+is no automatic review to wait for: the gate blocks straight away, before the
+wait. That is also what makes the rest trustworthy — identical files mean the
+workflow that ran is the one from the default branch, not something the PR
+brought along. A PR that edits this file needs a human review plus an admin
+merge.
+
+It compares `refs/pull/N/merge`, not the head commit. A `pull_request` run
+executes the workflow file as it stands in the test merge of PR and base, so a
+branch that has fallen behind still runs the base's copy. Comparing against the
+head commit would put exactly those branches on red while their review ran fine.
+
+Then it reads the proof out of the review job: the step **Record that the review
+ran** carries `if: steps.claude-review.outputs.execution_file != ''`, and that
+output is only set once the Claude CLI has actually run. Self-skip, and the step
+is `skipped`. The gate reads that step's conclusion from the `steps[]` array of
+the job it already looked up, so the proof is bound to this run and this attempt
+by construction, and it exists just as well when the review had zero findings. It
+insists on exactly one step by that name; two would let an added decoy outvote
+the real one.
+
+Do not rename that step without changing `PROOF_STEP` in the gate. The test suite
+asserts that the workflow still carries the step under that name with that `if:`,
+and the pre-commit hook runs on the workflow file for exactly that reason.
+
+What the gate treats as fact it fetches itself. The workflow that invokes it
+lives in the pull request, so anything that workflow passes in is written by the
+author of the change under review — `IS_DRAFT: true` in the env block used to be
+enough to declare the review inapplicable. Draft, fork, author and the workflow
+file all come from the API now; the env block carries only the coordinates of the
+run (repository, run id, PR number), and the gate checks that the run and the PR
+describe the same commit, so pointing it at another PR's run yields a red.
+
+What none of this reaches: the `review-gate` job itself lives in the workflow
+file the PR brings along. A PR that keeps the job name **Claude review completed**
+and replaces its steps with `run: true` reports green without ever running the
+script, and nothing inside the script can prevent that. Closing it takes a rule
+outside the pull request — a ruleset or CODEOWNERS entry over
+`.github/workflows/**`, or a `workflow_run`-triggered gate that judges the review
+run from the outside. Until then the gate protects against mistakes, not against
+someone determined to route around it.
+
+Every red outcome states what was established and names no cause it has not
+tested. An earlier version told every clean PR that the review action had skipped
+itself over a workflow change, on PRs that changed no workflow at all (issue
+#1178).
 
 The gate runs the copy of its own script from the base branch, not the one in
 the PR — otherwise a PR could turn the script into `exit 0` and be green by
@@ -257,8 +303,8 @@ It looks the review job up with `filter=all`, because the run id survives a
 "Re-run this job" and `claude-review` is then absent from the newest attempt's
 job list.
 
-The gate proves the review ran to completion for this commit and produced
-output. It says nothing about the content of the findings or whether they were
+The gate proves the review ran to completion for this commit. It says nothing
+about how many findings there were, whether they hold up, or whether they were
 addressed.
 
 The logic lives in `script/await-claude-review.sh`, with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,10 +242,11 @@ The gate does not verify that it ran.
 A green job is not enough on its own. `claude-code-action` exits with conclusion
 `success` **without reviewing anything** when the workflow file differs from the
 version on the default branch ("Exiting due to workflow validation skip"). The
-gate therefore also requires that `claude[bot]` posted a comment or review after
-the job started. Practical consequence: a PR that edits
-`.github/workflows/claude-code-review.yml` cannot get a green gate, and needs a
-human review plus an admin merge. Every other PR is unaffected.
+gate used to close that hole by requiring a comment from `claude[bot]` after the
+job started, but a review that finishes with nothing to report posts nothing, so
+every clean PR went red on a cause that had not been established (issue #1178).
+That requirement is gone; until the run-bound replacement lands, a self-skipped
+review passes the gate.
 
 The gate runs the copy of its own script from the base branch, not the one in
 the PR — otherwise a PR could turn the script into `exit 0` and be green by

--- a/script/await-claude-review.sh
+++ b/script/await-claude-review.sh
@@ -5,11 +5,10 @@
 # consistent with "the review is still running". So the wait is driven by the
 # job's status, never by a comment count.
 #
-# It exits 0 only when the review demonstrably ran to completion and left
-# something behind, or when the review demonstrably cannot apply (cross-repo PR,
-# draft, dependabot). Those reasons are read off the pull request itself, not off
-# the review's own result, so a review that ran and failed can never pass as one
-# that was never meant to run.
+# It exits 0 only when the review job ran to completion, or when the review
+# demonstrably cannot apply (cross-repo PR, draft, dependabot). Those reasons are
+# read off the pull request itself, not off the review's own result, so a review
+# that ran and failed can never pass as one that was never meant to run.
 #
 # The review job is looked up inside *this* workflow run rather than by head SHA.
 # A `ready_for_review` or `reopened` event keeps the same SHA, so a SHA lookup can
@@ -106,49 +105,15 @@ done
 
 conclusion=$(jq -r '.conclusion // "none"' <<<"$job")
 url=$(jq -r '.html_url // ""' <<<"$job")
-started_at=$(jq -r '.started_at // ""' <<<"$job")
-
-# Een groene job is niet genoeg. De claude-code-action stapt uit met conclusie
-# `success` zonder ook maar iets te reviewen zodra het workflowbestand afwijkt
-# van dat op de default branch ("Exiting due to workflow validation skip").
-# Gemeten op PR 1157: veertien seconden, groen, geen review. Eis daarom ook een
-# spoor van de review zelf, geplaatst na de start van die job. Dat is geen
-# comment-telling vooraf; de status zegt of hij klaar is, dit zegt of hij iets
-# heeft opgeleverd.
-assert_review_output() {
-  if [ -z "$started_at" ]; then
-    blocked "\`${JOB_NAME}\` levert geen \`started_at\`, dus is niet vast te stellen of een spoor van claude[bot] uit deze run komt of van een eerdere. Daar gokt de poort niet op. ${url}"
-  fi
-
-  # stderr apart houden: een waarschuwing van `gh` op een verder geslaagde
-  # aanroep zou de payload anders onparseerbaar maken, en dat kwam dan als
-  # "geen review" naar buiten in plaats van als leesprobleem.
-  local endpoint payload found stamps='' newest
-  for endpoint in "issues/${PR_NUMBER}/comments" "pulls/${PR_NUMBER}/reviews"; do
-    if ! payload=$(gh api "repos/${REPO}/${endpoint}?per_page=100" --paginate 2>"${TMPDIR:-/tmp}/gate-stderr"); then
-      blocked "\`repos/${REPO}/${endpoint}\` is niet te lezen, dus of claude[bot] iets heeft geplaatst is onbekend. Dat is geen uitspraak over de review zelf; draai deze job opnieuw. Foutmelding: $(cat "${TMPDIR:-/tmp}/gate-stderr")"
-    fi
-    if ! found=$(jq -rs '.[] | arrays | .[] | select(.user.login == "claude[bot]") | (.updated_at // .submitted_at) | select(. != null)' <<<"$payload"); then
-      blocked "Het antwoord van \`repos/${REPO}/${endpoint}\` is geen bruikbare JSON, dus of claude[bot] iets heeft geplaatst is onbekend. Dat is geen uitspraak over de review zelf; draai deze job opnieuw."
-    fi
-    stamps+="${found}"$'\n'
-  done
-  newest=$(printf '%s' "$stamps" | grep -v '^$' | sort | tail -1)
-
-  if [ -z "$newest" ] || [[ "$newest" < "$started_at" ]]; then
-    blocked "\`${JOB_NAME}\` meldt \`${conclusion}\`, maar claude[bot] heeft in die run niets geplaatst. De review-actie slaat zichzelf over (met conclusie success) zodra \`.github/workflows/claude-code-review.yml\` afwijkt van de versie op de default branch. Wijzigt deze PR dat bestand, dan is er geen automatische review en moet een mens de wijziging nalopen. ${url}"
-  fi
-}
 
 case "$conclusion" in
 success | neutral)
-  assert_review_output
   echo "::notice title=Claude review gate::review afgerond (${conclusion})"
   summary "### Claude review gate: groen"
   summary ""
   summary "\`${JOB_NAME}\` is afgerond voor commit \`${HEAD_SHA}\` met conclusie \`${conclusion}\`."
   summary ""
-  summary "Wat deze check bewijst: de review is gedraaid, klaar voor precies deze commit, en heeft daadwerkelijk iets geplaatst. Wat hij niet bewijst: dat de bevindingen deugen of dat ze zijn verwerkt. Dat blijft mensenwerk."
+  summary "Wat deze check bewijst: de job \`${JOB_NAME}\` is in deze run afgerond met conclusie \`${conclusion}\`. Wat hij niet bewijst: dat de review-actie binnen die job werkelijk een review heeft uitgevoerd, dat de bevindingen deugen, of dat ze zijn verwerkt."
   summary ""
   summary "[Bekijk de review-run](${url})"
   exit 0

--- a/script/await-claude-review.sh
+++ b/script/await-claude-review.sh
@@ -2,35 +2,50 @@
 # Merge gate: block until the Claude review of this workflow run is done.
 #
 # Zero review comments is not evidence of "no findings" — it is equally
-# consistent with "the review is still running". So the wait is driven by the
-# job's status, never by a comment count.
+# consistent with "the review is still running" and with "the review had nothing
+# to report". The gate therefore never counts comments. It reads two things off
+# the review job itself: its status and conclusion, and the outcome of the step
+# that only runs when the review action really executed.
 #
-# It exits 0 only when the review job ran to completion, or when the review
-# demonstrably cannot apply (cross-repo PR, draft, dependabot). Those reasons are
-# read off the pull request itself, not off the review's own result, so a review
-# that ran and failed can never pass as one that was never meant to run.
+# It exits 0 only when the review job ran to completion and that step ran with
+# it, or when the review demonstrably cannot apply (cross-repo PR, draft,
+# dependabot). Those reasons are read off the pull request itself, not off the
+# review's own result, so a review that ran and failed can never pass as one that
+# was never meant to run.
+#
+# What the gate treats as fact it fetches itself. The workflow that invokes it
+# lives in the pull request, so anything that workflow passes in is written by
+# the author of the change under review: `IS_DRAFT: true` in the env block would
+# otherwise be enough to declare the review inapplicable. Only the coordinates of
+# the run (repository, run id, pull request number) come from the environment,
+# and the gate checks that those three describe one and the same thing.
+#
+# What this cannot reach: the job that calls this script also lives in the pull
+# request's workflow file. A PR that keeps the job name and replaces its steps
+# reports green without ever running this script, and no line in here can stop
+# that. Closing it takes a rule outside the pull request — a ruleset or CODEOWNERS
+# entry over `.github/workflows/**`, or a `workflow_run`-triggered gate that
+# judges the review run from the outside.
 #
 # The review job is looked up inside *this* workflow run rather than by head SHA.
 # A `ready_for_review` or `reopened` event keeps the same SHA, so a SHA lookup can
 # race and read the previous run's leftover check-run.
 set -uo pipefail
 
-# Tijdstempels worden als string vergeleken; onder een collatie die interpunctie
-# negeert klopt die volgorde niet meer.
-export LC_ALL=C
-
 : "${REPO:?REPO is verplicht}"
 : "${RUN_ID:?RUN_ID is verplicht}"
 : "${PR_NUMBER:?PR_NUMBER is verplicht}"
 
-IS_CROSS_REPO="${IS_CROSS_REPO:-false}"
-IS_DRAFT="${IS_DRAFT:-false}"
-PR_AUTHOR="${PR_AUTHOR:-}"
-HEAD_SHA="${HEAD_SHA:-onbekend}"
-JOB_NAME="${JOB_NAME:-claude-review}"
 MAX_WAIT_SECONDS="${MAX_WAIT_SECONDS:-2100}"
 POLL_SECONDS="${POLL_SECONDS:-20}"
 GITHUB_STEP_SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+# Vaste namen, bewust geen env-variabelen: ze staan in het workflowbestand dat de
+# PR meebrengt, en een PR die ze mocht overschrijven kon de poort naar een stap
+# wijzen die altijd draait.
+readonly JOB_NAME='claude-review'
+readonly PROOF_STEP='Record that the review ran'
+readonly WORKFLOW_FILE='.github/workflows/claude-code-review.yml'
 
 summary() { printf '%s\n' "$1" >>"$GITHUB_STEP_SUMMARY"; }
 
@@ -50,19 +65,95 @@ blocked() {
   exit 1
 }
 
-if [ "$IS_CROSS_REPO" = "true" ]; then
+# stderr apart houden: een waarschuwing van `gh` op een verder geslaagde aanroep
+# zou de payload anders onparseerbaar maken, en dat kwam dan naar buiten als een
+# uitspraak over de review in plaats van als leesprobleem.
+gh_stderr=$(mktemp "${TMPDIR:-/tmp}/gate-stderr.XXXXXX")
+trap 'rm -f "$gh_stderr"' EXIT
+
+if ! pr=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" 2>"$gh_stderr") ||
+  ! head_sha=$(jq -er '.head.sha' <<<"$pr" 2>/dev/null); then
+  blocked "Pull request ${PR_NUMBER} in ${REPO} is niet op te halen, dus er valt niets over de review vast te stellen. Dat is geen uitspraak over de review zelf; draai deze job opnieuw. Foutmelding: $(cat "$gh_stderr")"
+fi
+
+pr_field() { jq -r "${1} // \"\"" <<<"$pr"; }
+
+# De koppeling tussen de drie coördinaten: run ${RUN_ID} moet over dezelfde
+# commit gaan als pull request ${PR_NUMBER}. Zonder die toets kan een PR de poort
+# naar de run van een andere, al gereviewde PR wijzen en is elke uitspraak
+# hieronder waar — over die andere PR.
+if ! run=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" 2>"$gh_stderr") ||
+  ! run_head=$(jq -er '.head_sha' <<<"$run" 2>/dev/null); then
+  blocked "Workflow-run ${RUN_ID} is niet op te halen, dus of deze run over pull request ${PR_NUMBER} gaat is niet vastgesteld. Dat is geen uitspraak over de review zelf; draai deze job opnieuw. Foutmelding: $(cat "$gh_stderr")"
+fi
+if [ "$run_head" != "$head_sha" ]; then
+  blocked "Workflow-run ${RUN_ID} draait op commit \`${run_head}\`, terwijl pull request ${PR_NUMBER} op \`${head_sha}\` staat. De poort zou dan over een andere wijziging rapporteren dan er wordt gemerged. Draai de workflow opnieuw op de actuele commit."
+fi
+
+if [ "$(jq -r '.head.repo' <<<"$pr")" = "null" ]; then
+  not_applicable "De head-repository van deze PR bestaat niet meer, dus er valt geen commit te reviewen en te mergen valt er ook niets."
+fi
+
+if [ "$(pr_field '.head.repo.full_name')" != "$REPO" ]; then
   not_applicable "Deze PR komt uit een andere repository (een fork). Zulke PR's krijgen geen secrets, dus \`CLAUDE_CODE_OAUTH_TOKEN\` ontbreekt en \`${JOB_NAME}\` draait daar niet. Review deze wijziging met de hand voordat je merget."
 fi
 
-if [ "$IS_DRAFT" = "true" ]; then
+if [ "$(pr_field '.draft')" = "true" ]; then
   not_applicable "Deze PR staat op draft. \`${JOB_NAME}\` draait pas bij \"ready for review\", en een draft is niet mergebaar."
 fi
 
-if [ "$PR_AUTHOR" = "dependabot[bot]" ]; then
+if [ "$(pr_field '.user.login')" = "dependabot[bot]" ]; then
   not_applicable "Deze PR komt van dependabot. Die loopt via de \`claude-dependabot\`-workflow, niet via \`${JOB_NAME}\`."
 fi
 
-echo "Wachten op job '${JOB_NAME}' in workflow-run ${RUN_ID} (commit ${HEAD_SHA}, max ${MAX_WAIT_SECONDS}s)."
+# De claude-code-action weigert te draaien zodra het workflowbestand afwijkt van
+# dat op de default branch: zij stapt uit met conclusie `success` zonder ook maar
+# iets te reviewen ("Exiting due to workflow validation skip"). Gemeten op PR
+# 1157: veertien seconden, groen, geen review.
+#
+# Die vergelijking maakt de poort zelf, vóór ze op de review gaat wachten. Dat
+# scheelt niet alleen een halfuur wachten op een review die er niet komt; het is
+# ook wat de rest van deze poort draagt. Zijn de twee versies gelijk, dan is het
+# workflowbestand dat deze run draait dat van de default branch, en niet iets wat
+# met de PR is meegekomen. Pas dan zegt de uitkomst van een stap in die workflow
+# iets.
+#
+# Vergeleken wordt de merge-ref, niet de head-commit: een `pull_request`-run
+# draait het workflowbestand zoals het in de test-merge van PR en base staat. Een
+# PR die het bestand zelf niet aanraakt heeft daar dus de versie van de base
+# staan, ook als de branch al weken achterloopt. Op `head.sha` vergelijken zou
+# precies die achterlopers rood zetten terwijl hun review gewoon draaide.
+blob_sha() {
+  local ref payload
+  ref="$1"
+  payload=$(gh api "repos/${REPO}/contents/${WORKFLOW_FILE}?ref=${ref}" 2>"$gh_stderr") || return 1
+  jq -er '.sha' <<<"$payload" 2>/dev/null
+}
+
+missing_file() { grep -qE 'HTTP 404|Not Found' "$gh_stderr"; }
+
+default_branch=$(pr_field '.base.repo.default_branch')
+[ -n "$default_branch" ] || blocked "De default branch van ${REPO} staat niet in het antwoord van de pull-request-API, dus \`${WORKFLOW_FILE}\` is niet te vergelijken. Draai deze job opnieuw."
+
+merge_ref="refs/pull/${PR_NUMBER}/merge"
+if ! run_workflow=$(blob_sha "$merge_ref"); then
+  if missing_file; then
+    blocked "\`${WORKFLOW_FILE}\` bestaat niet op \`${merge_ref}\`, de samenvoeging van deze PR met de base-branch. Zonder dat bestand is er geen review-workflow en kan de poort niets vaststellen. Opnieuw draaien helpt hier niet; zet het bestand terug of los het merge-conflict op."
+  fi
+  blocked "\`${WORKFLOW_FILE}\` is niet op te halen voor \`${merge_ref}\`, dus of de review-actie op deze PR draait is niet vastgesteld. Dat is geen uitspraak over de review zelf; draai deze job opnieuw. Foutmelding: $(cat "$gh_stderr")"
+fi
+if ! base_workflow=$(blob_sha "$default_branch"); then
+  if missing_file; then
+    blocked "\`${WORKFLOW_FILE}\` bestaat niet op branch \`${default_branch}\`. De review-actie valideert daartegen, dus zonder dat bestand draait zij nergens. Opnieuw draaien helpt hier niet."
+  fi
+  blocked "\`${WORKFLOW_FILE}\` is niet op te halen voor branch \`${default_branch}\`, dus of de review-actie op deze PR draait is niet vastgesteld. Dat is geen uitspraak over de review zelf; draai deze job opnieuw. Foutmelding: $(cat "$gh_stderr")"
+fi
+
+if [ "$run_workflow" != "$base_workflow" ]; then
+  blocked "\`${WORKFLOW_FILE}\` is in deze run een andere versie dan die op \`${default_branch}\`: de blob op \`${merge_ref}\` is \`${run_workflow}\`, die op \`${default_branch}\` is \`${base_workflow}\`. De review-actie valideert het workflowbestand tegen de default branch en stapt bij een verschil uit zonder te reviewen, dus deze PR krijgt geen automatische review en de poort kan er niet voor instaan. Wijzigt deze PR dat bestand, dan moet een mens de wijziging nalopen."
+fi
+
+echo "Wachten op job '${JOB_NAME}' in workflow-run ${RUN_ID} (commit ${head_sha}, max ${MAX_WAIT_SECONDS}s)."
 deadline=$(($(date +%s) + MAX_WAIT_SECONDS))
 job=''
 status=''
@@ -106,14 +197,62 @@ done
 conclusion=$(jq -r '.conclusion // "none"' <<<"$job")
 url=$(jq -r '.html_url // ""' <<<"$job")
 
+# Een groene job is geen bewijs dat er gereviewd is. Dat bewijs komt uit de
+# review-job zelf: een stap die alleen draait als de actie `execution_file` heeft
+# gezet, en dat doet zij pas nadat de CLI werkelijk gedraaid heeft. Die stap
+# staat in het job-object dat hierboven al is opgehaald, dus het bewijs is per
+# constructie aan déze run en deze attempt gebonden, en het bestaat ook wanneer
+# de review nul bevindingen had.
+#
+# Precies één stap met die naam, niet de laatste die zo heet: twee stappen met
+# dezelfde naam is geen situatie waarin de poort een winnaar hoort te kiezen.
+assert_review_ran() {
+  local matches proof
+  matches=$(jq -r --arg step "$PROOF_STEP" '(.steps // []) | map(select(.name == $step)) | length' <<<"$job" 2>/dev/null)
+
+  case "${matches:-onbekend}" in
+  0)
+    blocked "\`${JOB_NAME}\` meldt \`${conclusion}\`, maar de job kent geen stap \`${PROOF_STEP}\`, terwijl \`${WORKFLOW_FILE}\` gelijk is aan de versie op \`${default_branch}\`. Of er gereviewd is, valt daarmee niet af te lezen. Controleer of die stap nog in \`${WORKFLOW_FILE}\` staat. ${url}"
+    ;;
+  1) ;;
+  onbekend)
+    blocked "De stappen van \`${JOB_NAME}\` zijn niet uit het antwoord van de jobs-API te lezen, dus of er gereviewd is, is onbekend. Dat is geen uitspraak over de review zelf; draai deze job opnieuw. ${url}"
+    ;;
+  *)
+    blocked "\`${JOB_NAME}\` kent ${matches} stappen met de naam \`${PROOF_STEP}\`. Welke daarvan het bewijs is, kan de poort niet uitmaken. Laat één zo'n stap staan in \`${WORKFLOW_FILE}\`. ${url}"
+    ;;
+  esac
+
+  proof=$(jq -r --arg step "$PROOF_STEP" '(.steps // []) | map(select(.name == $step)) | .[0].conclusion // ""' <<<"$job" 2>/dev/null)
+  case "$proof" in
+  success)
+    return
+    ;;
+  skipped)
+    # De workflow-validation-skip is hierboven al uitgesloten: het
+    # workflowbestand is gelijk aan dat op de default branch. Blijft over dat de
+    # actie geen `execution_file` opleverde, bijvoorbeeld doordat zij vroegtijdig
+    # uitstapte of doordat een upgrade die output hernoemde.
+    blocked "\`${JOB_NAME}\` meldt \`${conclusion}\`, maar de stap \`${PROOF_STEP}\` is in die job overgeslagen. Die stap draait alleen als de review-actie een uitvoerbestand oplevert, dus dat is uitgebleven. \`${WORKFLOW_FILE}\` is gelijk aan de versie op \`${default_branch}\`, dus de bekende workflow-validation-skip verklaart dit niet. Lees het log van de review-job, en ga na of een upgrade van de review-actie de output \`execution_file\` heeft hernoemd. ${url}"
+    ;;
+  '')
+    blocked "De stap \`${PROOF_STEP}\` in \`${JOB_NAME}\` heeft geen leesbare conclusie, dus of er gereviewd is, is onbekend. Dat is geen uitspraak over de review zelf; draai deze job opnieuw. ${url}"
+    ;;
+  *)
+    blocked "\`${JOB_NAME}\` meldt \`${conclusion}\`, maar de stap \`${PROOF_STEP}\` eindigde op \`${proof}\`. Of er gereviewd is, is daarmee niet vastgesteld. Draai de review opnieuw: ${url}"
+    ;;
+  esac
+}
+
 case "$conclusion" in
 success | neutral)
+  assert_review_ran
   echo "::notice title=Claude review gate::review afgerond (${conclusion})"
   summary "### Claude review gate: groen"
   summary ""
-  summary "\`${JOB_NAME}\` is afgerond voor commit \`${HEAD_SHA}\` met conclusie \`${conclusion}\`."
+  summary "\`${JOB_NAME}\` is afgerond voor commit \`${head_sha}\` met conclusie \`${conclusion}\`."
   summary ""
-  summary "Wat deze check bewijst: de job \`${JOB_NAME}\` is in deze run afgerond met conclusie \`${conclusion}\`. Wat hij niet bewijst: dat de review-actie binnen die job werkelijk een review heeft uitgevoerd, dat de bevindingen deugen, of dat ze zijn verwerkt."
+  summary "Wat deze check bewijst: \`${WORKFLOW_FILE}\` is gelijk aan de versie op \`${default_branch}\`, de job \`${JOB_NAME}\` is in deze run afgerond met conclusie \`${conclusion}\`, en de stap \`${PROOF_STEP}\` is in die job gedraaid, dus de review-actie heeft werkelijk gereviewd. Wat hij niet bewijst: dat de review iets gevonden heeft, dat de bevindingen deugen, of dat ze zijn verwerkt. Dat blijft mensenwerk."
   summary ""
   summary "[Bekijk de review-run](${url})"
   exit 0

--- a/script/await-claude-review.test.sh
+++ b/script/await-claude-review.test.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 # Tests voor script/await-claude-review.sh.
 #
-# `gh` wordt vervangen door een stub die de jobs van de workflow-run uit een
-# reeks antwoordt: één antwoord per aanroep, zodat een lopende review die later
-# klaar is te simuleren valt. Zo is elk pad deterministisch te bewijzen zonder
-# GitHub. Elk ander endpoint laat de stub falen; de poort hoort niets anders te
-# raadplegen dan de jobs van deze run.
+# `gh` wordt vervangen door een stub die drie endpoints kent: de pull request,
+# de blob-sha van het workflowbestand per ref, en de jobs van de workflow-run.
+# Die laatste komen uit een reeks — één antwoord per aanroep — zodat een lopende
+# review die later klaar is te simuleren valt. Zo is elk pad deterministisch te
+# bewijzen zonder GitHub. Elk ander endpoint laat de stub falen; comments tellen
+# hoort de poort niet te doen.
 set -uo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -34,6 +35,50 @@ case "$url" in
   fi
   printf '%s\n' "$line"
   ;;
+*/actions/runs/*)
+  body=$(cat "$STUB_RUN")
+  if [ "$body" = "ERROR" ]; then
+    echo "gh: simulated API failure" >&2
+    exit 1
+  fi
+  printf '%s\n' "$body"
+  ;;
+*/contents/*)
+  # De opgevraagde ref wordt vastgelegd, zodat een test kan asserten dat de
+  # poort de merge-ref van déze PR vergelijkt en niet zomaar een commit.
+  printf '%s\n' "${url#*ref=}" >>"$STUB_REFS"
+  case "$url" in
+  *ref=main) body=$(cat "$STUB_WORKFLOW_BASE") ;;
+  *ref=refs/pull/1/merge) body=$(cat "$STUB_WORKFLOW_RUN") ;;
+  *)
+    echo "gh: HTTP 404: onverwachte ref in ${url}" >&2
+    exit 1
+    ;;
+  esac
+  if [ "$body" = "ERROR" ]; then
+    echo "gh: HTTP 404" >&2
+    exit 1
+  fi
+  if [ "$body" = "NETWERK" ]; then
+    echo "gh: connection reset by peer" >&2
+    exit 1
+  fi
+  printf '{"sha":"%s"}\n' "$body"
+  ;;
+*/pulls/*)
+  body=$(cat "$STUB_PR")
+  if [ "$body" = "ERROR" ]; then
+    echo "gh: HTTP 403" >&2
+    exit 1
+  fi
+  # WARN: geslaagde aanroep die ook naar stderr schrijft.
+  if [ "$body" = "WARN" ]; then
+    echo "gh: warning: this API is deprecated" >&2
+    cat "$STUB_PR_WARN_BODY"
+    exit 0
+  fi
+  printf '%s\n' "$body"
+  ;;
 *)
   echo "gh: onverwachte URL: $url" >&2
   exit 1
@@ -45,10 +90,57 @@ export PATH="${WORK}/bin:${PATH}"
 
 export STUB_COUNTER="${WORK}/counter"
 export STUB_JOBS="${WORK}/jobs"
+export STUB_PR="${WORK}/pr"
+export STUB_PR_WARN_BODY="${WORK}/pr-warn-body"
+export STUB_RUN="${WORK}/run"
+export STUB_REFS="${WORK}/refs"
+export STUB_WORKFLOW_RUN="${WORK}/workflow-run"
+export STUB_WORKFLOW_BASE="${WORK}/workflow-base"
+
+PROOF='Record that the review ran'
+HEAD_SHA='c0ffee0000000000000000000000000000000000'
+
+# pull_request <full_name van de head-repo> <draft> <auteur>
+pull_request() {
+  printf '{"draft":%s,"user":{"login":"%s"},"head":{"sha":"%s","repo":{"full_name":"%s"}},"base":{"repo":{"default_branch":"main"}}}' \
+    "${2:-false}" "${3:-iemand}" "$HEAD_SHA" "${1:-example-org/example-repo}"
+}
+
+PR_NORMAAL=$(pull_request)
+PR_FORK=$(pull_request 'iemand-anders/example-repo')
+PR_DRAFT=$(pull_request 'example-org/example-repo' true)
+PR_DEPENDABOT=$(pull_request 'example-org/example-repo' false 'dependabot[bot]')
+PR_ZONDER_DEFAULT_BRANCH='{"draft":false,"user":{"login":"iemand"},"head":{"sha":"c0ffee0000000000000000000000000000000000","repo":{"full_name":"example-org/example-repo"}},"base":{"repo":{}}}'
+# De head-repository is verwijderd; `head.repo` is dan null.
+PR_ZONDER_HEAD_REPO='{"draft":false,"user":{"login":"iemand"},"head":{"sha":"c0ffee0000000000000000000000000000000000","repo":null},"base":{"repo":{"default_branch":"main"}}}'
+GARBAGE='dit is geen JSON'
+
+RUN_VAN_DEZE_PR=$(printf '{"head_sha":"%s"}' "$HEAD_SHA")
+RUN_VAN_EEN_ANDERE_PR='{"head_sha":"beefbeef000000000000000000000000000000ff"}'
+
+# De stappen van de review-job. `$1` is de conclusie van de bewijsstap; laat hem
+# leeg voor een job die die stap helemaal niet kent.
+steps_json() {
+  if [ -z "${1:-}" ]; then
+    printf '[{"name":"Run Claude Code Review","conclusion":"success"}]'
+  else
+    printf '[{"name":"Run Claude Code Review","conclusion":"success"},{"name":"%s","conclusion":"%s"}]' \
+      "$PROOF" "$1"
+  fi
+}
+
+# Een job zonder `steps`-sleutel; die is in het API-schema optioneel.
+JOB_ZONDER_STEPS='{"jobs":[{"name":"claude-review","status":"completed","conclusion":"success","html_url":"http://example.invalid/job"}]}'
+# Een `steps`-waarde die geen lijst is: dan valt er niets te tellen.
+JOB_ONLEESBARE_STEPS='{"jobs":[{"name":"claude-review","status":"completed","conclusion":"success","steps":"geen lijst","html_url":"http://example.invalid/job"}]}'
+# De bewijsstap staat er wel, maar zonder conclusie.
+JOB_STAP_ZONDER_CONCLUSIE="{\"jobs\":[{\"name\":\"claude-review\",\"status\":\"completed\",\"conclusion\":\"success\",\"steps\":[{\"name\":\"${PROOF}\",\"conclusion\":null}],\"html_url\":\"http://example.invalid/job\"}]}"
+# Twee stappen met dezelfde naam: een decoy naast het echte bewijs.
+JOB_DUBBELE_STAP="{\"jobs\":[{\"name\":\"claude-review\",\"status\":\"completed\",\"conclusion\":\"success\",\"steps\":[{\"name\":\"${PROOF}\",\"conclusion\":\"skipped\"},{\"name\":\"${PROOF}\",\"conclusion\":\"success\"}],\"html_url\":\"http://example.invalid/job\"}]}"
 
 job() {
-  printf '{"jobs":[{"name":"claude-review","status":"%s","conclusion":%s,"html_url":"http://example.invalid/job"}]}\n' \
-    "$1" "$2"
+  printf '{"jobs":[{"name":"claude-review","status":"%s","conclusion":%s,"steps":%s,"html_url":"http://example.invalid/job"}]}\n' \
+    "$1" "$2" "$(steps_json "${3-success}")"
 }
 
 RUNNING=$(job in_progress null)
@@ -57,22 +149,38 @@ DONE_NEUTRAL=$(job completed '"neutral"')
 DONE_FAIL=$(job completed '"failure"')
 DONE_CANCELLED=$(job completed '"cancelled"')
 DONE_SKIPPED=$(job completed '"skipped"')
+# De review-actie stapte eruit voordat zij iets reviewde: de bewijsstap is
+# overgeslagen, terwijl de job groen afsluit.
+DONE_NO_REVIEW=$(job completed '"success"' skipped)
+# Een workflow van vóór de bewijsstap; de job kent de stap niet.
+DONE_NO_PROOF_STEP=$(job completed '"success"' '')
+DONE_PROOF_FAILED=$(job completed '"success"' failure)
 NO_JOB='{"jobs":[{"name":"iets-anders","status":"completed","conclusion":"success"}]}'
 # Na "Re-run this job" op de poort staan er meerdere attempts van dezelfde job
 # op één run-id; de hoogste id is de meest recente.
-ATTEMPTS='{"jobs":[{"name":"claude-review","status":"completed","conclusion":"success","id":9,"html_url":"http://example.invalid/9"},{"name":"claude-review","status":"completed","conclusion":"failure","id":1,"html_url":"http://example.invalid/1"}]}'
+ATTEMPTS="{\"jobs\":[{\"name\":\"claude-review\",\"status\":\"completed\",\"conclusion\":\"success\",\"steps\":$(steps_json success),\"id\":9,\"html_url\":\"http://example.invalid/9\"},{\"name\":\"claude-review\",\"status\":\"completed\",\"conclusion\":\"failure\",\"steps\":$(steps_json skipped),\"id\":1,\"html_url\":\"http://example.invalid/1\"}]}"
 
 passed=0
 failed=0
 
 jobs_are() { printf '%s\n' "$@" >"$STUB_JOBS"; }
+pr_is() { printf '%s\n' "$1" >"$STUB_PR"; }
+run_is() { printf '%s\n' "$1" >"$STUB_RUN"; }
+workflow_is() { printf '%s\n' "$1" >"$STUB_WORKFLOW_RUN"; }
 
-# Elke test start van dezelfde grond: één afgeronde, geslaagde review. Een test
-# zet alleen wat hij zelf wil bewijzen en kan niet per ongeluk slagen op de
-# fixtures van zijn voorganger.
+# Elke test start van dezelfde grond: een gewone PR waarvan het workflowbestand
+# gelijk is aan dat op de default branch, en één afgeronde, geslaagde review
+# waarvan de bewijsstap gedraaid heeft. Een test zet alleen wat hij zelf wil
+# bewijzen en kan niet per ongeluk slagen op de fixtures van zijn voorganger.
 reset_fixtures() {
   jobs_are "$DONE_OK"
+  pr_is "$PR_NORMAAL"
+  printf '%s\n' "$PR_NORMAAL" >"$STUB_PR_WARN_BODY"
+  run_is "$RUN_VAN_DEZE_PR"
+  workflow_is 'blob-van-main'
+  printf '%s\n' 'blob-van-main' >"$STUB_WORKFLOW_BASE"
   echo 0 >"$STUB_COUNTER"
+  : >"$STUB_REFS"
   : >"${WORK}/summary.md"
 }
 
@@ -86,7 +194,6 @@ check() {
     REPO='example-org/example-repo' \
     RUN_ID='42' \
     PR_NUMBER='1' \
-    HEAD_SHA='0000000000000000000000000000000000000000' \
     POLL_SECONDS=0 \
     GITHUB_STEP_SUMMARY="${WORK}/summary.md" \
     "$GATE" 2>&1)
@@ -112,18 +219,52 @@ check() {
 }
 
 echo "== niet van toepassing =="
-# De review draait hier nog; de poort mag daar niet op gaan wachten.
+# De review draait hier nog; de poort mag daar niet op gaan wachten. Fork, draft
+# en auteur haalt de poort zelf op bij de pull-request-API, niet uit de omgeving
+# die het workflowbestand van de PR meegeeft.
 reset_fixtures
 jobs_are "$RUNNING"
-check "cross-repo-PR wacht niet en blokkeert niet" 0 "niet van toepassing" "andere repository" -- IS_CROSS_REPO=true MAX_WAIT_SECONDS=0
+pr_is "$PR_FORK"
+check "cross-repo-PR wacht niet en blokkeert niet" 0 "niet van toepassing" "andere repository" -- MAX_WAIT_SECONDS=0
 reset_fixtures
 jobs_are "$RUNNING"
-check "draft-PR wacht niet en blokkeert niet" 0 "niet van toepassing" "draft" -- IS_DRAFT=true MAX_WAIT_SECONDS=0
+pr_is "$PR_DRAFT"
+check "draft-PR wacht niet en blokkeert niet" 0 "niet van toepassing" "draft" -- MAX_WAIT_SECONDS=0
 reset_fixtures
 jobs_are "$RUNNING"
-check "dependabot-PR wacht niet en blokkeert niet" 0 "niet van toepassing" "dependabot" -- PR_AUTHOR='dependabot[bot]' MAX_WAIT_SECONDS=0
+pr_is "$PR_DEPENDABOT"
+check "dependabot-PR wacht niet en blokkeert niet" 0 "niet van toepassing" "dependabot" -- MAX_WAIT_SECONDS=0
+# Een PR die de poort zelf een uitzondering probeert aan te praten via het
+# env-blok van het workflowbestand: de poort leest die variabelen niet.
+reset_fixtures
+check "env-blok van de PR maakt geen uitzondering" 0 "review afgerond (success)" "groen" \
+  -- IS_DRAFT=true IS_CROSS_REPO=true PR_AUTHOR='dependabot[bot]' MAX_WAIT_SECONDS=0
+reset_fixtures
+jobs_are "$DONE_NO_REVIEW"
+check "env-blok van de PR wijst de poort niet naar een andere stap" 1 "overgeslagen" "overgeslagen" \
+  -- PROOF_STEP='Run Claude Code Review' JOB_NAME='review-gate' WORKFLOW_FILE='README.md' MAX_WAIT_SECONDS=0
 
 echo "== de poort sluit =="
+reset_fixtures
+pr_is ERROR
+check "PR niet op te halen: rood, niet als 'geen review' gemeld" 1 "is niet op te halen" "draai deze job opnieuw" -- MAX_WAIT_SECONDS=0
+reset_fixtures
+pr_is "$GARBAGE"
+check "onparseerbaar antwoord op de PR: rood met een eigen melding" 1 "is niet op te halen" "draai deze job opnieuw" -- MAX_WAIT_SECONDS=0
+reset_fixtures
+pr_is "$PR_ZONDER_DEFAULT_BRANCH"
+check "PR zonder default branch: rood, want er valt niets te vergelijken" 1 "default branch" "niet te vergelijken" -- MAX_WAIT_SECONDS=0
+# De drie coordinaten moeten over hetzelfde gaan: een run-id dat naar de run van
+# een andere PR wijst, mag geen groen opleveren op andermans review.
+reset_fixtures
+run_is "$RUN_VAN_EEN_ANDERE_PR"
+check "run hoort bij een andere commit: rood" 1 "draait op commit" "andere wijziging" -- MAX_WAIT_SECONDS=0
+reset_fixtures
+run_is ERROR
+check "workflow-run niet op te halen: rood" 1 "Workflow-run 42 is niet op te halen" "draai deze job opnieuw" -- MAX_WAIT_SECONDS=0
+reset_fixtures
+pr_is "$PR_ZONDER_HEAD_REPO"
+check "verwijderde head-repo: niet van toepassing, met de juiste reden" 0 "bestaat niet meer" "bestaat niet meer" -- MAX_WAIT_SECONDS=0
 reset_fixtures
 jobs_are "$RUNNING"
 check "review loopt nog bij deadline: rood" 1 "nog niet klaar" "nog niet klaar" -- MAX_WAIT_SECONDS=0
@@ -144,6 +285,66 @@ reset_fixtures
 jobs_are ERROR
 check "jobs-API blijft onleesbaar tot de deadline: rood, niet als 'job ontbreekt'" 1 "niet op te halen" "niet op te halen" -- MAX_WAIT_SECONDS=0
 
+echo "== een workflowbestand dat afwijkt van de default branch =="
+# De claude-code-action weigert te draaien zodra dat bestand afwijkt: zij stapt
+# uit met conclusie success zonder te reviewen. De poort stelt die afwijking zelf
+# vast en wacht niet eerst een halfuur op een review die niet komt.
+reset_fixtures
+jobs_are "$RUNNING"
+workflow_is 'blob-van-de-pr'
+check "workflowbestand wijkt af: rood, zonder te wachten" 1 "is in deze run een andere versie" "een mens de wijziging nalopen" -- MAX_WAIT_SECONDS=0
+# Vergeleken wordt de merge-ref van deze PR: dat is het bestand dat de run
+# werkelijk draaide. De stub weigert elke andere ref, dus deze test valt om zodra
+# de poort op de head-commit gaat vergelijken.
+if grep -qxF 'refs/pull/1/merge' "$STUB_REFS" && grep -qxF 'main' "$STUB_REFS"; then
+  echo "ok   vergeleken wordt de merge-ref van deze PR tegen de default branch"
+  passed=$((passed + 1))
+else
+  echo "FAIL de poort vroeg de refs $(tr '\n' ' ' <"$STUB_REFS")op, niet refs/pull/1/merge en main"
+  failed=$((failed + 1))
+fi
+reset_fixtures
+jobs_are "$RUNNING"
+workflow_is ERROR
+check "workflowbestand ontbreekt op de merge-ref: rood, opnieuw draaien helpt niet" 1 "bestaat niet op" "helpt hier niet" -- MAX_WAIT_SECONDS=0
+reset_fixtures
+jobs_are "$RUNNING"
+workflow_is NETWERK
+check "workflowbestand onleesbaar door een leesfout: rood, draai opnieuw" 1 "niet op te halen voor" "draai deze job opnieuw" -- MAX_WAIT_SECONDS=0
+reset_fixtures
+jobs_are "$RUNNING"
+printf '%s\n' ERROR >"$STUB_WORKFLOW_BASE"
+check "workflowbestand ontbreekt op de default branch: rood" 1 "bestaat niet op branch" "helpt hier niet" -- MAX_WAIT_SECONDS=0
+
+echo "== een groene job die niets reviewde =="
+# Het workflowbestand is hier gelijk aan dat op de default branch, dus de
+# workflow-validation-skip is uitgesloten en de melding zegt dat er ook bij.
+reset_fixtures
+jobs_are "$DONE_NO_REVIEW"
+check "bewijsstap overgeslagen: rood" 1 "is in die job overgeslagen" "verklaart dit niet" -- MAX_WAIT_SECONDS=0
+reset_fixtures
+jobs_are "$DONE_NO_PROOF_STEP"
+check "job zonder bewijsstap: rood" 1 "kent geen stap" "kent geen stap" -- MAX_WAIT_SECONDS=0
+reset_fixtures
+jobs_are "$JOB_ZONDER_STEPS"
+check "job zonder stappenlijst: rood" 1 "kent geen stap" "kent geen stap" -- MAX_WAIT_SECONDS=0
+# Twee stappen met dezelfde naam: de poort kiest daar geen winnaar uit, want dan
+# zou één toegevoegde stap het bewijs kunnen overstemmen.
+reset_fixtures
+jobs_are "$JOB_DUBBELE_STAP"
+check "twee stappen met de bewijsnaam: rood" 1 "2 stappen met de naam" "kan de poort niet uitmaken" -- MAX_WAIT_SECONDS=0
+reset_fixtures
+jobs_are "$DONE_PROOF_FAILED"
+check "bewijsstap gefaald: rood" 1 'eindigde op `failure`' 'eindigde op `failure`' -- MAX_WAIT_SECONDS=0
+# De twee "we weten het niet"-armen horen rood te zijn, niet groen bij gebrek aan
+# een leesbare uitkomst.
+reset_fixtures
+jobs_are "$JOB_ONLEESBARE_STEPS"
+check "stappen niet te lezen: rood" 1 "zijn niet uit het antwoord" "draai deze job opnieuw" -- MAX_WAIT_SECONDS=0
+reset_fixtures
+jobs_are "$JOB_STAP_ZONDER_CONCLUSIE"
+check "bewijsstap zonder conclusie: rood" 1 "geen leesbare conclusie" "draai deze job opnieuw" -- MAX_WAIT_SECONDS=0
+
 echo "== de poort opent =="
 # Het geval uit issue 1178: de review draaide volledig af en had niets aan te
 # merken, dus claude[bot] plaatste geen enkele comment. Dat is een schone PR,
@@ -163,6 +364,34 @@ check "wacht door tot de review klaar is" 0 "review afgerond (success)" "groen" 
 reset_fixtures
 jobs_are ERROR "$DONE_OK"
 check "API-fout op de jobs is geen conclusie, er wordt doorgepolld" 0 "review afgerond (success)" "groen" -- MAX_WAIT_SECONDS=60
+reset_fixtures
+pr_is WARN
+check "waarschuwing op stderr bederft een geslaagde aanroep niet: groen" 0 "review afgerond (success)" "groen" -- MAX_WAIT_SECONDS=0
+
+echo "== de workflow levert het bewijs dat de poort zoekt =="
+# De poort kent de naam van de bewijsstap als vaste waarde; hernoemen in de
+# workflow zonder de poort mee te nemen zet elke PR op rood. Deze test bindt de
+# twee aan elkaar.
+WORKFLOW="$(cd "${HERE}/.." && pwd)/.github/workflows/claude-code-review.yml"
+if grep -qF -- "- name: ${PROOF}" "$WORKFLOW" &&
+  grep -qF -- "if: steps.claude-review.outputs.execution_file != ''" "$WORKFLOW"; then
+  echo "ok   de bewijsstap staat onder die naam in het workflowbestand"
+  passed=$((passed + 1))
+else
+  echo "FAIL de bewijsstap staat niet onder die naam in ${WORKFLOW}, of niet met de verwachte conditie"
+  failed=$((failed + 1))
+fi
+
+# De poort zoekt de job op onder de naam `claude-review`. Krijgt die job een
+# `name:`, dan heet zij in de API anders en wordt elke PR rood.
+if grep -qxF '  claude-review:' "$WORKFLOW" &&
+  awk '/^  claude-review:/ {inside = 1; next} /^  [a-z]/ {inside = 0} inside && /^    name:/ {found = 1} END {exit found}' "$WORKFLOW"; then
+  echo "ok   de review-job heet in de API nog \`claude-review\`"
+  passed=$((passed + 1))
+else
+  echo "FAIL de job \`claude-review\` ontbreekt in ${WORKFLOW} of heeft een eigen \`name:\`, waardoor de poort haar niet vindt"
+  failed=$((failed + 1))
+fi
 
 echo
 echo "${passed} geslaagd, ${failed} gefaald"

--- a/script/await-claude-review.test.sh
+++ b/script/await-claude-review.test.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # Tests voor script/await-claude-review.sh.
 #
-# `gh` wordt vervangen door een stub die per endpoint antwoordt: de jobs van de
-# workflow-run uit een reeks (één antwoord per aanroep, zodat een lopende review
-# die later klaar is te simuleren valt), comments en reviews uit fixtures. Zo is
-# elk pad deterministisch te bewijzen zonder GitHub.
+# `gh` wordt vervangen door een stub die de jobs van de workflow-run uit een
+# reeks antwoordt: één antwoord per aanroep, zodat een lopende review die later
+# klaar is te simuleren valt. Zo is elk pad deterministisch te bewijzen zonder
+# GitHub. Elk ander endpoint laat de stub falen; de poort hoort niets anders te
+# raadplegen dan de jobs van deze run.
 set -uo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -33,32 +34,6 @@ case "$url" in
   fi
   printf '%s\n' "$line"
   ;;
-*/comments*)
-  if [ "$(cat "$STUB_COMMENTS")" = "ERROR" ]; then
-    echo "gh: HTTP 403" >&2
-    exit 1
-  fi
-  # WARN: geslaagde aanroep die ook naar stderr schrijft.
-  if [ "$(cat "$STUB_COMMENTS")" = "WARN" ]; then
-    echo "gh: warning: this API is deprecated" >&2
-    cat "$STUB_WARN_BODY"
-    exit 0
-  fi
-  cat "$STUB_COMMENTS"
-  ;;
-*/reviews*)
-  if [ "$(cat "$STUB_REVIEWS")" = "ERROR" ]; then
-    echo "gh: HTTP 403" >&2
-    exit 1
-  fi
-  # WARN: geslaagde aanroep die ook naar stderr schrijft.
-  if [ "$(cat "$STUB_REVIEWS")" = "WARN" ]; then
-    echo "gh: warning: this API is deprecated" >&2
-    cat "$STUB_WARN_BODY"
-    exit 0
-  fi
-  cat "$STUB_REVIEWS"
-  ;;
 *)
   echo "gh: onverwachte URL: $url" >&2
   exit 1
@@ -70,15 +45,10 @@ export PATH="${WORK}/bin:${PATH}"
 
 export STUB_COUNTER="${WORK}/counter"
 export STUB_JOBS="${WORK}/jobs"
-export STUB_COMMENTS="${WORK}/comments"
-export STUB_REVIEWS="${WORK}/reviews"
-export STUB_WARN_BODY="${WORK}/warn-body"
-
-STARTED='2026-01-01T12:00:00Z'
 
 job() {
-  printf '{"jobs":[{"name":"claude-review","status":"%s","conclusion":%s,"started_at":%s,"html_url":"http://example.invalid/job"}]}\n' \
-    "$1" "$2" "${3:-\"$STARTED\"}"
+  printf '{"jobs":[{"name":"claude-review","status":"%s","conclusion":%s,"html_url":"http://example.invalid/job"}]}\n' \
+    "$1" "$2"
 }
 
 RUNNING=$(job in_progress null)
@@ -87,35 +57,21 @@ DONE_NEUTRAL=$(job completed '"neutral"')
 DONE_FAIL=$(job completed '"failure"')
 DONE_CANCELLED=$(job completed '"cancelled"')
 DONE_SKIPPED=$(job completed '"skipped"')
-DONE_NO_START=$(job completed '"success"' null)
 NO_JOB='{"jobs":[{"name":"iets-anders","status":"completed","conclusion":"success"}]}'
 # Na "Re-run this job" op de poort staan er meerdere attempts van dezelfde job
 # op één run-id; de hoogste id is de meest recente.
-ATTEMPTS='{"jobs":[{"name":"claude-review","status":"completed","conclusion":"success","started_at":"2026-01-01T12:00:00Z","id":9,"html_url":"http://example.invalid/9"},{"name":"claude-review","status":"completed","conclusion":"failure","started_at":"2026-01-01T10:00:00Z","id":1,"html_url":"http://example.invalid/1"}]}'
-GARBAGE='dit is geen JSON'
-
-
-NONE='[]'
-STICKY='[{"user":{"login":"claude[bot]"},"created_at":"2026-01-01T12:00:30Z","updated_at":"2026-01-01T12:00:30Z"}]'
-STICKY_STALE='[{"user":{"login":"claude[bot]"},"created_at":"2026-01-01T09:00:00Z","updated_at":"2026-01-01T09:00:00Z"}]'
-HUMAN_ONLY='[{"user":{"login":"someone"},"created_at":"2026-01-01T12:00:30Z","updated_at":"2026-01-01T12:00:30Z"}]'
-CLAUDE_REVIEW='[{"user":{"login":"claude[bot]"},"state":"COMMENTED","submitted_at":"2026-01-01T12:00:40Z"}]'
+ATTEMPTS='{"jobs":[{"name":"claude-review","status":"completed","conclusion":"success","id":9,"html_url":"http://example.invalid/9"},{"name":"claude-review","status":"completed","conclusion":"failure","id":1,"html_url":"http://example.invalid/1"}]}'
 
 passed=0
 failed=0
 
 jobs_are() { printf '%s\n' "$@" >"$STUB_JOBS"; }
-comments_are() { printf '%s\n' "$1" >"$STUB_COMMENTS"; }
-reviews_are() { printf '%s\n' "$1" >"$STUB_REVIEWS"; }
 
-# Elke test start van dezelfde grond: één afgeronde geslaagde review met een
-# verse sticky comment. Een test zet alleen wat hij zelf wil bewijzen en kan niet
-# per ongeluk slagen op de fixtures van zijn voorganger.
+# Elke test start van dezelfde grond: één afgeronde, geslaagde review. Een test
+# zet alleen wat hij zelf wil bewijzen en kan niet per ongeluk slagen op de
+# fixtures van zijn voorganger.
 reset_fixtures() {
   jobs_are "$DONE_OK"
-  comments_are "$STICKY"
-  reviews_are "$NONE"
-  printf '%s\n' "$STICKY" >"$STUB_WARN_BODY"
   echo 0 >"$STUB_COUNTER"
   : >"${WORK}/summary.md"
 }
@@ -184,48 +140,20 @@ reset_fixtures
 jobs_are "$DONE_SKIPPED"
 check "review overgeslagen zonder geldige reden: rood" 1 "is overgeslagen" "is overgeslagen" -- MAX_WAIT_SECONDS=0
 
-echo "== groen vraagt ook een spoor van de review zelf =="
-# De claude-code-action stapt uit met conclusie success, zonder te reviewen en
-# zonder iets te plaatsen, zodra het workflowbestand afwijkt van de default
-# branch. Een groene job alleen is dus geen bewijs.
-reset_fixtures
-comments_are "$NONE"
-check "groen zonder enig spoor van claude[bot]: rood" 1 "niets geplaatst" "niets geplaatst" -- MAX_WAIT_SECONDS=0
-reset_fixtures
-comments_are "$HUMAN_ONLY"
-check "alleen comments van mensen: rood" 1 "niets geplaatst" "niets geplaatst" -- MAX_WAIT_SECONDS=0
-reset_fixtures
-comments_are "$STICKY_STALE"
-check "spoor van vóór deze run telt niet: rood" 1 "niets geplaatst" "niets geplaatst" -- MAX_WAIT_SECONDS=0
-reset_fixtures
-jobs_are "$DONE_NO_START"
-check "job zonder started_at: rood, want versheid is onbepaalbaar" 1 'geen `started_at`' 'geen `started_at`' -- MAX_WAIT_SECONDS=0
-reset_fixtures
-comments_are ERROR
-check "comments-API onleesbaar: rood, niet als 'geen review' gemeld" 1 "is niet te lezen" "is niet te lezen" -- MAX_WAIT_SECONDS=0
-reset_fixtures
-reviews_are ERROR
-check "reviews-API onleesbaar: rood, niet als 'geen review' gemeld" 1 "is niet te lezen" "is niet te lezen" -- MAX_WAIT_SECONDS=0
-reset_fixtures
-comments_are "$GARBAGE"
-check "onparseerbaar antwoord: rood met een eigen melding" 1 "geen bruikbare JSON" "geen bruikbare JSON" -- MAX_WAIT_SECONDS=0
 reset_fixtures
 jobs_are ERROR
 check "jobs-API blijft onleesbaar tot de deadline: rood, niet als 'job ontbreekt'" 1 "niet op te halen" "niet op te halen" -- MAX_WAIT_SECONDS=0
 
 echo "== de poort opent =="
+# Het geval uit issue 1178: de review draaide volledig af en had niets aan te
+# merken, dus claude[bot] plaatste geen enkele comment. Dat is een schone PR,
+# geen ontbrekende review. De stub faalt op elk endpoint buiten de jobs van deze
+# run, dus deze test slaagt alleen als de poort geen comments raadpleegt.
 reset_fixtures
-check "review afgerond met sticky comment: groen" 0 "review afgerond (success)" "Wat hij niet bewijst" -- MAX_WAIT_SECONDS=0
+check "review af met nul bevindingen: groen" 0 "review afgerond (success)" "Wat hij niet bewijst" -- MAX_WAIT_SECONDS=0
 reset_fixtures
 jobs_are "$DONE_NEUTRAL"
 check "conclusie neutral telt als afgerond: groen" 0 "review afgerond (neutral)" "groen" -- MAX_WAIT_SECONDS=0
-reset_fixtures
-comments_are "$NONE"
-reviews_are "$CLAUDE_REVIEW"
-check "een geplaatste review telt ook als spoor: groen" 0 "review afgerond (success)" "groen" -- MAX_WAIT_SECONDS=0
-reset_fixtures
-comments_are WARN
-check "waarschuwing op stderr bederft een geslaagde aanroep niet: groen" 0 "review afgerond (success)" "groen" -- MAX_WAIT_SECONDS=0
 reset_fixtures
 jobs_are "$ATTEMPTS"
 check "meerdere attempts: de nieuwste job telt" 0 "review afgerond (success)" "groen" -- MAX_WAIT_SECONDS=0


### PR DESCRIPTION
De poort `Claude review completed` eiste dat claude[bot] na de start van de review-job iets had geplaatst. Een review die zonder bevindingen afloopt plaatst niets, dus viel elke schone PR rood, met een melding die een oorzaak noemde die niet was getoetst. In plaats van comments te tellen kijkt de poort nu naar `execution_file` van de `claude-code-action`. Dat wordt pas gezet nadat de CLI heeft gedraaid, en bestaat dus ook bij nul bevindingen.

Om dat bewijs te kunnen vertrouwen vergelijkt de poort eerst de blob-sha van `.github/workflows/claude-code-review.yml` op `refs/pull/N/merge` met die op de default branch. Fork, draft, auteur en head-commit haalt zij nu zelf bij de API op, in plaats van uit het env-blok van een workflowbestand dat de PR meebrengt.

Eén gat blijft open, en met een script is het niet te dichten: `review-gate` staat zelf in dat workflowbestand, dus een PR die de jobnaam laat staan en de stappen vervangt door `run: true` rapporteert groen zonder de poort te draaien. Dat vraagt een ruleset of een CODEOWNERS-regel over `.github/workflows/**`, en staat als aantekening in CLAUDE.md.

Closes #1178