### PR TITLE
ci: een preview draait alleen als iemand erom vraagt

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    types: [opened, synchronize, reopened, closed, labeled]
+    types: [opened, synchronize, reopened, closed, labeled, unlabeled]
 
 permissions: {}
 
@@ -14,16 +14,28 @@ env:
   ZAD_PROJECT: regel-k4c
 
 jobs:
-  # De fork-voorwaarde schakelt via `needs: changes` de hele build- en
-  # deploy-keten uit. Een fork-PR krijgt geen secrets en een read-only
-  # GITHUB_TOKEN, dus de push naar GHCR faalt daar per definitie.
+  # Deze job is de poort van de hele keten: alles wat bouwt of deployt hangt er
+  # via `needs: changes` aan, dus wat hier niet doorkomt kost geen runner.
+  #
+  # Een PR bouwt alleen met het label `preview` erop. Getoetst op aanwezigheid
+  # van het label, niet op het soort gebeurtenis, zodat dezelfde regel geldt bij
+  # openen, bij elke volgende commit en op het moment dat het label erbij komt.
+  # Bij `unlabeled` bouwt de keten nooit; dat event bestaat hier alleen om
+  # cleanup-preview af te trappen.
+  #
+  # Een fork-PR krijgt geen secrets en een read-only GITHUB_TOKEN, dus de push
+  # naar GHCR faalt daar per definitie.
   changes:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: >-
       github.event.action != 'closed' &&
+      github.event.action != 'unlabeled' &&
       github.event.pull_request.head.repo.fork != true &&
-      (github.event.action != 'labeled' || startsWith(github.event.label.name, 'deploy:'))
+      (
+        github.event_name == 'push' ||
+        contains(github.event.pull_request.labels.*.name, 'preview')
+      )
     permissions:
       contents: read
     outputs:
@@ -398,11 +410,20 @@ jobs:
   cleanup-preview:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Het label eraf halen ruimt op, net als het sluiten van de PR: een preview
+    # waar niemand meer naar kijkt hoort niet te blijven draaien. Sluiten ruimt
+    # ook op zonder dat het label er ooit op zat, want dan valt er niets te
+    # verwijderen en prunet deze job alsnog de verweesde sha-images.
+    #
     # Een fork-PR heeft nooit gebouwd of gedeployd, dus er valt niets op te
     # ruimen en de GHCR-aanroepen zouden alleen maar op rechten stuklopen.
     if: >-
-      github.event_name == 'pull_request' && github.event.action == 'closed' &&
-      github.event.pull_request.head.repo.fork != true
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.fork != true &&
+      (
+        github.event.action == 'closed' ||
+        (github.event.action == 'unlabeled' && github.event.label.name == 'preview')
+      )
     permissions:
       packages: write
       deployments: write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,9 +325,31 @@ decides green versus red; the tests run as a pre-commit hook.
 
 ### How It Works
 
-1. **PR opened/updated**: Builds changed Docker images, pushes to GHCR, deploys `prN` to ZAD
-2. **PR closed**: Deletes ZAD deployment and GHCR images
+1. **PR carrying the `preview` label, opened or pushed to**: Builds changed Docker images, pushes to GHCR, deploys `prN` to ZAD
+2. **`preview` label removed, or PR closed**: Deletes ZAD deployment and GHCR images
 3. **Push to main**: Deploys `regelrecht` (production) to ZAD
+
+### Previews are opt-in
+
+A pull request builds and deploys nothing unless someone puts the **`preview`**
+label on it. Seven images plus a preview environment per PR was about half of
+the repository's runner consumption, and it held up no merge: none of those
+checks is required and nothing tests against the preview (`E2E (mocked)` runs
+against mocks). The budget goes to the merge train; a preview is a choice
+someone makes.
+
+Put the label on and the build starts from that moment, however old the PR is.
+Every following commit rebuilds as long as the label is there. Take the label
+off and `cleanup-preview` runs, exactly as it does when the PR closes — no
+preview keeps running that nobody is looking at.
+
+The gate is the *presence* of the label on the PR, checked on every event, not
+the kind of event. The `deploy:<component>` labels are a separate, additive
+thing: they force a component to build that the change-detection did not flag,
+and they do nothing on a PR without `preview`.
+
+Fork PRs stay out of the chain regardless of labels; they have no secrets and a
+read-only `GITHUB_TOKEN`, so the push to GHCR could never succeed.
 
 ### Debugging deploy-preview failures
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ editor sessions; they are not meant to be read directly.
 
 The pipeline API and the harvester and enrich workers deploy alongside these but have no web UI of their own.
 
