### PR TITLE
docs: laat één echte uitvoering van de pijplijn zien

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -670,6 +670,11 @@ docs-preview:
 docs-a11y:
     cd docs && npm run a11y
 
+# Meet de CI-doorlooptijd opnieuw; vervang het ciWorkflows-blok in
+# docs/src/lib/ci-pipeline.ts door de uitvoer (zie /operations/ci-doorlooptijd)
+meet-ci:
+    ./script/meet-ci.sh
+
 # --- Architecture model ---
 
 # Generate the code-derived architecture model

--- a/Justfile
+++ b/Justfile
@@ -670,10 +670,10 @@ docs-preview:
 docs-a11y:
     cd docs && npm run a11y
 
-# Meet de CI-doorlooptijd opnieuw; vervang het ciWorkflows-blok in
+# Haal één CI-uitvoering op (leeg = nieuwste groene commit); vervang de blokken in
 # docs/src/lib/ci-pipeline.ts door de uitvoer (zie /operations/ci-doorlooptijd)
-meet-ci:
-    ./script/meet-ci.sh
+meet-ci sha="":
+    ./script/meet-ci.sh {{sha}}
 
 # --- Architecture model ---
 

--- a/Justfile
+++ b/Justfile
@@ -672,8 +672,8 @@ docs-a11y:
 
 # Haal één CI-uitvoering op (leeg = nieuwste groene commit); vervang de blokken in
 # docs/src/lib/ci-pipeline.ts door de uitvoer (zie /operations/ci-doorlooptijd)
-meet-ci sha="":
-    ./script/meet-ci.sh {{sha}}
+measure-ci sha="":
+    ./script/measure-ci.sh {{sha}}
 
 # --- Architecture model ---
 

