### PR TITLE
fix(deps): dompurify naar 3.4.13 tegen GHSA-55q2-fjhq-7xh7

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -5399,9 +5399,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,7 @@
     "@vue-flow/controls": "^1.1.3",
     "@vue-flow/core": "^1.48.2",
     "@vue-flow/minimap": "^1.5.4",
-    "dompurify": "^3.4.10",
+    "dompurify": "^3.4.13",
     "echarts": "^6.1.0",
     "js-yaml": "^5.2.2",
     "marked": "^18.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@vue-flow/controls": "^1.1.3",
         "@vue-flow/core": "^1.48.2",
         "@vue-flow/minimap": "^1.5.4",
-        "dompurify": "^3.4.10",
+        "dompurify": "^3.4.13",
         "echarts": "^6.1.0",
         "js-yaml": "^5.2.2",
         "marked": "^18.0.5",
@@ -2500,9 +2500,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"


### PR DESCRIPTION
`npm audit` valt sinds vandaag over GHSA-55q2-fjhq-7xh7: in dompurify tot en met 3.4.12 laat het verwijderen van een IN_PLACE-hook een losgekoppelde subtree uitvoerbaar achter, wat XSS mogelijk maakt. De verplichte Security Audit-stap kapt daarop af, dus op dit moment komt geen enkele openstaande PR nog door de merge-poort.

3.4.13 valt binnen de bestaande range `^3.4.10`, dus de fix is een lockfile-verversing. `frontend/package.json` gaat mee naar `^3.4.13` zodat de ondergrens de kwetsbare versies uitsluit.

De docs hebben een eigen lockfile en krijgen dompurify transitief via mermaid. Die valt buiten de audit-stap in `just audit`, maar droeg dezelfde 3.4.12, dus die lockfile gaat in dezelfde beweging mee.

Verder niets: geen brede `npm audit fix`, geen andere pakketten.