### PR TITLE
chore(docs): declareer de vier pakketten die docs via hoisting binnenkreeg

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -12,14 +12,18 @@
         "@nldd/design-system": "^0.8.78",
         "astro": "^7.1.6",
         "astro-pagefind": "^2.0.1",
+        "github-slugger": "^2.0.0",
         "rehype-mermaid": "^3",
-        "remark-gfm": "^4"
+        "remark-gfm": "^4",
+        "unist-util-visit": "^5.1.0"
       },
       "devDependencies": {
+        "@types/hast": "^3.0.4",
         "pa11y-ci": "^4.1.1",
         "playwright": "^1.62",
         "start-server-and-test": "^3",
-        "typescript": "^7.0"
+        "typescript": "^7.0",
+        "vfile": "^6.0.3"
       }
     },
     "node_modules/@antfu/install-pkg": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,8 @@
     "preview": "astro preview",
     "check:rfc-coverage": "node scripts/check-rfc-coverage.mjs",
     "check:schema-version": "node scripts/check-schema-version.mjs",
-    "a11y": "astro build && node scripts/check-rfc-coverage.mjs && node scripts/check-mermaid-alt.mjs && node scripts/check-heading-order.mjs && node scripts/check-links.mjs && node scripts/gen-pa11yci.mjs && start-server-and-test 'astro preview --port 4173' http://localhost:4173 'pa11y-ci'",
+    "check:imports": "node scripts/check-declared-imports.mjs",
+    "a11y": "node scripts/check-declared-imports.mjs && astro build && node scripts/check-rfc-coverage.mjs && node scripts/check-mermaid-alt.mjs && node scripts/check-heading-order.mjs && node scripts/check-links.mjs && node scripts/gen-pa11yci.mjs && start-server-and-test 'astro preview --port 4173' http://localhost:4173 'pa11y-ci'",
     "nldd:imports": "node ../script/check-nldd-imports.mjs src src/nldd-components.js --write",
     "nldd:check": "node ../script/check-nldd-imports.mjs src src/nldd-components.js"
   },
@@ -18,14 +19,18 @@
     "@nldd/design-system": "^0.8.78",
     "astro": "^7.1.6",
     "astro-pagefind": "^2.0.1",
+    "github-slugger": "^2.0.0",
     "rehype-mermaid": "^3",
-    "remark-gfm": "^4"
+    "remark-gfm": "^4",
+    "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {
+    "@types/hast": "^3.0.4",
     "pa11y-ci": "^4.1.1",
     "playwright": "^1.62",
     "start-server-and-test": "^3",