--- a/docs/src/components/CiGantt.astro
+++ b/docs/src/components/CiGantt.astro
@@ -1,0 +1,314 @@
+---
+/*
+ * Gantt van één pull request: per job een gestreepte balk voor wachten en een
+ * volle balk voor werken. Alles staat na de build in de HTML: de posities zijn
+ * inline percentages, berekend hier in de frontmatter. Er hoort geen
+ * client-side JavaScript bij; de docs draaien richting een CSP zonder
+ * `script-src unsafe-inline`.
+ */
+import {
+  ciWorkflows,
+  ciScaleMinutes,
+  ciTickMinutes,
+  nlNumber,
+} from '~/lib/ci-pipeline';
+
+const ticks: number[] = [];
+for (let m = 0; m <= ciScaleMinutes; m += ciTickMinutes) ticks.push(m);
+
+const pct = (minutes: number) => `${(minutes / ciScaleMinutes) * 100}%`;
+
+// Een job van een paar seconden zou anders als onzichtbare streep renderen.
+const minimumBar = 0.18;
+
+const rows = ciWorkflows.map((wf) => ({
+  ...wf,
+  jobs: wf.jobs.map((job) => {
+    const work = Math.max(job.work, minimumBar);
+    const roles = [
+      job.required ? 'verplicht voor de merge' : null,
+      job.gate ? 'poort die op andere jobs wacht' : null,
+    ].filter(Boolean);
+    return {
+      ...job,
+      waitLeft: '0',
+      waitWidth: pct(job.wait),
+      workLeft: pct(job.wait),
+      workWidth: pct(work),
+      numberLeft: pct(job.wait + work),
+      description:
+        `wacht ${nlNumber(job.wait)} minuten, draait ${nlNumber(job.work)} minuten` +
+        (roles.length ? `, ${roles.join(', ')}` : ''),
+    };
+  }),
+}));
+---
+
+<figure class="rr-gantt" data-width="full">
+  <ul class="rr-gantt-legend">
+    <li><span class="rr-gantt-swatch is-wait"></span>wachten op een runner</li>
+    <li><span class="rr-gantt-swatch is-work"></span>draaiend, niet verplicht</li>
+    <li>
+      <span class="rr-gantt-swatch is-required"></span>verplicht voor de merge
+      (<span aria-hidden="true">&#9679;</span>)
+    </li>
+    <li>
+      <span class="rr-gantt-swatch is-gate"></span>poort die op anderen wacht
+      (<span aria-hidden="true">&#9670;</span>)
+    </li>
+  </ul>
+
+  <div class="rr-gantt-scroll" tabindex="0" role="group" aria-label="Gantt van de jobs per workflow">
+    <div class="rr-gantt-inner">
+      <div class="rr-gantt-axis" aria-hidden="true">
+        {
+          ticks.map((m) => (
+            <>
+              <span class="rr-gantt-grid" style={`left: ${pct(m)}`} />
+              <span class="rr-gantt-tick" style={`left: ${pct(m)}`}>
+                {m === 0 ? '0 min' : m}
+              </span>
+            </>
+          ))
+        }
+      </div>
+
+      {
+        rows.map((wf) => (
+          <section class="rr-gantt-group">
+            <h3 class="rr-gantt-group-head">
+              <span class="rr-gantt-group-name">{wf.name}</span>
+              {wf.total !== null && (
+                <span class="rr-gantt-group-total">
+                  mediaan {nlNumber(wf.total)} min van aanmaak tot klaar
+                </span>
+              )}
+            </h3>
+            {wf.jobs.map((job) => (
+              <div class="rr-gantt-row">
+                <div class="rr-gantt-label">
+                  {job.required && (
+                    <span class="rr-gantt-mark is-required" aria-hidden="true">
+                      &#9679;
+                    </span>
+                  )}
+                  {job.gate && (
+                    <span class="rr-gantt-mark is-gate" aria-hidden="true">
+                      &#9670;
+                    </span>
+                  )}
+                  {job.name}
+                  <span class="rr-gantt-sr">: {job.description}</span>
+                </div>
+                <div class="rr-gantt-track" aria-hidden="true">
+                  <span
+                    class="rr-gantt-bar is-wait"
+                    style={`left: ${job.waitLeft}; width: ${job.waitWidth}`}
+                  />
+                  <span
+                    class:list={[
+                      'rr-gantt-bar',
+                      'is-work',
+                      job.required && 'is-required',
+                      job.gate && 'is-gate',
+                    ]}
+                    style={`left: ${job.workLeft}; width: ${job.workWidth}`}
+                  />
+                  <span class="rr-gantt-number" style={`left: ${job.numberLeft}`}>
+                    {nlNumber(job.work)}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </section>
+        ))
+      }
+    </div>
+  </div>
+</figure>
+
+<style>
+  /* De enige eigen CSS op deze pagina: er is geen designsysteem-component voor
+     een gantt. Kleuren, ruimtes en typografie komen uit de NLDD-tokens, die
+     light-dark()-paren zijn, dus de grafiek volgt het thema vanzelf.
+     nldd-rich-text geeft figure/ul/li/h3 een eigen font, marge en opsomming;
+     die worden hieronder teruggezet omdat de grafiek geen lopende tekst is. */
+  .rr-gantt {
+    display: flex;
+    flex-direction: column;
+    gap: var(--primitives-space-12);
+    margin: 0;
+    inline-size: 100%;
+    min-inline-size: 0;
+    font: var(--primitives-font-body-sm-regular-snug);
+    color: var(--semantics-content-color);
+  }
+
+  .rr-gantt-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--primitives-space-8) var(--primitives-space-20);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    color: var(--semantics-content-secondary-color);
+  }
+  .rr-gantt-legend li {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--primitives-space-6);
+    margin: 0;
+  }
+
+  .rr-gantt-swatch {
+    inline-size: 26px;
+    block-size: 11px;
+    border-radius: 2px;
+    flex: none;
+  }
+  .rr-gantt-swatch.is-wait,
+  .rr-gantt-bar.is-wait {
+    background: repeating-linear-gradient(
+      135deg,
+      var(--primitives-color-donkergeel-500) 0 3px,
+      transparent 3px 6px
+    );
+    border: 1px solid var(--primitives-color-donkergeel-500);
+  }
+  .rr-gantt-swatch.is-work,
+  .rr-gantt-bar.is-work {
+    background: var(--primitives-color-donkerblauw-500);
+  }
+  .rr-gantt-swatch.is-required,
+  .rr-gantt-bar.is-work.is-required {
+    background: var(--primitives-color-mosgroen-600);
+  }
+  .rr-gantt-swatch.is-gate,
+  .rr-gantt-bar.is-work.is-gate {
+    background: var(--primitives-color-paars-500);
+  }
+
+  /* De grafiek scrollt in zijn eigen venster; de pagina zelf blijft staan.
+     tabindex op de scroller maakt hem met het toetsenbord bereikbaar. */
+  .rr-gantt-scroll {
+    overflow-x: auto;
+    /* Zonder dit duwt de 44rem-brede grafiek de flex-container open en scrollt
+       de pagina zijwaarts mee. */
+    min-inline-size: 0;
+    border: var(--semantics-surfaces-border-width) solid
+      var(--semantics-surfaces-base-border-color);
+    border-radius: var(--semantics-surfaces-corner-radius);
+    padding: var(--primitives-space-16);
+  }
+  .rr-gantt-inner {
+    min-inline-size: 44rem;
+  }
+
+  .rr-gantt-axis {
+    position: relative;
+    block-size: 1.35rem;
+    margin-inline-start: var(--rr-gantt-label-width, 13rem);
+    border-bottom: 1px solid var(--semantics-dividers-color);
+    font: var(--primitives-font-body-xs-regular-snug);
+    color: var(--semantics-content-secondary-color);
+    font-variant-numeric: tabular-nums;
+  }
+  .rr-gantt-tick {
+    position: absolute;
+    top: 0;
+    transform: translateX(-50%);
+  }
+  .rr-gantt-grid {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    inline-size: 1px;
+    background: var(--semantics-dividers-color);
+  }
+
+  .rr-gantt-group {
+    margin-top: var(--primitives-space-20);
+  }
+  .rr-gantt-group-head {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: var(--primitives-space-8);
+    margin: 0 0 var(--primitives-space-6);
+    font: var(--primitives-font-body-sm-bold-snug);
+  }
+  .rr-gantt-group-name {
+    font: var(--primitives-font-body-sm-bold-snug);
+  }
+  .rr-gantt-group-total {
+    font: var(--primitives-font-body-xs-regular-snug);
+    color: var(--semantics-content-secondary-color);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .rr-gantt-row {
+    display: grid;
+    grid-template-columns: var(--rr-gantt-label-width, 13rem) 1fr;
+    align-items: center;
+    block-size: 1.85rem;
+  }
+  .rr-gantt-label {
+    padding-inline-end: var(--primitives-space-12);
+    text-align: end;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: var(--semantics-content-secondary-color);
+  }
+  .rr-gantt-mark {
+    margin-inline-end: 0.3em;
+  }
+  .rr-gantt-mark.is-required {
+    color: var(--primitives-color-mosgroen-600);
+  }
+  .rr-gantt-mark.is-gate {
+    color: var(--primitives-color-paars-500);
+  }
+
+  .rr-gantt-track {
+    position: relative;
+    block-size: 100%;
+  }
+  .rr-gantt-bar {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    block-size: 13px;
+    border-radius: 2px;
+  }
+  .rr-gantt-bar.is-wait {
+    border-radius: 2px 0 0 2px;
+  }
+  .rr-gantt-number {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    padding-inline-start: var(--primitives-space-6);
+    font: var(--primitives-font-body-xs-regular-snug);
+    color: var(--semantics-content-secondary-color);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+
+  /* De balken zijn aria-hidden; deze tekst geeft dezelfde cijfers aan een
+     schermlezer. */
+  .rr-gantt-sr {
+    position: absolute;
+    inline-size: 1px;
+    block-size: 1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
+
+  @media (max-width: 40rem) {
+    .rr-gantt {
+      --rr-gantt-label-width: 9rem;
+    }
+  }
+</style>

--- a/docs/src/components/CiGantt.astro
+++ b/docs/src/components/CiGantt.astro
@@ -1,64 +1,138 @@
 ---
 /*
- * Gantt van één pull request: per job een gestreepte balk voor wachten en een
- * volle balk voor werken. Alles staat na de build in de HTML: de posities zijn
- * inline percentages, berekend hier in de frontmatter. Er hoort geen
- * client-side JavaScript bij; de docs draaien richting een CSP zonder
- * `script-src unsafe-inline`.
+ * Gantt van één echte uitvoering van de CI. Een balk loopt van de start tot het
+ * einde van de job; de `needs`-relaties zijn pijlen in een SVG-laag over de
+ * rijen heen. Het gestreepte stukje vóór een balk is de tijd dat de job klaar
+ * stond zonder vrije runner: het einde van zijn laatste voorganger tot zijn
+ * eigen start.
+ *
+ * Alles staat na de build in de HTML: de balkposities zijn inline percentages
+ * en de pijlen zijn uitgerekende SVG-paden, allebei berekend hier in de
+ * frontmatter. Er hoort geen client-side JavaScript bij; de docs draaien
+ * richting een CSP zonder `script-src unsafe-inline`.
+ *
+ * De SVG heeft viewBox="0 0 100 <hoogte>" met preserveAspectRatio="none": x is
+ * een percentage van de tijdas en y telt in rijhoogtes. De horizontale rek die
+ * dat oplevert wordt met vector-effect="non-scaling-stroke" van de lijndikte
+ * weggehouden.
  */
 import {
   ciWorkflows,
   ciScaleMinutes,
   ciTickMinutes,
+  ciRowHeight,
+  ciMinimumBar,
   nlNumber,
 } from '~/lib/ci-pipeline';
 
 const ticks: number[] = [];
 for (let m = 0; m <= ciScaleMinutes; m += ciTickMinutes) ticks.push(m);
 
-const pct = (minutes: number) => `${(minutes / ciScaleMinutes) * 100}%`;
+const x = (minutes: number) => (minutes / ciScaleMinutes) * 100;
+const pct = (minutes: number) => `${x(minutes)}%`;
 
-// Een job van een paar seconden zou anders als onzichtbare streep renderen.
-const minimumBar = 0.18;
+// Een gestreept stukje van minder dan drie seconden is geen streep meer.
+const waitThreshold = 0.05;
 
-const rows = ciWorkflows.map((wf) => ({
-  ...wf,
-  jobs: wf.jobs.map((job) => {
-    const work = Math.max(job.work, minimumBar);
-    const roles = [
-      job.required ? 'verplicht voor de merge' : null,
-      job.gate ? 'poort die op andere jobs wacht' : null,
-    ].filter(Boolean);
-    return {
-      ...job,
-      waitLeft: '0',
-      waitWidth: pct(job.wait),
-      workLeft: pct(job.wait),
-      workWidth: pct(work),
-      numberLeft: pct(job.wait + work),
-      description:
-        `wacht ${nlNumber(job.wait)} minuten, draait ${nlNumber(job.work)} minuten` +
-        (roles.length ? `, ${roles.join(', ')}` : ''),
-    };
-  }),
-}));
+const groups = ciWorkflows.map((wf) => {
+  const index = new Map(wf.jobs.map((job, i) => [job.id, i]));
+  const byId = new Map(wf.jobs.map((job) => [job.id, job]));
+  const rowY = (id: string) => (index.get(id) ?? 0) * ciRowHeight + ciRowHeight / 2;
+
+  // Klaarstaan is het einde van de laatste voorganger; zonder voorgangers is
+  // dat het aanmaken van de run.
+  const ready = new Map<string, number>();
+  const predecessors = new Map<string, string[]>();
+  for (const edge of wf.edges) {
+    const from = byId.get(edge.from)!;
+    for (const to of edge.to) {
+      ready.set(to, Math.max(ready.get(to) ?? 0, from.end));
+      predecessors.set(to, [...(predecessors.get(to) ?? []), from.name]);
+    }
+  }
+  const readyAt = (id: string) => ready.get(id) ?? 0;
+
+  const paths: { d: string; arrow: boolean }[] = [];
+  for (const edge of wf.edges) {
+    const ex = x(byId.get(edge.from)!.end);
+    const ey = rowY(edge.from);
+    if (edge.spine) {
+      const lowest = Math.max(...edge.to.map(rowY));
+      paths.push({ d: `M ${ex} ${ey} L ${ex} ${lowest}`, arrow: false });
+      for (const to of edge.to) {
+        paths.push({ d: `M ${ex} ${rowY(to)} L ${x(readyAt(to))} ${rowY(to)}`, arrow: true });
+      }
+    } else {
+      for (const to of edge.to) {
+        const tx = x(readyAt(to));
+        const ty = rowY(to);
+        const knee = Math.max(ex, tx - 0.5);
+        paths.push({
+          d: `M ${ex} ${ey} L ${knee} ${ey} L ${knee} ${ty} L ${tx} ${ty}`,
+          arrow: true,
+        });
+      }
+    }
+  }
+
+  return {
+    name: wf.name,
+    note: wf.note,
+    slug: wf.name.replace(/\W/g, '').toLowerCase(),
+    height: wf.jobs.length * ciRowHeight,
+    paths,
+    jobs: wf.jobs.map((job) => {
+      const work = Math.max(job.end - job.start, ciMinimumBar);
+      const wait = job.start - readyAt(job.id);
+      const showWait = wait > waitThreshold;
+      const preds = predecessors.get(job.id) ?? [];
+      const roles = [
+        job.required ? 'verplicht voor de merge' : null,
+        job.gate ? 'poort die alleen wacht' : null,
+      ].filter(Boolean);
+      return {
+        ...job,
+        showWait,
+        waitLeft: pct(readyAt(job.id)),
+        waitWidth: pct(wait),
+        workLeft: pct(job.start),
+        workWidth: pct(work),
+        numberLeft: pct(job.start + work),
+        duration: nlNumber(job.end - job.start),
+        description:
+          (preds.length ? `wacht op ${preds.join(', ')}, ` : '') +
+          `van ${nlNumber(job.start)} tot ${nlNumber(job.end)} minuten` +
+          (showWait ? `, met ${nlNumber(wait)} minuten wachten op een runner` : '') +
+          (roles.length ? `, ${roles.join(', ')}` : ''),
+      };
+    }),
+  };
+});
 ---
 
 <figure class="rr-gantt" data-width="full">
   <ul class="rr-gantt-legend">
+    <li>
+      <span class="rr-gantt-swatch is-arrow"></span><code>needs</code>
+    </li>
     <li><span class="rr-gantt-swatch is-wait"></span>wachten op een runner</li>
-    <li><span class="rr-gantt-swatch is-work"></span>draaiend, niet verplicht</li>
+    <li><span class="rr-gantt-swatch is-work"></span>werken, niet verplicht</li>
     <li>
       <span class="rr-gantt-swatch is-required"></span>verplicht voor de merge
       (<span aria-hidden="true">&#9679;</span>)
     </li>
     <li>
-      <span class="rr-gantt-swatch is-gate"></span>poort die op anderen wacht
+      <span class="rr-gantt-swatch is-gate"></span>poort die alleen wacht
       (<span aria-hidden="true">&#9670;</span>)
     </li>
   </ul>
 
-  <div class="rr-gantt-scroll" tabindex="0" role="group" aria-label="Gantt van de jobs per workflow">
+  <div
+    class="rr-gantt-scroll"
+    tabindex="0"
+    role="group"
+    aria-label="Gantt van de jobs per workflow"
+  >
     <div class="rr-gantt-inner">
       <div class="rr-gantt-axis" aria-hidden="true">
         {
@@ -74,52 +148,89 @@ const rows = ciWorkflows.map((wf) => ({
       </div>
 
       {
-        rows.map((wf) => (
+        groups.map((wf) => (
           <section class="rr-gantt-group">
             <h3 class="rr-gantt-group-head">
               <span class="rr-gantt-group-name">{wf.name}</span>
-              {wf.total !== null && (
-                <span class="rr-gantt-group-total">
-                  mediaan {nlNumber(wf.total)} min van aanmaak tot klaar
-                </span>
-              )}
+              {wf.note && <span class="rr-gantt-group-note">{wf.note}</span>}
             </h3>
-            {wf.jobs.map((job) => (
-              <div class="rr-gantt-row">
-                <div class="rr-gantt-label">
-                  {job.required && (
-                    <span class="rr-gantt-mark is-required" aria-hidden="true">
-                      &#9679;
-                    </span>
-                  )}
-                  {job.gate && (
-                    <span class="rr-gantt-mark is-gate" aria-hidden="true">
-                      &#9670;
-                    </span>
-                  )}
-                  {job.name}
-                  <span class="rr-gantt-sr">: {job.description}</span>
-                </div>
-                <div class="rr-gantt-track" aria-hidden="true">
-                  <span
-                    class="rr-gantt-bar is-wait"
-                    style={`left: ${job.waitLeft}; width: ${job.waitWidth}`}
-                  />
-                  <span
-                    class:list={[
-                      'rr-gantt-bar',
-                      'is-work',
-                      job.required && 'is-required',
-                      job.gate && 'is-gate',
-                    ]}
-                    style={`left: ${job.workLeft}; width: ${job.workWidth}`}
-                  />
-                  <span class="rr-gantt-number" style={`left: ${job.numberLeft}`}>
-                    {nlNumber(job.work)}
+            <div class="rr-gantt-plot">
+              <div class="rr-gantt-labels">
+                {wf.jobs.map((job) => (
+                  <span class="rr-gantt-label">
+                    {job.required && (
+                      <span class="rr-gantt-mark is-required" aria-hidden="true">
+                        &#9679;
+                      </span>
+                    )}
+                    {job.gate && (
+                      <span class="rr-gantt-mark is-gate" aria-hidden="true">
+                        &#9670;
+                      </span>
+                    )}
+                    {job.name}
+                    <span class="rr-gantt-sr">: {job.description}</span>
                   </span>
-                </div>
+                ))}
               </div>
-            ))}
+              <div class="rr-gantt-tracks" aria-hidden="true">
+                {wf.jobs.map((job) => (
+                  <div class="rr-gantt-row">
+                    {job.showWait && (
+                      <span
+                        class="rr-gantt-bar is-wait"
+                        style={`left: ${job.waitLeft}; width: ${job.waitWidth}`}
+                      />
+                    )}
+                    <span
+                      class:list={[
+                        'rr-gantt-bar',
+                        'is-work',
+                        job.required && 'is-required',
+                        job.gate && 'is-gate',
+                        job.showWait && 'has-lead',
+                      ]}
+                      style={`left: ${job.workLeft}; width: ${job.workWidth}`}
+                    />
+                    <span class="rr-gantt-number" style={`left: ${job.numberLeft}`}>
+                      {job.duration}
+                    </span>
+                  </div>
+                ))}
+                {wf.paths.length > 0 && (
+                  <svg
+                    class="rr-gantt-arrows"
+                    viewBox={`0 0 100 ${wf.height}`}
+                    preserveAspectRatio="none"
+                    focusable="false"
+                  >
+                    <defs>
+                      <marker
+                        id={`rr-gantt-arrow-${wf.slug}`}
+                        viewBox="0 0 6 6"
+                        refX="5"
+                        refY="3"
+                        markerWidth="5"
+                        markerHeight="5"
+                        orient="auto"
+                        markerUnits="strokeWidth"
+                      >
+                        <path class="rr-gantt-arrowhead" d="M0,0 L6,3 L0,6 z" />
+                      </marker>
+                    </defs>
+                    {wf.paths.map((p) => (
+                      <path
+                        class="rr-gantt-arrow"
+                        d={p.d}
+                        marker-end={
+                          p.arrow ? `url(#rr-gantt-arrow-${wf.slug})` : undefined
+                        }
+                      />
+                    ))}
+                  </svg>
+                )}
+              </div>
+            </div>
           </section>
         ))
       }
@@ -134,6 +245,9 @@ const rows = ciWorkflows.map((wf) => ({
      nldd-rich-text geeft figure/ul/li/h3 een eigen font, marge en opsomming;
      die worden hieronder teruggezet omdat de grafiek geen lopende tekst is. */
   .rr-gantt {
+    --rr-gantt-label-width: 15rem;
+    --rr-gantt-row-height: 26px;
+    --rr-gantt-arrow-color: var(--primitives-color-coolgray-300);
     display: flex;
     flex-direction: column;
     gap: var(--primitives-space-12);
@@ -166,6 +280,28 @@ const rows = ciWorkflows.map((wf) => ({
     border-radius: 2px;
     flex: none;
   }
+  /* Pijl-swatch: een lijntje met een driehoekje, opgebouwd uit pseudo-elementen
+     omdat een tweede SVG voor één legenda-item niet loont. */
+  .rr-gantt-swatch.is-arrow {
+    position: relative;
+    border-radius: 0;
+  }
+  .rr-gantt-swatch.is-arrow::before {
+    content: '';
+    position: absolute;
+    inset-inline: 0 4px;
+    top: 5px;
+    block-size: 1px;
+    background: var(--rr-gantt-arrow-color);
+  }
+  .rr-gantt-swatch.is-arrow::after {
+    content: '';
+    position: absolute;
+    inset-inline-end: 0;
+    top: 2.5px;
+    border: 3px solid transparent;
+    border-inline-start-color: var(--rr-gantt-arrow-color);
+  }
   .rr-gantt-swatch.is-wait,
   .rr-gantt-bar.is-wait {
     background: repeating-linear-gradient(
@@ -192,7 +328,7 @@ const rows = ciWorkflows.map((wf) => ({
      tabindex op de scroller maakt hem met het toetsenbord bereikbaar. */
   .rr-gantt-scroll {
     overflow-x: auto;
-    /* Zonder dit duwt de 44rem-brede grafiek de flex-container open en scrollt
+    /* Zonder dit duwt de 52rem-brede grafiek de flex-container open en scrollt
        de pagina zijwaarts mee. */
     min-inline-size: 0;
     border: var(--semantics-surfaces-border-width) solid
@@ -201,13 +337,13 @@ const rows = ciWorkflows.map((wf) => ({
     padding: var(--primitives-space-16);
   }
   .rr-gantt-inner {
-    min-inline-size: 44rem;
+    min-inline-size: 52rem;
   }
 
   .rr-gantt-axis {
     position: relative;
     block-size: 1.35rem;
-    margin-inline-start: var(--rr-gantt-label-width, 13rem);
+    margin-inline-start: var(--rr-gantt-label-width);
     border-bottom: 1px solid var(--semantics-dividers-color);
     font: var(--primitives-font-body-xs-regular-snug);
     color: var(--semantics-content-secondary-color);
@@ -240,25 +376,29 @@ const rows = ciWorkflows.map((wf) => ({
   .rr-gantt-group-name {
     font: var(--primitives-font-body-sm-bold-snug);
   }
-  .rr-gantt-group-total {
+  .rr-gantt-group-note {
     font: var(--primitives-font-body-xs-regular-snug);
     color: var(--semantics-content-secondary-color);
-    font-variant-numeric: tabular-nums;
   }
 
-  .rr-gantt-row {
+  .rr-gantt-plot {
     display: grid;
-    grid-template-columns: var(--rr-gantt-label-width, 13rem) 1fr;
-    align-items: center;
-    block-size: 1.85rem;
+    grid-template-columns: var(--rr-gantt-label-width) 1fr;
+  }
+  .rr-gantt-labels {
+    display: flex;
+    flex-direction: column;
   }
   .rr-gantt-label {
+    block-size: var(--rr-gantt-row-height);
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
     padding-inline-end: var(--primitives-space-12);
-    text-align: end;
+    color: var(--semantics-content-secondary-color);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    color: var(--semantics-content-secondary-color);
   }
   .rr-gantt-mark {
     margin-inline-end: 0.3em;
@@ -270,9 +410,12 @@ const rows = ciWorkflows.map((wf) => ({
     color: var(--primitives-color-paars-500);
   }
 
-  .rr-gantt-track {
+  .rr-gantt-tracks {
     position: relative;
-    block-size: 100%;
+  }
+  .rr-gantt-row {
+    position: relative;
+    block-size: var(--rr-gantt-row-height);
   }
   .rr-gantt-bar {
     position: absolute;
@@ -284,6 +427,9 @@ const rows = ciWorkflows.map((wf) => ({
   .rr-gantt-bar.is-wait {
     border-radius: 2px 0 0 2px;
   }
+  .rr-gantt-bar.is-work.has-lead {
+    border-radius: 0 2px 2px 0;
+  }
   .rr-gantt-number {
     position: absolute;
     top: 50%;
@@ -293,6 +439,27 @@ const rows = ciWorkflows.map((wf) => ({
     color: var(--semantics-content-secondary-color);
     font-variant-numeric: tabular-nums;
     white-space: nowrap;
+  }
+
+  /* De pijlenlaag ligt over de rijen heen. De viewBox rekent in procenten op de
+     x-as en in pixels op de y-as; preserveAspectRatio="none" laat die twee los
+     van elkaar schalen, non-scaling-stroke houdt de lijn 1px. */
+  .rr-gantt-arrows {
+    position: absolute;
+    inset: 0;
+    inline-size: 100%;
+    block-size: 100%;
+    overflow: visible;
+    pointer-events: none;
+  }
+  .rr-gantt-arrow {
+    fill: none;
+    stroke: var(--rr-gantt-arrow-color);
+    stroke-width: 1;
+    vector-effect: non-scaling-stroke;
+  }
+  .rr-gantt-arrowhead {
+    fill: var(--rr-gantt-arrow-color);
   }
 
   /* De balken zijn aria-hidden; deze tekst geeft dezelfde cijfers aan een
@@ -308,7 +475,7 @@ const rows = ciWorkflows.map((wf) => ({
 
   @media (max-width: 40rem) {
     .rr-gantt {
-      --rr-gantt-label-width: 9rem;
+      --rr-gantt-label-width: 10rem;
     }
   }
 </style>

--- a/docs/src/content/docs/operations/ci-doorlooptijd.mdx
+++ b/docs/src/content/docs/operations/ci-doorlooptijd.mdx
@@ -1,86 +1,92 @@
 ---
 title: CI-doorlooptijd bij één pull request
-description: Wat er draait op één pull request, hoe lang elke job wacht en werkt, en waar de doorlooptijd heen gaat.
+description: Wat er draait op één pull request, waar elke job op wacht, en waar de doorlooptijd heen gaat.
 lang: nl
 ---
 
 import CiGantt from '~/components/CiGantt.astro';
 
 Een pull request op MinBZK/regelrecht start drie workflows met samen ruim
-twintig jobs. De mediane doorlooptijd is 12,8 minuten. Iets meer dan de helft
-daarvan is wachten op een runner. Het langst wacht je bovendien op checks die de
-merge helemaal niet tegenhouden.
+twintig jobs. Hieronder staat er één echt gelopen: commit `afa1408c` op PR 1179,
+7 augustus 2026 om 16:14 UTC. CI was klaar op 5,8 minuut; de hele run duurde
+17,6, en die staart hangt aan een preview die de merge niet tegenhoudt.
 
-De grafiek hieronder splitst dat uit per job. Wat er in de CI draait en waarom
-staat in [CI/CD Pipeline](/operations/ci-cd); hier gaat het alleen over de tijd.
+Wat er in de CI draait en waarom staat in
+[CI/CD Pipeline](/operations/ci-cd); hier gaat het alleen over de tijd.
 
 ## Elke job, van aanmaak tot klaar
 
-Elke balk is een mediaan. Het gestreepte deel is wachten, het volle deel is
-werken. De tijd loopt vanaf het aanmaken van de run, dus bij een job met
-`needs` zit de looptijd van zijn voorgangers in het gestreepte deel.
+Nul is het moment waarop de runs zijn aangemaakt. Pijlen zijn `needs`: een balk
+begint niet voordat de pijl bij hem aankomt. Het gestreepte stukje ervoor is de
+tijd dat de job klaar stond zonder vrije runner.
 
 <CiGantt />
 
-## Waar de 12,8 minuten heen gaan
+## Wat deze run laat zien
 
-### 5,7 minuten wachten op een runner
+### 17,6 minuten, waarvan de preview de staart is
 
-De run zelf begint binnen zes seconden, maar dat is de goedkope
-`Detect changes`. De echte jobs staan daarna vier tot acht minuten stil. Het
-kritieke pad is `changes` → `Rust tests` → `Test`: samen 7,1 minuut werk in een
-run die 12,8 minuut duurt. De rest is wachten op capaciteit die je met de hele
-organisatie deelt.
+CI was klaar op 5,8. Daarna liep er nog twaalf minuten door aan iets wat de merge
+niet tegenhoudt: vijf docker-images waarvan `build` er 12,5 minuut over doet, en
+een `deploy-preview` die pas op 13,9 mag beginnen. Twee images bleven deze keer
+achterwege omdat de wijziging hun paden niet raakte, dus de filter in `changes`
+werkt wel.
 
-### 8,0 minuten wachten op checks die niets tegenhouden
+### 4,5 minuten voor het testbeen met de database
 
-De vijf verplichte checks zijn juist de snelle. Wie wacht tot er niets meer
-draait, wacht op E2E, provenance en de docker-builds, en die blokkeren de merge
-niet. Bij vijftien pull requests is dat twee uur.
+`Rust tests (db)` loopt van 1,1 tot 5,6 en houdt de verplichte poort `Test`
+tegen, die er zelf vier seconden over doet. Het andere been is na 3,0 klaar en
+staat dus tweeënhalve minuut te niksen.
 
-### 3,4 minuten door drie deelbouwen die de rest ophouden
+### 1,8 minuut, de langste keer wachten op een runner
 
-`deploy-preview` wacht op zeven build-jobs. Vier van de zeven images zijn na 4,4
-minuut klaar. `enrich-worker` doet er 9,7 over, `harvester-worker` en
-`pipeline-api` 8,2. Zij bepalen wanneer `deploy-preview` mag beginnen, en die
-begint dus pas op 13,9.
+De langste runnerwachttijd in deze run is 1,8 minuut, bij `build-admin`. Verder
+blijft het onder de minuut. De pijplijn is lang door het werk zelf; capaciteit
+speelt hier geen rol.
 
 ## Verplicht en niet verplicht
 
 Branch protection op `main` eist vijf checks en draait met `strict: true`: een
-pull request die achterloopt kan niet mergen, hoe groen hij ook is. `Test` is
-zelf een poort van een paar seconden die wacht op `rust-tests` en
-`frontend-tests`.
+pull request die achterloopt kan niet mergen, hoe groen hij ook is.
 
 | Check | Rol | Duur |
 | --- | --- | --: |
+| Test | verplicht; poort op de testbenen, draait zelf niets | 0,1 |
+| Protect schema versions | verplicht | 0,2 |
+| WASM Build | verplicht | 0,5 |
+| Security Audit | verplicht; geen `needs`, start meteen | 0,7 |
 | Pre-commit | verplicht | 1,1 |
-| Security Audit | verplicht | 0,9 |
-| Protect schema versions | verplicht | 0,4 |
-| WASM Build | verplicht | 6,2 |
-| Test | verplicht, poort op beide testbenen | 0,1 |
-| Rust tests (unit) en (db) | niet verplicht, maar `Test` hangt eraan | 6,9 |
-| Claude review completed | niet verplicht; besluit staat nog open | 6,2 |
-| E2E, provenance, cross-law, a11y | niet verplicht | 0,4 – 6,9 |
-| Build and Deploy | niet verplicht | 12,7 |
+| Rust tests (unit) en (db) | niet verplicht, maar `Test` hangt eraan | 2,5 en 4,5 |
+| E2E (mocked) | niet verplicht; test niet tegen de preview | 2,6 |
+| Claude review completed | niet verplicht; besluit staat nog open | 5,3 |
+| Build and Deploy | niet verplicht | 17,6 |
 
-## Meetwijze
+## Waarom één run en geen gemiddelde
 
-Gemeten op 7 augustus 2026 over 60 afgeronde runs van het type
-`pull_request` op MinBZK/regelrecht. Elk getal is een mediaan. Wachttijd is
-gerekend vanaf het aanmaken van de run, niet vanaf het starten van de job.
-Overgeslagen jobs tellen niet mee. CodeQL draait via de standaardconfiguratie
-van GitHub en zat niet in deze steekproef.
+Een gemiddelde ligt voor de hand en kan hier niet. Medianen per job komen uit
+verschillende uitvoeringen, en zodra je die naast elkaar zet met `needs`-pijlen
+ertussen ontstaat een schema dat nergens zo gelopen heeft: een opvolger die
+eerder begint dan zijn voorganger eindigt. Op medianen eindigde `build` op 19,7
+terwijl `deploy-preview` op 17,4 begon, en die laatste wacht op de eerste.
 
-De cijfers verouderen zodra een workflow verandert. `script/meet-ci.sh` in de
-repo-root meet ze opnieuw via de GitHub-API en schrijft het resultaat in het
-formaat van de dataset:
+De cijfers hierboven zijn dus wat er die ene keer echt gebeurde. Een andere run
+ziet er anders uit; deze is representatief voor de vorm, niet voor elk getal.
+`cleanup-preview` hoort bij een latere run, aangezwengeld door het sluiten van de
+PR, en staat er niet bij. CodeQL draait via de standaardconfiguratie van GitHub
+en liep hier niet mee.
+
+## Bijwerken
+
+`script/meet-ci.sh` in de repo-root haalt één run op (standaard de nieuwste
+volledig geslaagde, of een run bij een commit die je meegeeft), leest de
+`needs`-graaf uit de workflow-bestanden en schrijft het resultaat in het formaat
+van de dataset:
 
 ```bash
 just meet-ci
+just meet-ci afa1408c
 ```
 
-Bijwerken is het `ciWorkflows`-blok in `docs/src/lib/ci-pipeline.ts` vervangen
-door wat het script uitspuugt, en `measuredOn` in datzelfde bestand op de nieuwe
-meetdatum zetten. Astro rendert de grafiek op bouwtijd uit die array; verder is
-er niets aan te passen.
+Vervang de `ciWorkflows`-array in `docs/src/lib/ci-pipeline.ts` door wat het
+script uitspuugt en werk `ciRun` en `ciScaleMinutes` bij. Astro rekent de balken
+en de pijlen op bouwtijd uit die array uit; verder is er niets aan te passen.

--- a/docs/src/content/docs/operations/ci-doorlooptijd.mdx
+++ b/docs/src/content/docs/operations/ci-doorlooptijd.mdx
@@ -77,14 +77,14 @@ en liep hier niet mee.
 
 ## Bijwerken
 
-`script/meet-ci.sh` in de repo-root haalt één run op (standaard de nieuwste
+`script/measure-ci.sh` in de repo-root haalt één run op (standaard de nieuwste
 volledig geslaagde, of een run bij een commit die je meegeeft), leest de
 `needs`-graaf uit de workflow-bestanden en schrijft het resultaat in het formaat
 van de dataset:
 
 ```bash
-just meet-ci
-just meet-ci afa1408c
+just measure-ci
+just measure-ci afa1408c
 ```
 
 Vervang de `ciWorkflows`-array in `docs/src/lib/ci-pipeline.ts` door wat het

--- a/docs/src/content/docs/operations/ci-doorlooptijd.mdx
+++ b/docs/src/content/docs/operations/ci-doorlooptijd.mdx
@@ -1,0 +1,86 @@
+---
+title: CI-doorlooptijd bij één pull request
+description: Wat er draait op één pull request, hoe lang elke job wacht en werkt, en waar de doorlooptijd heen gaat.
+lang: nl
+---
+
+import CiGantt from '~/components/CiGantt.astro';
+
+Een pull request op MinBZK/regelrecht start drie workflows met samen ruim
+twintig jobs. De mediane doorlooptijd is 12,8 minuten. Iets meer dan de helft
+daarvan is wachten op een runner. Het langst wacht je bovendien op checks die de
+merge helemaal niet tegenhouden.
+
+De grafiek hieronder splitst dat uit per job. Wat er in de CI draait en waarom
+staat in [CI/CD Pipeline](/operations/ci-cd); hier gaat het alleen over de tijd.
+
+## Elke job, van aanmaak tot klaar
+
+Elke balk is een mediaan. Het gestreepte deel is wachten, het volle deel is
+werken. De tijd loopt vanaf het aanmaken van de run, dus bij een job met
+`needs` zit de looptijd van zijn voorgangers in het gestreepte deel.
+
+<CiGantt />
+
+## Waar de 12,8 minuten heen gaan
+
+### 5,7 minuten wachten op een runner
+
+De run zelf begint binnen zes seconden, maar dat is de goedkope
+`Detect changes`. De echte jobs staan daarna vier tot acht minuten stil. Het
+kritieke pad is `changes` → `Rust tests` → `Test`: samen 7,1 minuut werk in een
+run die 12,8 minuut duurt. De rest is wachten op capaciteit die je met de hele
+organisatie deelt.
+
+### 8,0 minuten wachten op checks die niets tegenhouden
+
+De vijf verplichte checks zijn juist de snelle. Wie wacht tot er niets meer
+draait, wacht op E2E, provenance en de docker-builds, en die blokkeren de merge
+niet. Bij vijftien pull requests is dat twee uur.
+
+### 3,4 minuten door drie deelbouwen die de rest ophouden
+
+`deploy-preview` wacht op zeven build-jobs. Vier van de zeven images zijn na 4,4
+minuut klaar. `enrich-worker` doet er 9,7 over, `harvester-worker` en
+`pipeline-api` 8,2. Zij bepalen wanneer `deploy-preview` mag beginnen, en die
+begint dus pas op 13,9.
+
+## Verplicht en niet verplicht
+
+Branch protection op `main` eist vijf checks en draait met `strict: true`: een
+pull request die achterloopt kan niet mergen, hoe groen hij ook is. `Test` is
+zelf een poort van een paar seconden die wacht op `rust-tests` en
+`frontend-tests`.
+
+| Check | Rol | Duur |
+| --- | --- | --: |
+| Pre-commit | verplicht | 1,1 |
+| Security Audit | verplicht | 0,9 |
+| Protect schema versions | verplicht | 0,4 |
+| WASM Build | verplicht | 6,2 |
+| Test | verplicht, poort op beide testbenen | 0,1 |
+| Rust tests (unit) en (db) | niet verplicht, maar `Test` hangt eraan | 6,9 |
+| Claude review completed | niet verplicht; besluit staat nog open | 6,2 |
+| E2E, provenance, cross-law, a11y | niet verplicht | 0,4 – 6,9 |
+| Build and Deploy | niet verplicht | 12,7 |
+
+## Meetwijze
+
+Gemeten op 7 augustus 2026 over 60 afgeronde runs van het type
+`pull_request` op MinBZK/regelrecht. Elk getal is een mediaan. Wachttijd is
+gerekend vanaf het aanmaken van de run, niet vanaf het starten van de job.
+Overgeslagen jobs tellen niet mee. CodeQL draait via de standaardconfiguratie
+van GitHub en zat niet in deze steekproef.
+
+De cijfers verouderen zodra een workflow verandert. `script/meet-ci.sh` in de
+repo-root meet ze opnieuw via de GitHub-API en schrijft het resultaat in het
+formaat van de dataset:
+
+```bash
+just meet-ci
+```
+
+Bijwerken is het `ciWorkflows`-blok in `docs/src/lib/ci-pipeline.ts` vervangen
+door wat het script uitspuugt, en `measuredOn` in datzelfde bestand op de nieuwe
+meetdatum zetten. Astro rendert de grafiek op bouwtijd uit die array; verder is
+er niets aan te passen.

--- a/docs/src/lib/ci-pipeline.ts
+++ b/docs/src/lib/ci-pipeline.ts
@@ -5,7 +5,7 @@
  * verschillende runs, en zodra je die naast elkaar zet met `needs`-pijlen
  * ertussen ontstaat een schema dat nergens zo gelopen heeft.
  *
- * `script/meet-ci.sh` in de repo-root haalt een nieuwe run op en spuugt exact
+ * `script/measure-ci.sh` in de repo-root haalt een nieuwe run op en spuugt exact
  * de `ciWorkflows`-array hieronder uit, inclusief de `needs`-graaf waar de
  * pijlen uit getekend worden.
  */

--- a/docs/src/lib/ci-pipeline.ts
+++ b/docs/src/lib/ci-pipeline.ts
@@ -1,0 +1,99 @@
+/*
+ * Meetgegevens achter de CI-doorlooptijdpagina (/operations/ci-doorlooptijd).
+ *
+ * De cijfers verouderen zodra een workflow verandert. `script/meet-ci.sh` in de
+ * repo-root meet ze opnieuw en spuugt exact het `ciWorkflows`-blok hieronder
+ * uit; bijwerken is het script draaien en de array vervangen (en `measuredOn`
+ * meenemen).
+ */
+
+export interface CiJob {
+  /** Jobnaam zoals GitHub hem toont. */
+  name: string;
+  /** Minuten tussen het aanmaken van de run en het starten van deze job. */
+  wait: number;
+  /** Minuten dat de job zelf draait. */
+  work: number;
+  /** Staat als verplichte check in de branch protection van `main`. */
+  required?: boolean;
+  /** Doet zelf niets: wacht via `needs` tot andere jobs klaar zijn. */
+  gate?: boolean;
+}
+
+export interface CiWorkflow {
+  name: string;
+  /** Mediane doorlooptijd van de hele workflow, of null als hij niet als één run loopt. */
+  total: number | null;
+  jobs: CiJob[];
+}
+
+/** Meetmoment en -wijze, zichtbaar op de pagina zodat oude cijfers herkenbaar zijn. */
+export const ciMeasurement = {
+  measuredOn: '7 augustus 2026',
+  sampleSize: 60,
+  repository: 'MinBZK/regelrecht',
+} as const;
+
+/** Bovengrens van de tijdas in minuten; bepaalt de schaal van elke balk. */
+export const ciScaleMinutes = 18;
+
+/** Afstand tussen de labels op de tijdas, in minuten. */
+export const ciTickMinutes = 3;
+
+export const ciWorkflows: CiWorkflow[] = [
+  {
+    name: 'CI',
+    total: 12.8,
+    jobs: [
+      { name: 'Detect changes', wait: 2.9, work: 0.1 },
+      { name: 'Security Audit', wait: 5.1, work: 0.9, required: true },
+      { name: 'Pre-commit', wait: 8.2, work: 1.1, required: true },
+      { name: 'Protect schema versions', wait: 8.2, work: 0.4, required: true },
+      { name: 'WASM Build', wait: 4.7, work: 6.2, required: true },
+      { name: 'Rust tests (unit)', wait: 4.7, work: 6.9 },
+      { name: 'Rust tests (db)', wait: 4.7, work: 6.9 },
+      { name: 'Frontend tests', wait: 8.2, work: 0.5 },
+      { name: 'Test', wait: 15.1, work: 0.1, required: true, gate: true },
+      { name: 'E2E (mocked)', wait: 4.7, work: 6.2 },
+      { name: 'Provenance checks (RFC-013)', wait: 4.7, work: 6.9 },
+      { name: 'Cross-law integrity', wait: 8.2, work: 0.4 },
+      { name: 'Docs accessibility gate', wait: 8.2, work: 0.4 },
+    ],
+  },
+  {
+    name: 'Build and Deploy',
+    total: 12.7,
+    jobs: [
+      { name: 'changes', wait: 6.0, work: 0.3 },
+      { name: 'build', wait: 7.5, work: 4.4 },
+      { name: 'build-admin', wait: 7.5, work: 4.4 },
+      { name: 'build-docs', wait: 7.5, work: 4.4 },
+      { name: 'build-lawmaking', wait: 11.8, work: 4.4 },
+      { name: 'build-harvester-worker', wait: 6.4, work: 8.2 },
+      { name: 'build-pipeline-api', wait: 6.4, work: 8.2 },
+      { name: 'build-enrich-worker', wait: 6.3, work: 9.7 },
+      { name: 'deploy-preview', wait: 13.9, work: 3.6, gate: true },
+    ],
+  },
+  {
+    name: 'Claude Code Review',
+    total: 12.2,
+    jobs: [
+      { name: 'claude-review', wait: 5.5, work: 5.2 },
+      { name: 'Claude review completed', wait: 3.9, work: 6.2, gate: true },
+    ],
+  },
+  {
+    name: 'Overig',
+    total: null,
+    jobs: [
+      { name: 'Validate PR title', wait: 2.9, work: 0.1 },
+      { name: 'Mutation Testing (diff)', wait: 2.5, work: 1.6 },
+    ],
+  },
+];
+
+/** Eén decimaal met een komma, zoals de rest van de Nederlandstalige pagina. */
+export function nlNumber(value: number): string {
+  return value.toFixed(1).replace('.', ',');
+}

--- a/docs/src/lib/ci-pipeline.ts
+++ b/docs/src/lib/ci-pipeline.ts
@@ -1,95 +1,137 @@
 /*
  * Meetgegevens achter de CI-doorlooptijdpagina (/operations/ci-doorlooptijd).
  *
- * De cijfers verouderen zodra een workflow verandert. `script/meet-ci.sh` in de
- * repo-root meet ze opnieuw en spuugt exact het `ciWorkflows`-blok hieronder
- * uit; bijwerken is het script draaien en de array vervangen (en `measuredOn`
- * meenemen).
+ * Dit is één echte uitvoering, geen gemiddelde. Medianen per job komen uit
+ * verschillende runs, en zodra je die naast elkaar zet met `needs`-pijlen
+ * ertussen ontstaat een schema dat nergens zo gelopen heeft.
+ *
+ * `script/meet-ci.sh` in de repo-root haalt een nieuwe run op en spuugt exact
+ * de `ciWorkflows`-array hieronder uit, inclusief de `needs`-graaf waar de
+ * pijlen uit getekend worden.
  */
 
 export interface CiJob {
+  /** Sleutel binnen de workflow; de `edges` verwijzen hiernaar. */
+  id: string;
   /** Jobnaam zoals GitHub hem toont. */
   name: string;
-  /** Minuten tussen het aanmaken van de run en het starten van deze job. */
-  wait: number;
-  /** Minuten dat de job zelf draait. */
-  work: number;
+  /** Minuten na het aanmaken van de run waarop de job startte. */
+  start: number;
+  /** Minuten na het aanmaken van de run waarop de job klaar was. */
+  end: number;
   /** Staat als verplichte check in de branch protection van `main`. */
   required?: boolean;
-  /** Doet zelf niets: wacht via `needs` tot andere jobs klaar zijn. */
+  /** Doet zelf niets: leest alleen de uitkomst van de jobs waar hij op wacht. */
   gate?: boolean;
+}
+
+export interface CiEdge {
+  /** Job-id van de voorganger. */
+  from: string;
+  /** Job-ids die via `needs` op `from` wachten. */
+  to: string[];
+  /**
+   * Fan-out: één voorganger met veel opvolgers wordt als verticale spine met
+   * korte pijlen getekend in plaats van als bundel losse knieën.
+   */
+  spine?: boolean;
 }
 
 export interface CiWorkflow {
   name: string;
-  /** Mediane doorlooptijd van de hele workflow, of null als hij niet als één run loopt. */
-  total: number | null;
+  /** Korte duiding naast de workflownaam, redactioneel. */
+  note?: string;
   jobs: CiJob[];
+  edges: CiEdge[];
 }
 
-/** Meetmoment en -wijze, zichtbaar op de pagina zodat oude cijfers herkenbaar zijn. */
-export const ciMeasurement = {
-  measuredOn: '7 augustus 2026',
-  sampleSize: 60,
+/** Welke uitvoering hier staat. Zichtbaar op de pagina, zodat de plaat naspeelbaar is. */
+export const ciRun = {
+  commit: 'afa1408c',
+  pullRequest: 1179,
+  startedAt: '7 augustus 2026 om 16:14 UTC',
   repository: 'MinBZK/regelrecht',
 } as const;
 
 /** Bovengrens van de tijdas in minuten; bepaalt de schaal van elke balk. */
-export const ciScaleMinutes = 18;
+export const ciScaleMinutes = 18.4;
 
 /** Afstand tussen de labels op de tijdas, in minuten. */
 export const ciTickMinutes = 3;
 
+/** Rijhoogte in pixels; de SVG-laag met de pijlen rekent hierin. */
+export const ciRowHeight = 26;
+
+/** Ondergrens voor een werkbalk, zodat een job van seconden zichtbaar blijft. */
+export const ciMinimumBar = 0.12;
+
 export const ciWorkflows: CiWorkflow[] = [
   {
     name: 'CI',
-    total: 12.8,
+    note: 'klaar op 5,8',
     jobs: [
-      { name: 'Detect changes', wait: 2.9, work: 0.1 },
-      { name: 'Security Audit', wait: 5.1, work: 0.9, required: true },
-      { name: 'Pre-commit', wait: 8.2, work: 1.1, required: true },
-      { name: 'Protect schema versions', wait: 8.2, work: 0.4, required: true },
-      { name: 'WASM Build', wait: 4.7, work: 6.2, required: true },
-      { name: 'Rust tests (unit)', wait: 4.7, work: 6.9 },
-      { name: 'Rust tests (db)', wait: 4.7, work: 6.9 },
-      { name: 'Frontend tests', wait: 8.2, work: 0.5 },
-      { name: 'Test', wait: 15.1, work: 0.1, required: true, gate: true },
-      { name: 'E2E (mocked)', wait: 4.7, work: 6.2 },
-      { name: 'Provenance checks (RFC-013)', wait: 4.7, work: 6.9 },
-      { name: 'Cross-law integrity', wait: 8.2, work: 0.4 },
-      { name: 'Docs accessibility gate', wait: 8.2, work: 0.4 },
+      { id: 'changes', name: 'Detect changes', start: 0.05, end: 0.18 },
+      { id: 'audit', name: 'Security Audit', start: 0.15, end: 0.88, required: true },
+      { id: 'a11y', name: 'Docs accessibility gate', start: 0.27, end: 0.43 },
+      { id: 'schema', name: 'Protect schema versions', start: 0.47, end: 0.62, required: true },
+      { id: 'cross', name: 'Cross-law integrity', start: 0.47, end: 0.68 },
+      { id: 'rsu', name: 'Rust tests (unit)', start: 0.48, end: 2.97 },
+      { id: 'fe', name: 'Frontend tests', start: 0.65, end: 1.15 },
+      { id: 'prov', name: 'Provenance checks (RFC-013)', start: 0.72, end: 0.88 },
+      { id: 'e2e', name: 'E2E (mocked)', start: 0.73, end: 3.32 },
+      { id: 'wasm', name: 'WASM Build', start: 0.93, end: 1.45, required: true },
+      { id: 'pre', name: 'Pre-commit', start: 1.1, end: 2.22, required: true },
+      { id: 'rsd', name: 'Rust tests (db)', start: 1.12, end: 5.63 },
+      { id: 'test', name: 'Test', start: 5.68, end: 5.75, required: true, gate: true },
+    ],
+    edges: [
+      {
+        from: 'changes',
+        to: ['a11y', 'schema', 'cross', 'rsu', 'fe', 'prov', 'e2e', 'wasm', 'pre', 'rsd'],
+        spine: true,
+      },
+      { from: 'rsu', to: ['test'] },
+      { from: 'fe', to: ['test'] },
+      { from: 'rsd', to: ['test'] },
     ],
   },
   {
     name: 'Build and Deploy',
-    total: 12.7,
+    note: 'klaar op 17,6 · niets hiervan is verplicht',
     jobs: [
-      { name: 'changes', wait: 6.0, work: 0.3 },
-      { name: 'build', wait: 7.5, work: 4.4 },
-      { name: 'build-admin', wait: 7.5, work: 4.4 },
-      { name: 'build-docs', wait: 7.5, work: 4.4 },
-      { name: 'build-lawmaking', wait: 11.8, work: 4.4 },
-      { name: 'build-harvester-worker', wait: 6.4, work: 8.2 },
-      { name: 'build-pipeline-api', wait: 6.4, work: 8.2 },
-      { name: 'build-enrich-worker', wait: 6.3, work: 9.7 },
-      { name: 'deploy-preview', wait: 13.9, work: 3.6, gate: true },
+      { id: 'dch', name: 'changes', start: 0.05, end: 0.42 },
+      { id: 'b5', name: 'build-pipeline-api', start: 0.92, end: 10.23 },
+      { id: 'b3', name: 'build-enrich-worker', start: 0.93, end: 11.05 },
+      { id: 'b1', name: 'build', start: 1.18, end: 13.7 },
+      { id: 'b4', name: 'build-harvester-worker', start: 1.72, end: 11.67 },
+      { id: 'b2', name: 'build-admin', start: 2.25, end: 12.32 },
+      { id: 'dp', name: 'deploy-preview', start: 13.9, end: 17.55, gate: true },
+    ],
+    edges: [
+      { from: 'dch', to: ['b5', 'b3', 'b1', 'b4', 'b2'], spine: true },
+      { from: 'b5', to: ['dp'] },
+      { from: 'b3', to: ['dp'] },
+      { from: 'b1', to: ['dp'] },
+      { from: 'b4', to: ['dp'] },
+      { from: 'b2', to: ['dp'] },
     ],
   },
   {
     name: 'Claude Code Review',
-    total: 12.2,
+    note: 'klaar op 5,4',
     jobs: [
-      { name: 'claude-review', wait: 5.5, work: 5.2 },
-      { name: 'Claude review completed', wait: 3.9, work: 6.2, gate: true },
+      { id: 'crc', name: 'Claude review completed', start: 0.13, end: 5.43, gate: true },
+      { id: 'cr', name: 'claude-review', start: 0.32, end: 5.37 },
     ],
+    edges: [],
   },
   {
     name: 'Overig',
-    total: null,
     jobs: [
-      { name: 'Validate PR title', wait: 2.9, work: 0.1 },
-      { name: 'Mutation Testing (diff)', wait: 2.5, work: 1.6 },
+      { id: 'mut', name: 'Mutation Testing (diff)', start: 0.05, end: 0.8 },
+      { id: 'ttl', name: 'Validate PR title', start: 0.17, end: 0.23 },
     ],
+    edges: [],
   },
 ];
 

--- a/docs/src/lib/sidebar.ts
+++ b/docs/src/lib/sidebar.ts
@@ -110,6 +110,7 @@ export const sidebar: Record<string, SidebarGroup[]> = {
       text: 'Deployment',
       items: [
         { text: 'CI/CD Pipeline', link: '/operations/ci-cd' },
+        { text: 'CI-doorlooptijd', link: '/operations/ci-doorlooptijd' },
         { text: 'Deployment', link: '/operations/deployment' },
       ],
     },

--- a/script/measure-ci.sh
+++ b/script/measure-ci.sh
@@ -4,8 +4,8 @@
 # `ciWorkflows`.
 #
 # Bijwerken van de pagina /operations/ci-doorlooptijd:
-#   just meet-ci > /tmp/ci.ts          # nieuwste volledig geslaagde run
-#   just meet-ci afa1408c > /tmp/ci.ts # een specifieke commit
+#   just measure-ci > /tmp/ci.ts          # nieuwste volledig geslaagde run
+#   just measure-ci afa1408c > /tmp/ci.ts # een specifieke commit
 # en dan de drie blokken in docs/src/lib/ci-pipeline.ts vervangen.
 #
 # Eén run en geen gemiddelde: medianen per job komen uit verschillende

--- a/script/meet-ci.sh
+++ b/script/meet-ci.sh
@@ -1,82 +1,166 @@
 #!/usr/bin/env bash
-# Meet de doorlooptijd van de CI op één pull request en spuugt het
-# `ciWorkflows`-blok uit dat docs/src/lib/ci-pipeline.ts verwacht.
+# Haalt één uitvoering van de CI op en spuugt de blokken uit die
+# docs/src/lib/ci-pipeline.ts verwacht: `ciRun`, `ciScaleMinutes` en
+# `ciWorkflows`.
 #
 # Bijwerken van de pagina /operations/ci-doorlooptijd:
-#   just meet-ci > /tmp/ci.ts
-# en dan het `ciWorkflows`-blok in docs/src/lib/ci-pipeline.ts vervangen door
-# de inhoud van dat bestand, plus `measuredOn` op vandaag zetten.
+#   just meet-ci > /tmp/ci.ts          # nieuwste volledig geslaagde run
+#   just meet-ci afa1408c > /tmp/ci.ts # een specifieke commit
+# en dan de drie blokken in docs/src/lib/ci-pipeline.ts vervangen.
 #
-# Meetwijze (moet gelijk blijven aan wat de pagina zegt): medianen over de
-# laatste N afgeronde runs van het type pull_request. Wachttijd is gerekend
-# vanaf het aanmaken van de run, niet vanaf het starten van de job, zodat de
-# looptijd van voorgangers in de wachtbalk zichtbaar blijft. Overgeslagen jobs
-# tellen niet mee.
+# Eén run en geen gemiddelde: medianen per job komen uit verschillende
+# uitvoeringen, en met `needs`-pijlen ertussen levert dat een schema op dat
+# nergens zo gelopen heeft. Nul op de tijdas is het vroegste aanmaakmoment van
+# de runs bij deze commit; `start` en `end` van elke job zijn gerekend vanaf
+# daar. De runnerwachttijd staat er niet in: de pagina leidt hem af uit het
+# einde van de laatste `needs`-voorganger.
+#
+# De jobs-API geeft de `needs`-graaf niet mee, dus die wordt uit de
+# workflow-bestanden gelezen. Zonder die graaf zijn de pijlen niet te tekenen.
+# Matrix-jobs (`name: Rust tests (${{ matrix.leg }})`) worden op patroon
+# gematcht, zodat beide benen bij hun definitie horen.
+#
+# Wat het script niet meelevert is redactioneel: de `note` naast een
+# workflownaam.
 set -euo pipefail
 
+cd "$(dirname "$0")/.."
+
 REPO="${REPO:-MinBZK/regelrecht}"
-RUNS="${RUNS:-60}"
+SHA="${1:-}"
 
 # Workflows met een eigen groep in de grafiek, in deze volgorde. Alles wat hier
 # niet in staat komt onder "Overig" terecht.
 WORKFLOW_GROUPS=("CI" "Build and Deploy" "Claude Code Review")
 
-# Poorten: jobs die zelf niets doen en via `needs` op andere jobs wachten. Dit
-# is een leesbeslissing over de workflow, niet iets wat de API vertelt.
+# Poorten: jobs die zelf niets doen en alleen de uitkomst van andere jobs lezen.
+# Dat is een leesbeslissing over de workflow, niet iets wat de API zegt.
 GATES=("Test" "deploy-preview" "Claude review completed")
 
-for cmd in gh jq; do
+for cmd in gh jq awk; do
     if ! command -v "$cmd" >/dev/null 2>&1; then
         echo "FOUT: $cmd is nodig maar niet geïnstalleerd" >&2
         exit 1
     fi
 done
 
-echo "Runs ophalen van $REPO ..." >&2
-# Pagineren met de hand: `gh api --paginate` haalt alles op wat er is, en dat
-# zijn er duizenden.
-runs_json='[]'
-page=1
-while [ "$(jq 'length' <<<"$runs_json")" -lt "$RUNS" ]; do
-    page_json=$(gh api \
-        "repos/$REPO/actions/runs?event=pull_request&status=completed&per_page=100&page=$page" \
-        --jq '[.workflow_runs[] | {id, name, created_at, updated_at}]')
-    [ "$(jq 'length' <<<"$page_json")" -eq 0 ] && break
-    runs_json=$(jq -s 'add' <<<"$runs_json"$'\n'"$page_json")
-    page=$((page + 1))
-done
-runs_json=$(jq ".[0:$RUNS]" <<<"$runs_json")
+# --- needs-graaf uit de workflow-bestanden ---------------------------------
+# De vorm van een workflow-bestand is vast: een job-sleutel op twee spaties,
+# zijn eigenschappen op vier. Alleen `name` en `needs` zijn hier interessant.
+graph_json=$(
+    for wf in .github/workflows/*.yml .github/workflows/*.yaml; do
+        [ -e "$wf" ] || continue
+        awk -v path="$wf" '
+            function esc(s) { gsub(/\\/, "\\\\", s); gsub(/"/, "\\\"", s); return s }
+            function trim(s) { sub(/^[ \t]+/, "", s); sub(/[ \t\r]+$/, "", s); return s }
+            function unquote(s,   q) {
+                s = trim(s)
+                q = substr(s, 1, 1)
+                if ((q == "\"" || q == "'"'"'") && substr(s, length(s), 1) == q)
+                    s = substr(s, 2, length(s) - 2)
+                return s
+            }
+            function flush(   n, i, parts, v, first) {
+                if (id == "") return
+                printf "{\"path\":\"%s\",\"id\":\"%s\",\"name\":\"%s\",\"needs\":[",
+                       esc(path), esc(id), esc(name == "" ? id : name)
+                n = split(needs, parts, ",")
+                first = 1
+                for (i = 1; i <= n; i++) {
+                    v = unquote(parts[i])
+                    if (v == "") continue
+                    printf "%s\"%s\"", (first ? "" : ","), esc(v)
+                    first = 0
+                }
+                print "]}"
+                id = ""; name = ""; needs = ""
+            }
+            /^jobs:[ \t]*$/ { injobs = 1; next }
+            /^[^ \t#]/ { if (injobs) { flush(); injobs = 0 } }
+            !injobs { next }
+            /^  [A-Za-z0-9_-]+:[ \t]*$/ {
+                flush()
+                id = $0; sub(/^  /, "", id); sub(/:[ \t]*$/, "", id)
+                next
+            }
+            /^    name:/ { s = $0; sub(/^    name:/, "", s); name = unquote(s); next }
+            /^    needs:/ {
+                s = $0; sub(/^    needs:/, "", s); s = trim(s)
+                gsub(/^\[|\]$/, "", s)
+                needs = s
+                next
+            }
+            END { flush() }
+        ' "$wf"
+    done | jq -s '.'
+)
 
-run_count=$(jq 'length' <<<"$runs_json")
-if [ "$run_count" -eq 0 ]; then
-    echo "FOUT: geen afgeronde pull_request-runs gevonden" >&2
+if [ "$(jq 'length' <<<"$graph_json")" -eq 0 ]; then
+    echo "FOUT: geen jobs gevonden in .github/workflows" >&2
     exit 1
 fi
-echo "$run_count runs, jobs ophalen ..." >&2
 
-# Per job één regel JSON. `started_at` van een job is het moment dat de runner
-# hem oppakt; het verschil met `created_at` van de run is dus de wachttijd
-# inclusief de looptijd van alles waar hij via `needs` op wacht.
-jobs_json=$(
-    jq -r '.[] | "\(.id)\t\(.name)\t\(.created_at)"' <<<"$runs_json" |
-        while IFS=$'\t' read -r run_id wf_name created_at; do
+# --- de run kiezen ----------------------------------------------------------
+recent=$(gh api \
+    "repos/$REPO/actions/runs?event=pull_request&status=completed&per_page=100" \
+    --jq '[.workflow_runs[] | {id, name, path, head_sha, conclusion, created_at,
+                               pr: (.pull_requests[0].number // null)}]')
+
+if [ -z "$SHA" ]; then
+    # Nieuwste commit waarvan alle pull_request-runs geslaagd zijn en waar de
+    # drie hoofdworkflows in zitten; anders staan er gaten in de plaat.
+    SHA=$(jq -r --argjson groups "$(printf '%s\n' "${WORKFLOW_GROUPS[@]}" | jq -R . | jq -s '.')" '
+        group_by(.head_sha)
+        | map(select(($groups - [.[].name]) | length == 0))
+        | map(select(all(.[] | select(.name | IN($groups[])); .conclusion == "success")))
+        | sort_by(.[0].created_at)
+        | reverse
+        | .[0][0].head_sha // ""
+    ' <<<"$recent")
+fi
+
+if [ -z "$SHA" ]; then
+    echo "FOUT: geen commit gevonden waar ${WORKFLOW_GROUPS[*]} alle drie geslaagd zijn" >&2
+    exit 1
+fi
+
+# Bij een re-run staan er twee runs van dezelfde workflow op één commit; alleen
+# de nieuwste telt, anders komt elke job dubbel in de plaat.
+runs_json=$(jq --arg sha "$SHA" '
+    [.[] | select(.head_sha | startswith($sha))]
+    | group_by(.name)
+    | map(sort_by(.created_at) | last)
+    | sort_by(.created_at)
+' <<<"$recent")
+if [ "$(jq 'length' <<<"$runs_json")" -eq 0 ]; then
+    echo "FOUT: geen afgeronde pull_request-runs gevonden voor $SHA" >&2
+    exit 1
+fi
+
+failed=$(jq -r '[.[] | select(.conclusion != "success") | .name] | join(", ")' <<<"$runs_json")
+if [ -n "$failed" ]; then
+    echo "LET OP: niet alles is groen bij $SHA ($failed); de plaat toont een run met een rode workflow" >&2
+fi
+
+echo "Run bij $SHA: $(jq -r 'length' <<<"$runs_json") workflows, jobs ophalen ..." >&2
+
+runs_with_jobs=$(
+    jq -r '.[] | "\(.id)\t\(.name)\t\(.path)\t\(.created_at)"' <<<"$runs_json" |
+        while IFS=$'\t' read -r run_id wf_name wf_path created; do
             # </dev/null: zonder dat leest gh de resterende regels van de
             # while-lus op en blijft er één run over.
             gh api --paginate "repos/$REPO/actions/runs/$run_id/jobs?per_page=100" \
-                --jq '.jobs[]' </dev/null |
-                jq -c --arg wf "$wf_name" --arg created "$created_at" '
-                    select(.conclusion != "skipped")
-                    | select(.started_at != null and .completed_at != null)
-                    | { workflow: $wf,
-                        job: .name,
-                        wait: ((.started_at | fromdateiso8601) - ($created | fromdateiso8601)),
-                        work: ((.completed_at | fromdateiso8601) - (.started_at | fromdateiso8601)) }'
+                --jq '[.jobs[] | {name, conclusion, started_at, completed_at}]' </dev/null |
+                jq -c -s --arg wf "$wf_name" --arg path "$wf_path" --arg created "$created" \
+                    '{ workflow: $wf, path: $path, created: $created,
+                       jobs: (add | map(select(.started_at != null and .completed_at != null))) }'
         done | jq -s '.'
 )
 
-# De verplichte checks komen uit de branch protection van main. Die endpoint
-# vereist admin-rechten; zonder die rechten valt het script terug op wat de
-# pagina nu zegt, met een waarschuwing zodat het opvalt.
+# --- verplichte checks ------------------------------------------------------
+# Die staan in de branch protection van main. Dat endpoint vereist
+# admin-rechten; zonder die rechten valt het script terug op wat de pagina nu
+# zegt, met een waarschuwing zodat het opvalt.
 required_json=$(gh api "repos/$REPO/branches/main/protection/required_status_checks" \
     --jq '[.contexts[]]' 2>/dev/null || true)
 if [ -z "$required_json" ]; then
@@ -86,53 +170,95 @@ fi
 
 groups_json=$(printf '%s\n' "${WORKFLOW_GROUPS[@]}" | jq -R . | jq -s '.')
 gates_json=$(printf '%s\n' "${GATES[@]}" | jq -R . | jq -s '.')
+pr_number=$(jq -r '[.[].pr] | map(select(. != null)) | first // "null"' <<<"$runs_json")
 
 # Het jq-programma staat in een quoted heredoc: het bevat zelf enkele
 # aanhalingstekens (de TypeScript-strings die het uitspuugt).
 jq_program=$(cat <<'JQ'
-def median: sort
-    | (length / 2 | floor) as $m
-    | if length == 0 then null
-      elif length % 2 == 1 then .[$m]
-      else (.[$m - 1] + .[$m]) / 2 end;
-def minutes: (. / 60 * 10 | round) / 10;
+def minutes: (if . < 0 then 0 else . end) | (. * 100 | round) / 100;
 def num: tostring | if test("[.]") then . else . + ".0" end;
+def secs: fromdateiso8601;
+def slug: ascii_downcase | gsub("[^a-z0-9]+"; "-") | gsub("^-|-$"; "");
 
-. as $jobs
-| ($jobs | map(.workflow) | unique) as $seen
+# Een jobnaam in een workflow-bestand kan een expressie bevatten
+# (`Rust tests (${{ matrix.leg }})`). Die wordt een wildcard; de rest van de
+# naam wordt letterlijk gematcht.
+def to_regex:
+    gsub("\\$\\{\\{[^}]*\\}\\}"; "")
+    | gsub("(?<c>[.\\[\\]{}()*+?^$|\\\\])"; "\\\(.c)")
+    | gsub(""; ".*")
+    | "^" + . + "$";
+
+($graph | map(. + { regex: (.name | to_regex) })) as $defs
+| ([.[] | .created | secs] | min) as $t0
+
+# Eén regel per job: wanneer hij begon en wanneer hij klaar was.
+| [ .[]
+    | . as $run
+    | ($defs | map(select(.path == $run.path))) as $wfdefs
+    | $run.jobs[]
+    | . as $job
+    | select($job.conclusion != "skipped")
+    | ($wfdefs | map(.regex as $re | select($job.name | test($re))) | first) as $def
+    | { workflow: $run.workflow,
+        id: ($job.name | slug),
+        name: $job.name,
+        defid: ($def.id // $job.name),
+        needs: ($def.needs // []),
+        start: ((($job.started_at | secs) - $t0) / 60 | minutes),
+        end: ((($job.completed_at | secs) - $t0) / 60 | minutes) }
+  ] as $rows
+
+| ($rows | map(.workflow) | unique) as $seen
 | ($groups + (($seen - $groups) | sort)) as $ordered
 | [ $ordered[]
     | . as $wf
-    | ($jobs | map(select(.workflow == $wf))) as $rows
-    | select(($rows | length) > 0)
-    | { workflow: $wf,
-        total: ($runs
-                | map(select(.name == $wf)
-                      | (.updated_at | fromdateiso8601) - (.created_at | fromdateiso8601))
-                | median
-                | if . == null then null else minutes end),
-        jobs: ($rows
-               | group_by(.job)
-               | map({ name: .[0].job,
-                       wait: (map(.wait) | median | minutes),
-                       work: (map(.work) | median | minutes) })
-               | sort_by(.wait)) }
-  ]
+    | ($rows | map(select(.workflow == $wf)) | sort_by(.start)) as $jobs
+    | select(($jobs | length) > 0)
+    | { workflow: $wf, jobs: $jobs } ]
 | ( [ .[] | select(.workflow | IN($groups[])) ]
     + ( [ .[] | select(.workflow | IN($groups[]) | not) | .jobs ]
         | flatten
         | if length == 0 then []
-          else [{ workflow: "Overig", total: null, jobs: sort_by(.wait) }] end ) )
-| "export const ciWorkflows: CiWorkflow[] = [",
-  ( .[]
+          else [{ workflow: "Overig", jobs: sort_by(.start) }] end ) )
+
+# Pijlen: elke `needs`-relatie tussen twee jobs die allebei in deze groep staan.
+# Een voorganger met meer dan drie opvolgers wordt als spine getekend.
+| map(.jobs as $jobs
+      | . + { edges: ( [ $jobs[] as $j
+                         | $j.needs[] as $n
+                         | ($jobs[] | select(.defid == $n)) as $p
+                         | { from: $p.id, to: $j.id } ]
+                       | group_by(.from)
+                       | map({ from: .[0].from, to: map(.to), spine: (length > 3) })) })
+| . as $out
+| ([ $out[].jobs[].end ] | max) as $last
+
+| "export const ciRun = {",
+  "  commit: '\($sha[0:8])',",
+  "  pullRequest: \($pr),",
+  "  startedAt: '\($started)',",
+  "  repository: '\($repo)',",
+  "} as const;",
+  "",
+  "export const ciScaleMinutes = \(($last + 0.85) * 10 | ceil | . / 10 | num);",
+  "",
+  "export const ciWorkflows: CiWorkflow[] = [",
+  ( $out[]
     | "  {",
       "    name: '\(.workflow)',",
-      "    total: \(if .total == null then "null" else (.total | num) end),",
       "    jobs: [",
       ( .jobs[]
-        | "      { name: '\(.name)', wait: \(.wait | num), work: \(.work | num)"
+        | "      { id: '\(.id)', name: '\(.name)', start: \(.start | num), end: \(.end | num)"
           + (if (.name | IN($required[])) then ", required: true" else "" end)
           + (if (.name | IN($gates[])) then ", gate: true" else "" end)
+          + " },"
+      ),
+      "    ],",
+      "    edges: [",
+      ( .edges[]
+        | "      { from: '\(.from)', to: ['\(.to | join("', '"))']"
+          + (if .spine then ", spine: true" else "" end)
           + " },"
       ),
       "    ],",
@@ -142,9 +268,29 @@ def num: tostring | if test("[.]") then . else . + ".0" end;
 JQ
 )
 
+started_at=$(jq -r '[.[].created_at] | min' <<<"$runs_json")
+# Nederlandse maandnaam met de hand: de container heeft geen nl_NL-locale.
+maanden=(januari februari maart april mei juni juli augustus september oktober november december)
+started_human=$(
+    d=$(date -u -d "$started_at" +'%-d') || d=""
+    if [ -n "$d" ]; then
+        m=$(date -u -d "$started_at" +'%-m')
+        printf '%s %s %s om %s UTC' \
+            "$d" "${maanden[$((m - 1))]}" \
+            "$(date -u -d "$started_at" +'%Y')" \
+            "$(date -u -d "$started_at" +'%H:%M')"
+    else
+        printf '%s' "$started_at"
+    fi
+)
+
 jq -r \
-    --argjson runs "$runs_json" \
+    --argjson graph "$graph_json" \
     --argjson groups "$groups_json" \
     --argjson gates "$gates_json" \
     --argjson required "$required_json" \
-    "$jq_program" <<<"$jobs_json"
+    --arg sha "$SHA" \
+    --arg pr "$pr_number" \
+    --arg started "$started_human" \
+    --arg repo "$REPO" \
+    "$jq_program" <<<"$runs_with_jobs"

--- a/script/meet-ci.sh
+++ b/script/meet-ci.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Meet de doorlooptijd van de CI op één pull request en spuugt het
+# `ciWorkflows`-blok uit dat docs/src/lib/ci-pipeline.ts verwacht.
+#
+# Bijwerken van de pagina /operations/ci-doorlooptijd:
+#   just meet-ci > /tmp/ci.ts
+# en dan het `ciWorkflows`-blok in docs/src/lib/ci-pipeline.ts vervangen door
+# de inhoud van dat bestand, plus `measuredOn` op vandaag zetten.
+#
+# Meetwijze (moet gelijk blijven aan wat de pagina zegt): medianen over de
+# laatste N afgeronde runs van het type pull_request. Wachttijd is gerekend
+# vanaf het aanmaken van de run, niet vanaf het starten van de job, zodat de
+# looptijd van voorgangers in de wachtbalk zichtbaar blijft. Overgeslagen jobs
+# tellen niet mee.
+set -euo pipefail
+
+REPO="${REPO:-MinBZK/regelrecht}"
+RUNS="${RUNS:-60}"
+
+# Workflows met een eigen groep in de grafiek, in deze volgorde. Alles wat hier
+# niet in staat komt onder "Overig" terecht.
+WORKFLOW_GROUPS=("CI" "Build and Deploy" "Claude Code Review")
+
+# Poorten: jobs die zelf niets doen en via `needs` op andere jobs wachten. Dit
+# is een leesbeslissing over de workflow, niet iets wat de API vertelt.
+GATES=("Test" "deploy-preview" "Claude review completed")
+
+for cmd in gh jq; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "FOUT: $cmd is nodig maar niet geïnstalleerd" >&2
+        exit 1
+    fi
+done
+
+echo "Runs ophalen van $REPO ..." >&2
+# Pagineren met de hand: `gh api --paginate` haalt alles op wat er is, en dat
+# zijn er duizenden.
+runs_json='[]'
+page=1
+while [ "$(jq 'length' <<<"$runs_json")" -lt "$RUNS" ]; do
+    page_json=$(gh api \
+        "repos/$REPO/actions/runs?event=pull_request&status=completed&per_page=100&page=$page" \
+        --jq '[.workflow_runs[] | {id, name, created_at, updated_at}]')
+    [ "$(jq 'length' <<<"$page_json")" -eq 0 ] && break
+    runs_json=$(jq -s 'add' <<<"$runs_json"$'\n'"$page_json")
+    page=$((page + 1))
+done
+runs_json=$(jq ".[0:$RUNS]" <<<"$runs_json")
+
+run_count=$(jq 'length' <<<"$runs_json")
+if [ "$run_count" -eq 0 ]; then
+    echo "FOUT: geen afgeronde pull_request-runs gevonden" >&2
+    exit 1
+fi
+echo "$run_count runs, jobs ophalen ..." >&2
+
+# Per job één regel JSON. `started_at` van een job is het moment dat de runner
+# hem oppakt; het verschil met `created_at` van de run is dus de wachttijd
+# inclusief de looptijd van alles waar hij via `needs` op wacht.
+jobs_json=$(
+    jq -r '.[] | "\(.id)\t\(.name)\t\(.created_at)"' <<<"$runs_json" |
+        while IFS=$'\t' read -r run_id wf_name created_at; do
+            # </dev/null: zonder dat leest gh de resterende regels van de
+            # while-lus op en blijft er één run over.
+            gh api --paginate "repos/$REPO/actions/runs/$run_id/jobs?per_page=100" \
+                --jq '.jobs[]' </dev/null |
+                jq -c --arg wf "$wf_name" --arg created "$created_at" '
+                    select(.conclusion != "skipped")
+                    | select(.started_at != null and .completed_at != null)
+                    | { workflow: $wf,
+                        job: .name,
+                        wait: ((.started_at | fromdateiso8601) - ($created | fromdateiso8601)),
+                        work: ((.completed_at | fromdateiso8601) - (.started_at | fromdateiso8601)) }'
+        done | jq -s '.'
+)
+
+# De verplichte checks komen uit de branch protection van main. Die endpoint
+# vereist admin-rechten; zonder die rechten valt het script terug op wat de
+# pagina nu zegt, met een waarschuwing zodat het opvalt.
+required_json=$(gh api "repos/$REPO/branches/main/protection/required_status_checks" \
+    --jq '[.contexts[]]' 2>/dev/null || true)
+if [ -z "$required_json" ]; then
+    echo "LET OP: branch protection niet leesbaar (admin-recht nodig); terugval op de bekende lijst" >&2
+    required_json='["Pre-commit","WASM Build","Protect schema versions","Security Audit","Test"]'
+fi
+
+groups_json=$(printf '%s\n' "${WORKFLOW_GROUPS[@]}" | jq -R . | jq -s '.')
+gates_json=$(printf '%s\n' "${GATES[@]}" | jq -R . | jq -s '.')
+
+# Het jq-programma staat in een quoted heredoc: het bevat zelf enkele
+# aanhalingstekens (de TypeScript-strings die het uitspuugt).
+jq_program=$(cat <<'JQ'
+def median: sort
+    | (length / 2 | floor) as $m
+    | if length == 0 then null
+      elif length % 2 == 1 then .[$m]
+      else (.[$m - 1] + .[$m]) / 2 end;
+def minutes: (. / 60 * 10 | round) / 10;
+def num: tostring | if test("[.]") then . else . + ".0" end;
+
+. as $jobs
+| ($jobs | map(.workflow) | unique) as $seen
+| ($groups + (($seen - $groups) | sort)) as $ordered
+| [ $ordered[]
+    | . as $wf
+    | ($jobs | map(select(.workflow == $wf))) as $rows
+    | select(($rows | length) > 0)
+    | { workflow: $wf,
+        total: ($runs
+                | map(select(.name == $wf)
+                      | (.updated_at | fromdateiso8601) - (.created_at | fromdateiso8601))
+                | median
+                | if . == null then null else minutes end),
+        jobs: ($rows
+               | group_by(.job)
+               | map({ name: .[0].job,
+                       wait: (map(.wait) | median | minutes),
+                       work: (map(.work) | median | minutes) })
+               | sort_by(.wait)) }
+  ]
+| ( [ .[] | select(.workflow | IN($groups[])) ]
+    + ( [ .[] | select(.workflow | IN($groups[]) | not) | .jobs ]
+        | flatten
+        | if length == 0 then []
+          else [{ workflow: "Overig", total: null, jobs: sort_by(.wait) }] end ) )
+| "export const ciWorkflows: CiWorkflow[] = [",
+  ( .[]
+    | "  {",
+      "    name: '\(.workflow)',",
+      "    total: \(if .total == null then "null" else (.total | num) end),",
+      "    jobs: [",
+      ( .jobs[]
+        | "      { name: '\(.name)', wait: \(.wait | num), work: \(.work | num)"
+          + (if (.name | IN($required[])) then ", required: true" else "" end)
+          + (if (.name | IN($gates[])) then ", gate: true" else "" end)
+          + " },"
+      ),
+      "    ],",
+      "  },"
+  ),
+  "];"
+JQ
+)
+
+jq -r \
+    --argjson runs "$runs_json" \
+    --argjson groups "$groups_json" \
+    --argjson gates "$gates_json" \
+    --argjson required "$required_json" \
+    "$jq_program" <<<"$jobs_json"


### PR DESCRIPTION
Nieuwe docs-pagina `/operations/ci-doorlooptijd`: een gantt van één echte CI-uitvoering, met de `needs`-relaties als pijlen en per job de runnerwachttijd en de looptijd.

Geen client-side JavaScript; balkposities en SVG-paden worden in de Astro-frontmatter berekend. `just meet-ci [sha]` ververst de dataset.

Eén run in plaats van een gemiddelde, want medianen uit verschillende runs leveren met afhankelijkheden erbij een schema op dat nergens zo gelopen heeft. De pagina is niet in een browser gezien; Chromium start niet in de ontwikkelcontainer.