-PR preview environments are deployed automatically and cleaned up when the PR is closed.
+A PR gets a preview environment once it carries the `preview` label; taking the label off, or closing the PR, cleans it up again.
 
 ## Getting started
 

--- a/docs/src/content/docs/components/frontend.md
+++ b/docs/src/content/docs/components/frontend.md
@@ -108,7 +108,7 @@ just dev             # Starts everything with hot reload
 The editor ships as a single Docker image (`regelrecht-editor`) that bundles the built Vue frontend together with the [editor-api](./editor-api) Rust binary, which serves the static assets and the REST API. It is deployed to RIG/ZAD:
 
 - **Production**: `editor.regelrecht.rijks.app`
-- **PR previews**: automatically deployed for each pull request
+- **PR previews**: deployed for a pull request that carries the `preview` label
 
 ## Admin Dashboard
 

--- a/docs/src/content/docs/operations/adding-a-law.md
+++ b/docs/src/content/docs/operations/adding-a-law.md
@@ -74,7 +74,7 @@ just bdd
 
 ## Step 6: Open a pull request
 
-Commit the new law file, any BDD scenarios, and open a PR. CI will run schema validation, BDD tests, and all other checks automatically. A preview deployment lets reviewers try the law in the editor.
+Commit the new law file, any BDD scenarios, and open a PR. CI will run schema validation, BDD tests, and all other checks automatically. Add the `preview` label to the PR if reviewers should be able to try the law in a running editor.
 
 ## Further reading
 

--- a/docs/src/content/docs/operations/contributing.md
+++ b/docs/src/content/docs/operations/contributing.md
@@ -51,7 +51,7 @@ Do not bypass hooks with `--no-verify`. If a hook fails, fix the underlying prob
 
 1. Create a feature branch and push your changes
 2. Open a PR - CI runs all relevant checks automatically
-3. A preview deployment is created (see [Deployment](./deployment))
+3. Add the `preview` label if reviewers need a running preview (see [Deployment](./deployment))
 4. Get a code review
 5. Merge to main - production deploys automatically
 

--- a/docs/src/content/docs/operations/deployment.md
+++ b/docs/src/content/docs/operations/deployment.md
@@ -9,14 +9,16 @@ All components are deployed to ZAD (RIG/Quattro/rijksapps) via GitHub Actions. D
 
 ### On pull request
 
-When a PR is opened or updated:
+A PR only builds and deploys when it carries the `preview` label. Without that label nothing is built, because a preview costs about half of the repository's runner budget and no required check depends on it. Add the label and the build starts, whether the PR was opened a minute or a month ago:
 
 1. Changed components are detected automatically
 2. Docker images are built and pushed to `ghcr.io/minbzk/regelrecht-{component}:sha-{commit}`
 3. A preview deployment named `pr{N}` is created on ZAD
 4. The PR gets a comment with preview URLs
 
-Only changed components are rebuilt. Any component can also be forced to build by adding its `deploy:<component>` label to the PR (for example `deploy:editor`).
+Every later commit on a labelled PR repeats this. Remove the label and the preview and its images are cleaned up.
+
+Only changed components are rebuilt. Any component can also be forced to build by adding its `deploy:<component>` label to the PR (for example `deploy:editor`); those labels are additive and do nothing on their own, since `preview` is what opens the gate.
 
 ### On merge to main
 
@@ -26,7 +28,7 @@ When a PR merges to main, production deployment runs:
 2. Components are deployed to the `regelrecht` deployment on ZAD
 3. Production URLs update within minutes
 
-### On PR close
+### On PR close, or when the label is removed
 
 The preview deployment and its GHCR images are cleaned up automatically.
 


### PR DESCRIPTION
Elke pull request bouwde zeven docker-images en zette daarna een preview-omgeving neer. Dat is ongeveer de helft van al het runnerverbruik van de repo en het houdt geen merge tegen: geen van die jobs is een verplichte check, en er test niets tegen de preview. Voortaan gebeurt dat alleen nog met het label `preview` op de PR. De poort zit op de `changes`-job, waar de hele bouw- en deployketen via `needs` aan hangt. `cleanup-preview` gaat nu ook af als iemand het label eraf haalt, zodat een PR geen draaiende preview achterlaat, en `deploy-production` is ongemoeid.

Ik heb één vast label genomen in plaats van het bestaande `deploy:`-prefix. Expressies in GitHub Actions kennen geen prefix-toets over een lijst, en `deploy:<component>` betekent al "bouw dit onderdeel ook al is het niet gewijzigd". Verder heb ik het label aangemaakt en de teksten bijgewerkt die zeiden dat elke PR een preview krijgt.