-    "typescript": "^7.0"
+    "typescript": "^7.0",
+    "vfile": "^6.0.3"
   },
   "overrides": {
     "astro-pagefind": {

--- a/docs/scripts/check-declared-imports.mjs
+++ b/docs/scripts/check-declared-imports.mjs
@@ -1,0 +1,88 @@
+// Assert every npm package the docs source imports is declared in
+// docs/package.json.
+//
+// An undeclared import resolves anyway as long as some dependency happens to
+// pull the package in and npm hoists it to the top of docs/node_modules. That
+// makes the failure latent: nothing in docs/ has to change for a dedupe in
+// Astro's tree to move the package down a level and break the build. This check
+// makes the omission fail now instead.
+
+import { readdirSync, statSync, readFileSync } from 'node:fs';
+import { join, extname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { builtinModules } from 'node:module';
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+const SRC = join(ROOT, 'src');
+const EXTENSIONS = new Set(['.ts', '.mts', '.js', '.mjs', '.astro', '.vue']);
+
+const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8'));
+const declared = new Set([
+  ...Object.keys(pkg.dependencies ?? {}),
+  ...Object.keys(pkg.devDependencies ?? {}),
+  ...Object.keys(pkg.peerDependencies ?? {}),
+]);
+
+const builtins = new Set([...builtinModules, ...builtinModules.map((m) => `node:${m}`)]);
+
+function sourceFiles(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...sourceFiles(full));
+    else if (EXTENSIONS.has(extname(entry))) out.push(full);
+  }
+  return out;
+}
+
+// `import x from 's'`, `import 's'`, `export … from 's'`, `import('s')`,
+// `require('s')`. Also catches the type-only forms, which need the package just
+// as much: tsc resolves `import type { Root } from 'hast'` through node_modules.
+const SPECIFIER = /(?:\bfrom|\bimport|\brequire)\s*\(?\s*['"]([^'"\n]+)['"]/g;
+
+function packageName(specifier) {
+  const parts = specifier.split('/');
+  return specifier.startsWith('@') ? parts.slice(0, 2).join('/') : parts[0];
+}
+
+const missing = new Map();
+let seen = 0;
+
+for (const file of sourceFiles(SRC)) {
+  const source = readFileSync(file, 'utf8');
+  for (const [, specifier] of source.matchAll(SPECIFIER)) {
+    // Relative paths, the `~/` src alias, and the `astro:*` / `virtual:*`
+    // module namespaces are not npm packages.
+    if (/^[./~#]/.test(specifier) || specifier.includes(':')) continue;
+    if (builtins.has(specifier)) continue;
+    seen++;
+    const name = packageName(specifier);
+    // A package that ships no runtime code (`hast`, `unist`) is satisfied by
+    // its DefinitelyTyped stub, which TypeScript resolves under the same
+    // specifier. `@scope/name` maps to `@types/scope__name`.
+    const typesName = name.startsWith('@')
+      ? `@types/${name.slice(1).replace('/', '__')}`
+      : `@types/${name}`;
+    if (declared.has(name) || declared.has(typesName)) continue;
+    if (!missing.has(name)) missing.set(name, new Set());
+    missing.get(name).add(file.replace(ROOT, 'docs/'));
+  }
+}
+
+if (missing.size) {
+  console.error(`Undeclared imports in docs/src (${missing.size}):`);
+  for (const [name, files] of [...missing].sort()) {
+    console.error(`  ${name} — ${[...files].sort().join(', ')}`);
+  }
+  console.error('\nAdd them to docs/package.json (types and type-only packages in devDependencies).');
+  process.exit(1);
+}
+
+// A green run must mean imports were actually inspected. Zero means the walk or
+// the regex stopped matching and the check is passing vacuously.
+if (seen === 0) {
+  console.error('Undeclared-import check found NO package imports in docs/src. Failing rather than passing vacuously.');
+  process.exit(1);
+}
+
+console.log(`Undeclared-import check passed: ${seen} package import(s), all declared.`);


### PR DESCRIPTION
`docs/` importeerde vier pakketten die nergens gedeclareerd stonden. Ze kwamen
mee als transitieve dependency van Astro en werden door npm naar de top van
`docs/node_modules` gehoist, dus alles werkte. Verandert die dedupe, dan breekt
de docs-build zonder dat er iets aan `docs/` is veranderd.

- `github-slugger` (waarde-import, `src/lib/rfcs.ts`) → `dependencies`
- `unist-util-visit` (waarde-import, `src/lib/rehype-nldd-code-viewer.ts`) → `dependencies`
- `@types/hast` (als `hast`, alleen types, vier rehype-plugins) → `devDependencies`
- `vfile` (alleen types, `rehype-source-lines.ts` en `rehype-rfc-links.ts`) → `devDependencies`

De versies zijn precies wat er vandaag in de boom zit (2.0.0, 5.1.0, 3.0.4,
6.0.3), dus de lockfile verschuift geen enkele resolutie: de diff bestaat
uitsluitend uit de vier nieuwe declaraties. `npm run build` in `docs/` draait
schoon.

`docs/scripts/check-declared-imports.mjs` bewaakt dit van nu af aan. Hij loopt
`docs/src` af, haalt de bare specifiers eruit (ook de type-only vorm, want tsc
resolvet `import type … from 'hast'` net zo goed via node_modules) en vergelijkt
met `docs/package.json`. Hij hangt vooraan de a11y-gate, die al op elke
docs-wijziging draait, en faalt op deze branch zonder de vier declaraties met
precies die vier namen.

De andere JS-bomen (`frontend/`, `frontend-lawmaking/`,
`packages/frontend-shared/`, `script/`, `bdd/`) zijn nagelopen en hebben geen
enkele ongedeclareerde import.
