### PR TITLE
chore: negeer de core dump van headless chromium in frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,12 @@ mutants.out*/
 # BDD trace output
 trace_output/
 
+# Core dump van de headless Chromium die de frontend-tests en de docs-build
+# aansturen. `kernel.core_pattern` staat op de kale naam `core`, dus zo'n dump
+# landt in de werkmap van het proces. Geankerd op deze ene plek, want een kaal
+# `core` zou ook elke toekomstige map met die naam wegnemen.
+/frontend/core
+
 # Architecture model — generated on-demand by `arch-extract` for the local
 # architecture explorer (`just arch-generate`). Never committed: the explorer
 # regenerates it from the working tree, so it is always current by construction.


### PR DESCRIPTION
Twee keer op één dag liet een omgevallen headless Chromium een dump van bijna 200 MB achter in `frontend/`, één keer bij de e2e-tests en één keer bij het toetsen van de CSP. `kernel.core_pattern` staat op de kale naam `core`, dus zo'n bestand landt in de werkmap van het proces.

Geankerd op `/frontend/core`. Een kaal `core` zou ook elke toekomstige map met die naam wegnemen, en dat is een gewone naam voor een module.

De echte oplossing ligt buiten deze repo: `kernel.core_pattern` op de host naar `/tmp` laten wijzen, dan komt zo'n dump nergens meer in een werkmap terecht. Dit is het vangnet voor het geval dat niet gezet is.