### PR TITLE
docs: rebase alleen de eerstvolgende PR, op verse origin/main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,25 @@ When using git worktrees, create them **inside the project folder** (e.g., `.wor
 git worktree add .worktrees/feature-branch feature-branch
 ```
 
+### Rebasing open PRs
+
+Branch protection on `main` runs with `strict: true`: a PR that is behind cannot
+merge, no matter how green its checks are. Every merge invalidates the checks of
+every other open PR.
+
+So rebase **one** PR at a time, the one that is merged next, right after the
+previous merge landed. Leave the rest alone. Rebasing ten branches at once
+queues dozens of runs that can never lead to a merge, and the PR at the front of
+the line ends up waiting behind them for a runner.
+
+Always fetch first and rebase onto `origin/main` — a local `main` ref is
+usually stale, and the rebase then quietly produces a branch that is still
+behind. Verify before pushing:
+
+```bash
+gh api repos/MinBZK/regelrecht/compare/main...<branch> --jq .behind_by   # must be 0
+```
+
 ## Architecture Notes
 
 ### Law Format


### PR DESCRIPTION
Branch protection op main draait met `strict: true`, dus een PR die achterloopt kan niet mergen hoe groen hij ook is, en elke merge maakt de checks van alle andere open PR's ongeldig. Dat stond nergens opgeschreven, met als gevolg dat een merge-trein tien branches tegelijk rebasete op een main van een uur oud: dertig runs in de wachtrij die geen van alle tot een merge konden leiden, en de kop-PR die daarachter op een runner stond te wachten.

CLAUDE.md legt nu vast dat je één PR tegelijk rebaset, degene die als volgende gemerged wordt, direct na de vorige merge. Met de fetch op `origin/main` erbij en `compare/main...<branch> --jq .behind_by` als controle voor de push, want een lokale main-ref is meestal oud en `git log origin/main..HEAD` verbergt juist de commits die je mist.