### PR TITLE
fix: vijf plekken waar twee kopieën uit elkaar waren gelopen

### DIFF
--- a/bdd/codegen/gen-js.mjs
+++ b/bdd/codegen/gen-js.mjs
@@ -73,7 +73,10 @@ const entries = grammar.steps.map((step) => {
     `template: ${templateFn(step)} }`;
 });
 
+const vt = grammar.value_typing ?? {};
 const out = `// @generated from bdd/grammar.yaml by bdd/codegen/gen-js.mjs — do not edit.
+export const VALUE_TYPING = ${JSON.stringify(vt)};
+
 export const GRAMMAR = [
 ${entries.join(',\n')},
 ];

--- a/bdd/conformance/value_typing.feature
+++ b/bdd/conformance/value_typing.feature
@@ -1,0 +1,42 @@
+@tier:core
+Feature: Typing of a parameter value — bdd/grammar.yaml value_typing
+  The language writes the same value three ways: `is "42"`, `is 42`, and a
+  table cell. All three name the same value — the content decides what it is,
+  and the quotes are only there because the language has no bare form for a
+  boolean or a date. An engine that reads the quoted form as text hands the
+  law a String where it compares an Int, and since EQUALS is structural that
+  comparison goes quietly false instead of failing.
+
+  EQUALS is exactly what reports which type actually reached the engine.
+
+  Background:
+    Given the calculation date is "2025-01-01"
+
+  Scenario: A quoted number is a number
+    Given parameter "waarde" is "42"
+    When I evaluate outputs "waarde_is_getal, waarde_is_tekst" of "test_value_typing"
+    Then the execution succeeds
+    Then output "waarde_is_getal" is true
+    Then output "waarde_is_tekst" is false
+
+  Scenario: A bare number is the same number
+    Given parameter "waarde" is 42
+    When I evaluate outputs "waarde_is_getal, waarde_is_tekst" of "test_value_typing"
+    Then the execution succeeds
+    Then output "waarde_is_getal" is true
+    Then output "waarde_is_tekst" is false
+
+  Scenario: A table cell reads the same way
+    Given the following parameters:
+      | waarde | 42 |
+    When I evaluate outputs "waarde_is_getal, waarde_is_tekst" of "test_value_typing"
+    Then the execution succeeds
+    Then output "waarde_is_getal" is true
+    Then output "waarde_is_tekst" is false
+
+  Scenario: A value that is not a number literal stays text
+    Given parameter "waarde" is "GM0384"
+    When I evaluate outputs "waarde_is_getal, waarde_is_tekst" of "test_value_typing"
+    Then the execution succeeds
+    Then output "waarde_is_getal" is false
+    Then output "waarde_is_tekst" is false

--- a/bdd/grammar.yaml
+++ b/bdd/grammar.yaml
@@ -6,6 +6,27 @@ version: 1
 # Quoted-only steps emit Cucumber-expression bindings ({string}); any numeric
 # arg forces a regex binding. See bdd/codegen/.
 
+# What a captured value means once it reaches the engine.
+#
+# The quoted form does not mean "text". `is "42"` and `is 42` name the same
+# value; the content decides what it is, and the quotes are only there because
+# the language has no bare form for a boolean or a date — the editor writes
+# every boolean as `is "true"`. Reading quotes as text would hand the engine a
+# String where the law compares a Bool, and EQUALS is structural, so that
+# comparison silently goes false instead of failing.
+#
+# A data-table cell carries no quoting either, and reads the same way. The cost
+# is that a numeric-looking identifier loses its string form (a leading zero
+# does not survive); which literals this language actually knows is #1172.
+#
+# Codegen carries these three keys into both dispatchers (Rust
+# packages/engine/tests/bdd, JS frontend/src/gherkin), so a change here changes
+# both engines and neither can hold its own opinion. See issue #1160.
+value_typing:
+  quoted: inferred
+  bare: number
+  table_cell: inferred
+
 steps:
   # ---------- core: setup ----------
   - id: set_calculation_date

--- a/corpus/regulation/nl/wet/test_value_typing/2023-01-01.yaml
+++ b/corpus/regulation/nl/wet/test_value_typing/2023-01-01.yaml
@@ -1,0 +1,41 @@
+---
+$schema: >-
+  https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.6/schema/v0.5.6/schema.json
+$id: test_value_typing
+name: Testwet waardetypering
+regulatory_layer: WET
+bwb_id: BWBR9999904
+publication_date: '2023-01-01'
+valid_from: '2023-01-01'
+url: https://example.com/test_value_typing
+
+articles:
+  - number: '1'
+    url: https://example.com/test_value_typing/1
+    text: >-
+      De waarde is een getal indien zij gelijk is aan 42, en tekst indien zij
+      gelijk is aan "42".
+    machine_readable:
+      execution:
+        parameters:
+          - name: waarde
+            type: string
+            required: true
+        output:
+          - name: waarde_is_getal
+            type: boolean
+          - name: waarde_is_tekst
+            type: boolean
+        actions:
+          # EQUALS is structureel: Int(42) en String("42") zijn niet gelijk.
+          # Daarmee verraadt de uitkomst welk type de stap heeft opgeleverd.
+          - output: waarde_is_getal
+            value:
+              operation: EQUALS
+              subject: $waarde
+              value: 42
+          - output: waarde_is_tekst
+            value:
+              operation: EQUALS
+              subject: $waarde
+              value: '42'

--- a/frontend/e2e/corpus-version.js
+++ b/frontend/e2e/corpus-version.js
@@ -1,0 +1,54 @@
+/**
+ * The editor-api's version-selection rule, in JS.
+ *
+ * A mirror of `extract_date_from_path` / `pick_best_version` in
+ * `packages/corpus/src/source_map.rs`. The e2e corpus mock serves laws straight
+ * off disk, so it has to collapse a law's versions exactly as the server does —
+ * otherwise a spec silently tests a version the editor would never be handed.
+ * Keep both sides in step: a change to the Rust rule belongs here too.
+ */
+
+/** Today as YYYY-MM-DD, matching the server's UTC `today_str()`. */
+export function todayIso() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Extract a YYYY-MM-DD date from the FILENAME of a path (the corpus convention
+ * is `…/{law_id}/{valid_from}.yaml`). The body's `publication_date` is a
+ * different fact and deliberately plays no part. Returns null for anything that
+ * isn't a dated `.yaml`.
+ */
+export function extractDateFromPath(path) {
+  const filename = String(path ?? '').split('/').pop();
+  if (!filename.endsWith('.yaml')) return null;
+  const stem = filename.slice(0, -'.yaml'.length);
+  return /^\d{4}-\d{2}-\d{2}$/.test(stem) ? stem : null;
+}
+
+/**
+ * Whether `candidate` should replace `existing`, both as filename dates
+ * (null = undated). A version in force today beats a future one; within either
+ * group the later date wins; a dated file always beats an undated one.
+ */
+export function pickBestVersion(existing, candidate, today) {
+  if (existing == null) return candidate != null;
+  if (candidate == null) return false;
+  const existingInForce = existing <= today;
+  const candidateInForce = candidate <= today;
+  if (existingInForce === candidateInForce) return candidate > existing;
+  return candidateInForce;
+}
+
+/**
+ * Comparator for the `/versions` contract: newest filename date first, undated
+ * entries last (`insert_version`'s `sort_by_cached_key(Reverse(...))`).
+ */
+export function compareVersionsNewestFirst(pathA, pathB) {
+  const a = extractDateFromPath(pathA);
+  const b = extractDateFromPath(pathB);
+  if (a === b) return 0;
+  if (a == null) return 1;
+  if (b == null) return -1;
+  return a < b ? 1 : -1;
+}

--- a/frontend/e2e/corpus-version.js
+++ b/frontend/e2e/corpus-version.js
@@ -8,9 +8,13 @@
  * Keep both sides in step: a change to the Rust rule belongs here too.
  */
 
-/** Today as YYYY-MM-DD, matching the server's UTC `today_str()`. */
+/**
+ * Today as YYYY-MM-DD in Europe/Amsterdam, the one clock the server reads a
+ * calendar date off (`regelrecht_shared::dates`). `toLocaleDateString` with the
+ * `en-CA` locale yields ISO order.
+ */
 export function todayIso() {
-  return new Date().toISOString().slice(0, 10);
+  return new Date().toLocaleDateString('en-CA', { timeZone: 'Europe/Amsterdam' });
 }
 
 /**
@@ -23,7 +27,8 @@ export function extractDateFromPath(path) {
   const filename = String(path ?? '').split('/').pop();
   if (!filename.endsWith('.yaml')) return null;
   const stem = filename.slice(0, -'.yaml'.length);
-  return /^\d{4}-\d{2}-\d{2}$/.test(stem) ? stem : null;
+  if (!/^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/.test(stem)) return null;
+  return stem;
 }
 
 /**

--- a/frontend/e2e/corpus-version.test.js
+++ b/frontend/e2e/corpus-version.test.js
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { extractDateFromPath, pickBestVersion } from './corpus-version.js';
+import { loadCorpus, loadCorpusVersions } from './helpers-corpus.js';
+
+// A law whose filename date and publication_date deliberately disagree: the
+// server keys on the filename, so the two must not be interchangeable here.
+function lawYaml(id, publicationDate) {
+  return `$id: ${id}\nregulatory_layer: WET\npublication_date: '${publicationDate}'\narticles: []\n`;
+}
+
+let root;
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), 'corpus-version-'));
+  const dir = join(root, 'wet', 'test_wet');
+  mkdirSync(dir, { recursive: true });
+  // In force since 2020, superseded on paper by a version that only takes
+  // effect in 2099 — and whose publication_date is the highest of the two.
+  writeFileSync(join(dir, '2020-01-01.yaml'), lawYaml('test_wet', '2019-12-01'));
+  writeFileSync(join(dir, '2099-01-01.yaml'), lawYaml('test_wet', '2098-12-01'));
+
+  const undatedDir = join(root, 'wet', 'ander_wet');
+  mkdirSync(undatedDir, { recursive: true });
+  writeFileSync(join(undatedDir, 'concept.yaml'), lawYaml('ander_wet', '2030-01-01'));
+  writeFileSync(join(undatedDir, '2021-06-01.yaml'), lawYaml('ander_wet', '2001-01-01'));
+});
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('loadCorpus', () => {
+  it('serves the version in force today, not the latest publication_date', () => {
+    const entry = loadCorpus(root, '2025-06-01').get('test_wet');
+    expect(entry.path).toContain('2020-01-01.yaml');
+    expect(entry.content).toContain("publication_date: '2019-12-01'");
+  });
+
+  it('follows today past a future version once it takes effect', () => {
+    expect(loadCorpus(root, '2099-06-01').get('test_wet').path).toContain('2099-01-01.yaml');
+  });
+
+  it('prefers a dated file over an undated one', () => {
+    expect(loadCorpus(root, '2025-06-01').get('ander_wet').path).toContain('2021-06-01.yaml');
+  });
+});
+
+describe('loadCorpusVersions', () => {
+  it('orders by filename date, newest first and undated last', () => {
+    const versions = loadCorpusVersions(root);
+    expect(versions.get('test_wet')).toEqual([
+      lawYaml('test_wet', '2098-12-01'),
+      lawYaml('test_wet', '2019-12-01'),
+    ]);
+    // The undated concept has the highest publication_date of its pair and
+    // still sorts last.
+    expect(versions.get('ander_wet')).toEqual([
+      lawYaml('ander_wet', '2001-01-01'),
+      lawYaml('ander_wet', '2030-01-01'),
+    ]);
+  });
+});
+
+describe('extractDateFromPath', () => {
+  it('reads the date off the filename', () => {
+    expect(extractDateFromPath('/corpus/wet/my_law/2025-01-01.yaml')).toBe('2025-01-01');
+  });
+
+  it('rejects anything that is not a dated yaml filename', () => {
+    expect(extractDateFromPath('/corpus/wet/my_law/concept.yaml')).toBeNull();
+    expect(extractDateFromPath('/corpus/2025-01-01/my_law.yaml')).toBeNull();
+    expect(extractDateFromPath('/corpus/wet/my_law/2025-1-1.yaml')).toBeNull();
+    expect(extractDateFromPath('/corpus/wet/my_law/2025-01-01.yml')).toBeNull();
+  });
+});
+
+describe('pickBestVersion', () => {
+  const today = '2025-06-01';
+
+  it('lets an in-force version beat a future one, in either direction', () => {
+    expect(pickBestVersion('2099-01-01', '2020-01-01', today)).toBe(true);
+    expect(pickBestVersion('2020-01-01', '2099-01-01', today)).toBe(false);
+  });
+
+  it('takes the latest date within one group', () => {
+    expect(pickBestVersion('2020-01-01', '2024-01-01', today)).toBe(true);
+    expect(pickBestVersion('2024-01-01', '2020-01-01', today)).toBe(false);
+    expect(pickBestVersion('2099-01-01', '2100-01-01', today)).toBe(true);
+  });
+
+  it('lets any dated version beat an undated one', () => {
+    expect(pickBestVersion(null, '2099-01-01', today)).toBe(true);
+    expect(pickBestVersion('2020-01-01', null, today)).toBe(false);
+    expect(pickBestVersion(null, null, today)).toBe(false);
+  });
+
+  it('treats a version starting today as in force', () => {
+    expect(pickBestVersion('2099-01-01', today, today)).toBe(true);
+  });
+});

--- a/frontend/e2e/helpers-corpus.js
+++ b/frontend/e2e/helpers-corpus.js
@@ -13,6 +13,7 @@ import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import * as yaml from 'js-yaml';
 import { mockAuthedEditor } from './helpers.js';
+import { compareVersionsNewestFirst, pickBestVersion, todayIso, extractDateFromPath } from './corpus-version.js';
 
 // Corpus law endpoints exist in two shapes: the global read-only
 // `/api/corpus/laws/...` and the authenticated, traject-scoped
@@ -31,20 +32,14 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 export const CORPUS_ROOT = resolve(__dirname, '../../corpus/regulation/nl');
 
 /**
- * Recursively walk a corpus directory and pick one YAML per `$id`,
- * preferring the latest publication date. Returns a Map<lawId,
- * { content, path, pubDate }>.
+ * Recursively walk a corpus directory and pick one YAML per `$id` — the version
+ * the editor-api would serve today, per `SourceMap::pick_best_version`. Returns
+ * a Map<lawId, { content, path }>.
  *
- * NOTE: this picks by `publication_date` (lexicographic compare),
- * whereas the editor-api's `SourceMap::pick_best_version` selects by
- * `valid_from` against today's date. The two will agree as long as
- * each law in the test corpus has only one dated file (the case for
- * wet_op_de_zorgtoeslag today). If a future test fixture introduces multiple
- * dated files for the same `$id`, align this with the server logic
- * to avoid the spec serving a different version than the editor would
- * see in production.
+ * `today` is injectable so a test can pin the "in force now" boundary; it
+ * defaults to the real date, which is what the specs run on.
  */
-export function loadCorpus(rootDir = CORPUS_ROOT) {
+export function loadCorpus(rootDir = CORPUS_ROOT, today = todayIso()) {
   const byId = new Map();
 
   function visit(dir) {
@@ -57,12 +52,13 @@ export function loadCorpus(rootDir = CORPUS_ROOT) {
         const idMatch = content.match(/^\$id:\s*['"]?([^'"\n]+)['"]?$/m);
         if (!idMatch) continue;
         const lawId = idMatch[1].trim();
-        const pubMatch = content.match(/^publication_date:\s*['"]?([^'"\n]+)['"]?$/m);
-        const pubDate = pubMatch ? pubMatch[1].trim() : '';
         const existing = byId.get(lawId);
-        if (!existing || pubDate > existing.pubDate) {
-          byId.set(lawId, { content, path: full, pubDate });
-        }
+        const wins = !existing || pickBestVersion(
+          extractDateFromPath(existing.path),
+          extractDateFromPath(full),
+          today,
+        );
+        if (wins) byId.set(lawId, { content, path: full });
       }
     }
   }
@@ -73,7 +69,8 @@ export function loadCorpus(rootDir = CORPUS_ROOT) {
 
 /**
  * Recursively walk a corpus directory and collect **every** version YAML per
- * `$id` (newest publication_date first). Returns Map<lawId, string[]>.
+ * `$id`, newest filename date first (undated last) — the order the editor-api's
+ * `/versions` endpoint returns. Returns Map<lawId, string[]>.
  *
  * The engine's dependency loader fetches `/corpus/laws/{id}/versions` and loads
  * the whole version set so its date-aware resolver can pick the one in force on
@@ -94,19 +91,16 @@ export function loadCorpusVersions(rootDir = CORPUS_ROOT) {
         const idMatch = content.match(/^\$id:\s*['"]?([^'"\n]+)['"]?$/m);
         if (!idMatch) continue;
         const lawId = idMatch[1].trim();
-        const pubMatch = content.match(/^publication_date:\s*['"]?([^'"\n]+)['"]?$/m);
-        const pubDate = pubMatch ? pubMatch[1].trim() : '';
         const list = byId.get(lawId) ?? [];
-        list.push({ content, pubDate });
+        list.push({ content, path: full });
         byId.set(lawId, list);
       }
     }
   }
 
   visit(rootDir);
-  // Newest-first, matching the editor-api `/versions` contract.
   for (const [id, list] of byId) {
-    list.sort((a, b) => (a.pubDate < b.pubDate ? 1 : a.pubDate > b.pubDate ? -1 : 0));
+    list.sort((a, b) => compareVersionsNewestFirst(a.path, b.path));
     byId.set(id, list.map((e) => e.content));
   }
   return byId;

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -2,6 +2,9 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './e2e',
+  // Only the browser specs. The default pattern also picks up `*.test.js`,
+  // which in `e2e/` are the vitest unit tests of the shared helpers.
+  testMatch: '**/*.spec.js',
   timeout: 30_000,
   retries: process.env.CI ? 1 : 0,
   // Eén worker in CI. De suite leunt op vaste wachttijden in plaats van op

--- a/frontend/src/EditorView.vue
+++ b/frontend/src/EditorView.vue
@@ -44,6 +44,7 @@ import MachineReadable from './components/MachineReadable.vue';
 import MachineEmptyState from './components/MachineEmptyState.vue';
 import ScenarioBuilder from './components/ScenarioBuilder.vue';
 import ExecutionTraceView from './components/ExecutionTraceView.vue';
+import { buildOutputTypeMap } from './utils/articleMapping.js';
 import LawGraphView from './components/LawGraphView.vue';
 
 const { authenticated, oidcConfigured } = useAuth();
@@ -1183,6 +1184,10 @@ const lastScenarioName = ref('');
 // The scenario's entry output (e.g. "is_rechthebbende"). The graph view
 // uses this to pin its "▶ start" marker to the right leaf.
 const lastOutputName = ref(null);
+// Declared units of the opened law's outputs, so the result sheet renders a
+// value as money only when its type_spec says so. Scenarios execute the opened
+// law, so its articles carry the outputs the trace reports.
+const outputTypeMap = computed(() => buildOutputTypeMap(articles.value));
 // Loading state of the last scenario and a bound re-run callback, so the
 // result sheet can show "running…" / an error with a reload action.
 const lastRunning = ref(false);
@@ -3073,6 +3078,7 @@ async function handleActionSave() {
           :error="lastError"
           :running="lastRunning"
           :expectations="lastExpectations"
+          :output-types="outputTypeMap"
           :can-reload="!!lastReload"
           @reload="lastReload && lastReload()"
         />

--- a/frontend/src/components/ExecutionTraceView.vue
+++ b/frontend/src/components/ExecutionTraceView.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { computed } from 'vue';
-import { formatValue, formatOutputValue, formatOutputValueParts, normalizeForCompare, matchStatus as _matchStatus, humanize } from '../utils/outputFormat.js';
+import { formatValue, formatOutputValueParts, normalizeForCompare, matchStatus as _matchStatus, humanize } from '../utils/outputFormat.js';
 
 const props = defineProps({
   /** Execution result with outputs */
@@ -15,12 +15,21 @@ const props = defineProps({
   running: { type: Boolean, default: false },
   /** Whether a re-run action is available */
   canReload: { type: Boolean, default: false },
+  /** Declared output types from buildOutputTypeMap(): name -> { type, unit } */
+  outputTypes: { type: Object, default: null },
 });
 
 const emit = defineEmits(['reload']);
 
 function matchStatus(outputName, actualValue) {
   return _matchStatus(outputName, actualValue, props.expectations);
+}
+
+function outputParts(name) {
+  return formatOutputValueParts(
+    props.result?.outputs?.[name],
+    props.outputTypes?.get(name)?.unit ?? null,
+  );
 }
 
 const hasContent = computed(() =>
@@ -91,8 +100,8 @@ const overallStatus = computed(() => {
             size="md"
             horizontal-alignment="right"
             width="100px"
-            :text="humanize(formatOutputValueParts(result.outputs?.[name], name).text)"
-            :supporting-text="formatOutputValueParts(result.outputs?.[name], name).supportingText"
+            :text="humanize(outputParts(name).text)"
+            :supporting-text="outputParts(name).supportingText"
           ></nldd-text-cell>
           <nldd-spacer-cell size="8"></nldd-spacer-cell>
           <nldd-text-cell

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, computed, watch, onBeforeUnmount, useId } from 'vue';
 import { parseValue } from '../gherkin/steps.js';
-import { formatValue, formatOutputValue, normalizeForCompare, matchStatus as _matchStatus, humanize } from '../utils/outputFormat.js';
+import { formatValue, normalizeForCompare, matchStatus as _matchStatus, humanize } from '../utils/outputFormat.js';
 import DataSourceTable from './DataSourceTable.vue';
 import ScenarioParameterInput from './ScenarioParameterInput.vue';
 

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, computed, watch, onBeforeUnmount, useId } from 'vue';
-import { parseValue } from '../gherkin/steps.js';
+import { quotedValue, tableCellValue } from '../gherkin/actions.js';
 import { formatValue, normalizeForCompare, matchStatus as _matchStatus, humanize } from '../utils/outputFormat.js';
 import DataSourceTable from './DataSourceTable.vue';
 import ScenarioParameterInput from './ScenarioParameterInput.vue';
@@ -181,7 +181,7 @@ function execute() {
         const typed = {};
         for (const [k, v] of Object.entries(row)) {
           if (k === '_id') continue;
-          typed[k] = typeof v === 'string' ? parseValue(v) : v;
+          typed[k] = typeof v === 'string' ? tableCellValue(v) : v;
         }
         return typed;
       });
@@ -189,10 +189,12 @@ function execute() {
     }
 
     // Build parameters
+    // Type each parameter by the grammar's rule, so a live run in the editor
+    // sees the same values the Rust runner reads back from the saved feature.
     const params = {};
     for (const [k, v] of Object.entries(parameterValues.value)) {
       if (v !== '' && v !== null && v !== undefined) {
-        params[k] = typeof v === 'string' ? parseValue(v) : v;
+        params[k] = typeof v === 'string' ? quotedValue(v) : v;
       }
     }
 

--- a/frontend/src/components/graph/TraceStepDetail.vue
+++ b/frontend/src/components/graph/TraceStepDetail.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { computed } from 'vue';
-import { formatValue, formatOutputValue, normalizeForCompare, matchStatus as _matchStatus } from '../../utils/outputFormat.js';
+import { formatValue, normalizeForCompare, matchStatus as _matchStatus } from '../../utils/outputFormat.js';
 
 const props = defineProps({
   step: { type: Object, default: null },
@@ -54,11 +54,14 @@ const expectationEntries = computed(() => Object.entries(props.expectations || {
       </dl>
     </div>
 
+    <!-- Plain values, no currency form: a trace spans every law the run
+         touched, so this panel has no single law's type_spec to read a unit
+         from. Rendering euros here would mean guessing per name again. -->
     <h3 class="step-detail__section-title">Outputs</h3>
     <dl class="step-detail__outputs">
       <div v-for="[k, v] in outputEntries" :key="k" class="step-detail__row">
         <dt>{{ k }}:</dt>
-        <dd class="mono">{{ formatOutputValue(v, k) }}</dd>
+        <dd class="mono">{{ formatValue(v) }}</dd>
       </div>
       <div v-if="outputEntries.length === 0" class="step-detail__empty">Geen outputs</div>
     </dl>

--- a/frontend/src/gherkin/actions.js
+++ b/frontend/src/gherkin/actions.js
@@ -14,6 +14,8 @@
  * has one, a parameter table does not.
  */
 
+import { VALUE_TYPING } from './grammar.generated.js';
+
 /**
  * Parse a string value to a typed value, mirroring Rust value_conversion.rs.
  * - "true"/"false" → boolean
@@ -40,9 +42,39 @@ export function parseValue(str) {
 }
 
 /**
+ * Type a quoted capture. The three `value_typing` rules live in
+ * bdd/grammar.yaml and reach both dispatchers through codegen, so neither
+ * engine can hold its own opinion about what a quote means.
+ */
+export function quotedValue(raw) {
+  switch (VALUE_TYPING.quoted) {
+    case 'literal': return raw;
+    case 'inferred': return parseValue(raw);
+    default:
+      throw new Error(`bdd/grammar.yaml: unknown value_typing.quoted '${VALUE_TYPING.quoted}'`);
+  }
+}
+
+/** Type a bare (unquoted) capture; see [quotedValue] for where the rule lives. */
+export function bareValue(raw) {
+  if (VALUE_TYPING.bare !== 'number') {
+    throw new Error(`bdd/grammar.yaml: unknown value_typing.bare '${VALUE_TYPING.bare}'`);
+  }
+  return Number(raw);
+}
+
+/** Type a data-table cell; see [quotedValue] for where the rule lives. */
+export function tableCellValue(raw) {
+  switch (VALUE_TYPING.table_cell) {
+    case 'inferred': return parseValue(raw);
+    case 'literal': return raw.trim();
+    default:
+      throw new Error(`bdd/grammar.yaml: unknown value_typing.table_cell '${VALUE_TYPING.table_cell}'`);
+  }
+}
+
+/**
  * Parse a data table into record objects using the header row.
- * Values are auto-typed via parseValue() so the engine receives correctly
- * typed numbers, booleans, and nulls.
  *
  * A row that does not match the header row is rejected rather than filled with
  * undefined: today the Gherkin parser already rejects a varying cell count, but
@@ -61,7 +93,7 @@ export function tableToRecords(dataTable) {
     }
     const record = {};
     headers.forEach((h, i) => {
-      record[h] = parseValue(row[i]);
+      record[h] = tableCellValue(row[i]);
     });
     return record;
   });
@@ -123,8 +155,7 @@ export async function dispatch(ctx, engine, action, args, table, { loadDependenc
     }
 
     case 'set_parameter':
-      // String form keeps the raw string (preserves identifiers like BSNs);
-      // numeric form arrives already typed as a Number from the grammar.
+      // Already typed by the grammar's `value_typing` rule in buildArgs.
       ctx.parameters[args[0]] = args[1];
       break;
 
@@ -133,7 +164,7 @@ export async function dispatch(ctx, engine, action, args, table, { loadDependenc
     case 'set_parameters_table':
       for (const row of table || []) {
         if (row.length < 2) continue;
-        ctx.parameters[row[0].trim()] = parseValue(row[1] || '');
+        ctx.parameters[row[0].trim()] = tableCellValue(row[1] || '');
       }
       break;
 

--- a/frontend/src/gherkin/formMapper.js
+++ b/frontend/src/gherkin/formMapper.js
@@ -5,7 +5,7 @@
  * Reverse:  visual form state → formStateToGherkin() → Gherkin text
  */
 
-import { parseValue } from './actions.js';
+import { bareValue, quotedValue, tableCellValue } from './actions.js';
 import { GRAMMAR } from './grammar.generated.js';
 
 // --- Generated grammar lookups (single source of truth for phrasing) ---
@@ -39,7 +39,7 @@ function extractFragment(entry, match, step) {
       return {
         type: 'parameter',
         name: match[1],
-        value: entry.id === 'set_parameter_number' ? parseValue(match[2]) : match[2],
+        value: entry.id === 'set_parameter_number' ? bareValue(match[2]) : quotedValue(match[2]),
       };
     case 'set_parameters_table':
       return { type: 'parameterTable', parameters: tableToParams(step.dataTable) };
@@ -68,7 +68,7 @@ function extractFragment(entry, match, step) {
       };
     case 'assert_equals':
       return entry.id === 'assert_equals_number'
-        ? { type: 'assertion', assertionType: 'equals', outputName: match[1], value: parseValue(match[2]) }
+        ? { type: 'assertion', assertionType: 'equals', outputName: match[1], value: bareValue(match[2]) }
         : { type: 'assertion', assertionType: 'equalsString', outputName: match[1], value: match[2] };
     case 'assert_null':
       return { type: 'assertion', assertionType: 'null', outputName: match[1] };
@@ -87,7 +87,7 @@ function tableToParams(dataTable) {
     .filter((row) => row.length >= 2)
     .map((row) => ({
       name: row[0].trim(),
-      value: parseValue(row[1] || ''),
+      value: tableCellValue(row[1] || ''),
     }));
 }
 
@@ -288,7 +288,10 @@ export function syncEditedValues(formState, scenarioIndex, values) {
   const bgParamMap = new Map(bgParams.map((p) => [p.name, p]));
 
   for (const [name, rawValue] of Object.entries(parameterValues)) {
-    const value = parseValue(rawValue);
+    // Same rule as reading a step: the content decides. An input control hands
+    // back a raw string, and leaving it at that would write `is "50000"` where
+    // the scenario said `is 50000`.
+    const value = quotedValue(rawValue);
 
     if (scenarioParamMap.has(name)) {
       // Update existing scenario-level parameter

--- a/frontend/src/gherkin/formMapper.test.js
+++ b/frontend/src/gherkin/formMapper.test.js
@@ -51,7 +51,7 @@ Feature: With background
     expect(form.background.dependencies).toEqual(['law_a', 'law_b']);
 
     const s = form.scenarios[0];
-    expect(s.setup.parameters).toEqual([{ name: 'bsn', value: '999993653' }]);
+    expect(s.setup.parameters).toEqual([{ name: 'bsn', value: 999993653 }]);
     expect(s.assertions[0]).toEqual({ assertionType: 'boolean', outputName: 'output', value: false });
   });
 
@@ -124,7 +124,7 @@ Feature: Params
     const form = mapFeatureToForm(parsed);
     const params = form.scenarios[0].setup.parameters;
     expect(params).toEqual([
-      { name: 'bsn', value: '999993653' },
+      { name: 'bsn', value: 999993653 },
       { name: 'amount', value: 1500 },
       { name: 'rate', value: 3.14 },
     ]);
@@ -251,7 +251,7 @@ Feature: Merge test
 
     expect(effective.calculationDate).toBe('2025-01-01');
     expect(effective.dependencies).toEqual(['dep_a', 'dep_b']);
-    expect(effective.parameters).toEqual([{ name: 'bsn', value: '123' }]);
+    expect(effective.parameters).toEqual([{ name: 'bsn', value: 123 }]);
   });
 
   it('scenario date overrides background date', () => {
@@ -443,5 +443,46 @@ Feature: Typed values
     );
     expect(parseValue(reparams.is_verzekerde)).toBe(true);
     expect(reparams.inkomen).toBe(150000);
+  });
+});
+
+// The canonical rule (bdd/grammar.yaml `value_typing`) is that the quotes do
+// not change what a value is — the content decides, on both sides of the
+// language. The editor used to keep the quoted form as a raw string, so it ran
+// a scenario with different types than the Rust runner did (#1160). A save may
+// normalise a quoted number to its bare form; what it may not do is leave the
+// two engines reading the same line differently.
+describe('a quoted value carries its content, not its quotes', () => {
+  const feature = `
+Feature: Round trip
+
+  Scenario: Test
+    Given parameter "bsn" is "999993653"
+    Given parameter "is_verzekerde" is "true"
+    Given parameter "gemeente" is "GM0384"
+    When I evaluate "result" of "law"
+`;
+
+  it('reads a quoted value by its content', () => {
+    const form = mapFeatureToForm(parseFeature(feature));
+    const params = Object.fromEntries(
+      form.scenarios[0].setup.parameters.map((p) => [p.name, p.value]),
+    );
+    expect(params.bsn).toBe(999993653);
+    expect(params.is_verzekerde).toBe(true);
+    expect(params.gemeente).toBe('GM0384');
+  });
+
+  it('round-trips every form to the same values', () => {
+    const form = mapFeatureToForm(parseFeature(feature));
+    syncEditedValues(form, 0, {
+      parameterValues: { bsn: '999993653', is_verzekerde: 'true', gemeente: 'GM0384' },
+      calculationDate: null,
+    });
+    const reform = mapFeatureToForm(parseFeature(formStateToGherkin(form)));
+    const params = Object.fromEntries(
+      reform.scenarios[0].setup.parameters.map((p) => [p.name, p.value]),
+    );
+    expect(params).toEqual({ bsn: 999993653, is_verzekerde: true, gemeente: 'GM0384' });
   });
 });

--- a/frontend/src/gherkin/grammar.generated.js
+++ b/frontend/src/gherkin/grammar.generated.js
@@ -1,4 +1,6 @@
 // @generated from bdd/grammar.yaml by bdd/codegen/gen-js.mjs — do not edit.
+export const VALUE_TYPING = {"quoted":"inferred","bare":"number","table_cell":"inferred"};
+
 export const GRAMMAR = [
   { id: "set_calculation_date", action: "set_calculation_date", keyword: "given", tier: "core", datatable: false, pattern: /^the calculation date is "([^"]*)"$/, argTypes: ["string"], literals: [], template: (a) => `the calculation date is "${a[0]}"` },
   { id: "load_law", action: "load_law", keyword: "given", tier: "core", datatable: false, pattern: /^law "([^"]*)" is loaded$/, argTypes: ["string"], literals: [], template: (a) => `law "${a[0]}" is loaded` },

--- a/frontend/src/gherkin/steps.js
+++ b/frontend/src/gherkin/steps.js
@@ -9,16 +9,20 @@
  */
 
 import { GRAMMAR } from './grammar.generated.js';
-import { dispatch } from './actions.js';
+import { dispatch, bareValue, quotedValue } from './actions.js';
 
 /** Tiers the editor's WASM engine can execute. */
 export const SUPPORTED_TIERS = ['core'];
 
-/** Parse a regex match's captures into typed args, then append the grammar literals. */
+/**
+ * Parse a regex match's captures into typed args, then append the grammar
+ * literals. Which capture becomes what is `value_typing` in bdd/grammar.yaml;
+ * the Rust dispatcher reads the same three keys.
+ */
 function buildArgs(entry, match) {
   const args = entry.argTypes.map((t, i) => {
     const raw = match[i + 1];
-    return t === 'number' ? Number(raw) : raw;
+    return t === 'number' ? bareValue(raw) : quotedValue(raw);
   });
   return [...args, ...entry.literals];
 }
@@ -42,5 +46,6 @@ export function createStepDefinitions({ loadDependency }) {
   }));
 }
 
-// Keep the public re-export ScenarioForm.vue relies on (single home in actions.js).
+// parseValue has a single home in actions.js; re-exported for the tests that
+// pin which literals it recognises.
 export { parseValue } from './actions.js';

--- a/frontend/src/gherkin/steps.test.js
+++ b/frontend/src/gherkin/steps.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { parseValue, createStepDefinitions, SUPPORTED_TIERS } from './steps.js';
-import { GRAMMAR } from './grammar.generated.js';
+import { GRAMMAR, VALUE_TYPING } from './grammar.generated.js';
 
 describe('parseValue', () => {
   it('parses booleans', () => {
@@ -109,5 +109,40 @@ describe('set_parameters_table dispatch', () => {
     expect(await runTable([['indieningsdatum', '2025-01-01']])).toEqual({
       indieningsdatum: '2025-01-01',
     });
+  });
+});
+
+// The canonical typing rule lives in bdd/grammar.yaml (`value_typing`) and is
+// carried into both dispatchers by codegen. These assertions are the editor
+// half of bdd/conformance/value_typing.feature: the same three lines, the same
+// three types. Drift here is the failure mode of issue #1160 — a scenario that
+// runs green in the editor and red in CI.
+describe('value typing follows bdd/grammar.yaml', () => {
+  const defs = createStepDefinitions({ loadDependency: async () => {} });
+
+  async function runStep(line, table = null) {
+    const ctx = { parameters: {} };
+    const def = defs.find((d) => d.pattern.test(line));
+    expect(def, `no step matches "${line}"`).toBeTruthy();
+    await def.execute(ctx, null, line.match(def.pattern), table ? { dataTable: table } : null);
+    return ctx.parameters;
+  }
+
+  it('declares the three rules', () => {
+    expect(VALUE_TYPING).toEqual({ quoted: 'inferred', bare: 'number', table_cell: 'inferred' });
+  });
+
+  it('reads a quoted value by its content, not by its quotes', async () => {
+    expect(await runStep('parameter "waarde" is "42"')).toEqual({ waarde: 42 });
+    expect(await runStep('parameter "verzekerd" is "true"')).toEqual({ verzekerd: true });
+    expect(await runStep('parameter "gemeente" is "GM0384"')).toEqual({ gemeente: 'GM0384' });
+  });
+
+  it('reads a bare value as a number', async () => {
+    expect(await runStep('parameter "waarde" is 42')).toEqual({ waarde: 42 });
+  });
+
+  it('lets the content decide in a data table cell', async () => {
+    expect(await runStep('the following parameters:', [['waarde', '42']])).toEqual({ waarde: 42 });
   });
 });

--- a/frontend/src/utils/articleMapping.js
+++ b/frontend/src/utils/articleMapping.js
@@ -61,6 +61,27 @@ export function buildTypeMap(articles) {
 }
 
 /**
+ * Builds an outputName -> { type, unit } map from `execution.output`, so result
+ * views can format a value by its declared unit instead of guessing from the
+ * name. First declaration wins on a name collision, matching the backend's
+ * `collect_law_outputs` dedup.
+ *
+ * @param {Array} articles - Articles array from useLaw()
+ * @returns {Map<string, { type: (string|null), unit: (string|null) }>}
+ */
+export function buildOutputTypeMap(articles) {
+  const map = new Map();
+  for (const article of articles || []) {
+    for (const o of article.machine_readable?.execution?.output || []) {
+      if (o?.name && !map.has(o.name)) {
+        map.set(o.name, { type: o.type ?? null, unit: o.type_spec?.unit ?? null });
+      }
+    }
+  }
+  return map;
+}
+
+/**
  * Builds a fieldName -> { type, unit } map for EXTERNAL data-source fields -
  * inputs whose `source` is empty (no `regulation` and no `output`), i.e. raw
  * data the engine resolves by field name (e.g. insurance.verdragsinschrijving).

--- a/frontend/src/utils/outputFormat.js
+++ b/frontend/src/utils/outputFormat.js
@@ -25,27 +25,34 @@ const EURO_FORMATTER = new Intl.NumberFormat('nl-NL', {
   currency: 'EUR',
 });
 
-function isMonetary(value, name) {
-  return typeof value === 'number' && Number.isInteger(value) &&
-    (name.includes('hoogte') || name.includes('bedrag') || name.includes('premie'));
+/**
+ * Euro rendering of a value, or '' when the field isn't money.
+ *
+ * The declared `type_spec.unit` is the only signal, matching the engine
+ * (`packages/engine/src/units.rs`): a unit labels the value, it never states a
+ * conversion the engine performs. `eurocent` stores cents so display divides by
+ * 100; `euro` already stores euros. An unannotated or unknown unit gets no
+ * currency form at all — guessing from the field name used to hand
+ * `toetsingsinkomen` a raw cent count and a name-matched integer a euro sign it
+ * had not earned.
+ */
+function euroText(value, unit) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return '';
+  if (unit === 'eurocent') return EURO_FORMATTER.format(value / 100);
+  if (unit === 'euro') return EURO_FORMATTER.format(value);
+  return '';
 }
 
-export function formatOutputValue(value, name) {
+export function formatOutputValue(value, unit) {
   const raw = formatValue(value);
-  if (isMonetary(value, name)) {
-    return `${raw} (${EURO_FORMATTER.format(value / 100)})`;
-  }
-  return raw;
+  const euros = euroText(value, unit);
+  return euros ? `${raw} (${euros})` : raw;
 }
 
 /** Returns `{ text, supportingText }` for output rendering. For monetary
- *  integer outputs the euro-formatted value becomes supporting text. */
-export function formatOutputValueParts(value, name) {
-  const raw = formatValue(value);
-  if (isMonetary(value, name)) {
-    return { text: raw, supportingText: EURO_FORMATTER.format(value / 100) };
-  }
-  return { text: raw, supportingText: '' };
+ *  outputs the euro-formatted value becomes supporting text. */
+export function formatOutputValueParts(value, unit) {
+  return { text: formatValue(value), supportingText: euroText(value, unit) };
 }
 
 export function normalizeForCompare(value) {

--- a/frontend/src/utils/outputFormat.test.js
+++ b/frontend/src/utils/outputFormat.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { formatOutputValue, formatOutputValueParts } from './outputFormat.js';
+
+// Intl renders the euro sign followed by a non-breaking space; matching on the
+// digits keeps the assertions readable and independent of that whitespace.
+const EUROS = /1\.500,00/;
+
+describe('formatOutputValueParts', () => {
+  it('gives a eurocent output its euro supporting text, whatever it is called', () => {
+    expect(formatOutputValueParts(150000, 'eurocent')).toEqual({
+      text: '150000',
+      supportingText: expect.stringMatching(EUROS),
+    });
+  });
+
+  it('leaves an integer without a unit unformatted, even when it is called a bedrag', () => {
+    expect(formatOutputValueParts(150000, null)).toEqual({
+      text: '150000',
+      supportingText: '',
+    });
+  });
+
+  it('formats a euro output without dividing', () => {
+    const parts = formatOutputValueParts(1500, 'euro');
+    expect(parts.text).toBe('1500');
+    expect(parts.supportingText).toMatch(EUROS);
+  });
+
+  it('ignores units that are not money', () => {
+    expect(formatOutputValueParts(65, 'jaar').supportingText).toBe('');
+    expect(formatOutputValueParts(150000, 'percentage').supportingText).toBe('');
+  });
+
+  it('never currency-formats a non-numeric value', () => {
+    expect(formatOutputValueParts('150000', 'eurocent').supportingText).toBe('');
+    expect(formatOutputValueParts(true, 'eurocent')).toEqual({ text: 'ja', supportingText: '' });
+    expect(formatOutputValueParts(null, 'eurocent')).toEqual({ text: 'null', supportingText: '' });
+  });
+});
+
+describe('formatOutputValue', () => {
+  it('appends the euro form for a eurocent value', () => {
+    expect(formatOutputValue(150000, 'eurocent')).toMatch(/^150000 \(.*1\.500,00\)$/);
+  });
+
+  it('returns the bare value without a monetary unit', () => {
+    expect(formatOutputValue(150000, null)).toBe('150000');
+    expect(formatOutputValue(150000, 'eurocenten')).toBe('150000');
+  });
+});

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -50,7 +50,11 @@ export default defineConfig({
   },
   test: {
     environment: 'happy-dom',
-    include: ['src/**/*.test.js'],
+    // `e2e/` holds Playwright specs (`*.spec.js`) plus plain Node helpers those
+    // specs share; the helpers' own unit tests are `*.test.js` and run here.
+    // Playwright's `testMatch` is narrowed to `*.spec.js` so the two never
+    // collect each other's files.
+    include: ['src/**/*.test.js', 'e2e/**/*.test.js'],
     pool: 'vmThreads',
     testTimeout: 10000,
     server: {

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -722,6 +722,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf 0.12.1",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1083,7 +1093,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
- "phf",
+ "phf 0.11.3",
 ]
 
 [[package]]
@@ -2992,7 +3002,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
  "http",
@@ -3365,7 +3375,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
 ]
 
 [[package]]
@@ -3375,7 +3394,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -3384,7 +3403,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.7",
 ]
 
@@ -3395,7 +3414,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -3406,6 +3425,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
 ]
@@ -4265,6 +4293,8 @@ dependencies = [
 name = "regelrecht-shared"
 version = "0.1.0"
 dependencies = [
+ "chrono",
+ "chrono-tz",
  "serde",
  "serde_json",
  "tracing-subscriber",
@@ -4280,6 +4310,7 @@ dependencies = [
  "ratatui",
  "regelrecht-engine",
  "regelrecht-law-model",
+ "regelrecht-shared",
  "tokio",
  "tracing",
  "walkdir",
@@ -5493,7 +5524,7 @@ checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
  "nom 7.1.3",
- "phf",
+ "phf 0.11.3",
  "phf_codegen",
 ]
 
@@ -5530,7 +5561,7 @@ dependencies = [
  "ordered-float 4.6.0",
  "pest",
  "pest_derive",
- "phf",
+ "phf 0.11.3",
  "sha2",
  "signal-hook",
  "siphasher",

--- a/packages/Cargo.toml
+++ b/packages/Cargo.toml
@@ -32,6 +32,7 @@ base64 = "0.23"
 # `OsRng` for nonce generation.
 chacha20poly1305 = { version = "0.10", features = ["getrandom"] }
 chrono = { version = "0.4", features = ["serde"] }
+chrono-tz = "0.10"
 # Every schema this workspace validates against is baked into the binary with
 # `include_str!` and every `$ref` in them is a local `#/definitions/...`
 # pointer, so no reference is ever resolved over the network or from disk.

--- a/packages/admin/Cargo.toml
+++ b/packages/admin/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 [dependencies]
 axum.workspace = true
 regelrecht-auth = { path = "../auth" }
-regelrecht-shared = { path = "../shared", features = ["telemetry"] }
+regelrecht-shared = { path = "../shared", features = ["telemetry", "dates"] }
 sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls-aws-lc-rs", "postgres", "uuid", "chrono"] }
 regelrecht-corpus = { path = "../corpus", default-features = false }
 regelrecht-harvester = { path = "../harvester", default-features = false }

--- a/packages/admin/src/corpus_handlers.rs
+++ b/packages/admin/src/corpus_handlers.rs
@@ -106,7 +106,8 @@ pub async fn sync_source(
 
     // Phase 2: no lock held — do all disk I/O on a blocking thread
     // to avoid blocking the Tokio worker pool during directory traversal.
-    let new_map = tokio::task::spawn_blocking(move || registry.load_local_sources())
+    let today = regelrecht_shared::dates::today_str();
+    let new_map = tokio::task::spawn_blocking(move || registry.load_local_sources(&today))
         .await
         .map_err(|e| {
             tracing::error!(error = %e, "spawn_blocking task failed");

--- a/packages/admin/src/main.rs
+++ b/packages/admin/src/main.rs
@@ -308,14 +308,14 @@ fn init_corpus() -> state::CorpusState {
         regelrecht_corpus::CorpusRegistry::empty()
     };
 
-    let source_map = match registry.load_local_sources() {
+    let source_map = match registry.load_local_sources(&regelrecht_shared::dates::today_str()) {
         Ok(map) => {
             tracing::info!(laws = map.len(), "Loaded corpus laws");
             map
         }
         Err(e) => {
             tracing::warn!(error = %e, "Failed to load corpus sources");
-            regelrecht_corpus::SourceMap::new()
+            regelrecht_corpus::SourceMap::new(regelrecht_shared::dates::today_str())
         }
     };
 

--- a/packages/admin/src/state.rs
+++ b/packages/admin/src/state.rs
@@ -54,7 +54,7 @@ impl CorpusState {
     pub fn empty() -> Self {
         Self {
             registry: regelrecht_corpus::CorpusRegistry::empty(),
-            source_map: SourceMap::new(),
+            source_map: SourceMap::new(regelrecht_shared::dates::today_str()),
         }
     }
 }

--- a/packages/corpus/src/dto.rs
+++ b/packages/corpus/src/dto.rs
@@ -135,7 +135,7 @@ mod tests {
             "GitHub Trees API returned 404".to_string(),
         )]);
 
-        let summaries = build_source_summaries(&registry, &SourceMap::new(), &failures);
+        let summaries = build_source_summaries(&registry, &SourceMap::new("2026-06-01"), &failures);
 
         let broken = summaries.iter().find(|s| s.id == "broken").unwrap();
         assert_eq!(broken.law_count, 0);

--- a/packages/corpus/src/github.rs
+++ b/packages/corpus/src/github.rs
@@ -294,14 +294,16 @@ fn group_best_versions(
             }
         }
 
-        let filename = parts[parts.len() - 1];
-        let new_date = filename.strip_suffix(".yaml");
+        let new_date = crate::source_map::extract_date_from_path(rel);
 
         if let Some(existing) = best_per_law.get(law_id) {
-            let existing_filename = existing.path.rsplit('/').next().unwrap_or("");
-            let existing_date = existing_filename.strip_suffix(".yaml");
+            let existing_date = crate::source_map::extract_date_from_path(&existing.path);
 
-            let new_wins = crate::source_map::pick_best_version(existing_date, new_date, &today);
+            let new_wins = crate::source_map::pick_best_version(
+                existing_date.as_deref(),
+                new_date.as_deref(),
+                &today,
+            );
 
             if new_wins {
                 best_per_law.insert(law_id.to_string(), file.clone());
@@ -395,6 +397,64 @@ mod tests {
         assert!(
             !best.contains_key("zorgtoeslagwet"),
             "annotation file was mis-indexed as law 'zorgtoeslagwet'"
+        );
+    }
+
+    // Both routes into `pick_best_version` must read a filename the same way.
+    // The tree route used to hand it the bare stem, so `2025-01-01-concept`
+    // sorted above `2025-01-01` and the concept won — while the local scan,
+    // which validates the stem as a date, dropped it. Same repo, two answers.
+    #[test]
+    fn undated_stem_loses_to_a_dated_file_on_both_routes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let law_dir = dir.path().join("wet").join("test_wet");
+        std::fs::create_dir_all(&law_dir).expect("create law dir");
+        let body = "$id: test_wet\nname: Test\nregulatory_layer: WET\narticles: []\n";
+        for stem in ["2025-01-01", "2025-01-01-concept"] {
+            std::fs::write(law_dir.join(format!("{stem}.yaml")), body).expect("write law");
+        }
+
+        let source = crate::models::Source {
+            id: "local".to_string(),
+            name: "Local".to_string(),
+            source_type: crate::models::SourceType::Local {
+                local: crate::models::LocalSource {
+                    path: dir.path().to_path_buf(),
+                },
+            },
+            scopes: vec![],
+            priority: 1,
+            auth_ref: None,
+            strict_auth: false,
+        };
+        let mut map = crate::source_map::SourceMap::new();
+        map.load_source(&source).expect("load local source");
+        let local_pick = map
+            .get_law("test_wet")
+            .expect("law loaded")
+            .file_path
+            .clone();
+
+        let paths: Vec<TreeFile> = ["2025-01-01", "2025-01-01-concept"]
+            .iter()
+            .map(|stem| TreeFile {
+                path: format!("wet/test_wet/{stem}.yaml"),
+                sha: None,
+            })
+            .collect();
+        let tree_pick = group_best_versions(&paths, "", None)
+            .get("test_wet")
+            .expect("law indexed")
+            .path
+            .clone();
+
+        assert!(
+            local_pick.ends_with("2025-01-01.yaml"),
+            "local scan picked {local_pick}"
+        );
+        assert!(
+            tree_pick.ends_with("2025-01-01.yaml"),
+            "tree scan picked {tree_pick}"
         );
     }
 }

--- a/packages/corpus/src/github.rs
+++ b/packages/corpus/src/github.rs
@@ -105,6 +105,7 @@ pub async fn fetch_source_filtered(
     source: &GitHubSource,
     token: Option<&str>,
     law_ids: &HashSet<String>,
+    today: &str,
 ) -> Result<FetchResult> {
     if law_ids.is_empty() {
         return Ok(FetchResult::Fetched(Vec::new()));
@@ -125,7 +126,7 @@ pub async fn fetch_source_filtered(
         None => return Ok(FetchResult::NotModified),
     };
 
-    let best_per_law = group_best_versions(&all_paths, base_path, Some(law_ids));
+    let best_per_law = group_best_versions(&all_paths, base_path, Some(law_ids), today);
 
     tracing::info!(
         matched = best_per_law.len(),
@@ -167,6 +168,7 @@ pub async fn list_source_law_paths(
     client: &GithubClient,
     source: &GitHubSource,
     token: Option<&str>,
+    today: &str,
 ) -> Result<Vec<(String, String, Option<String>)>> {
     let base_path = source.path.as_deref().unwrap_or("");
     let all_paths = match list_yaml_files(
@@ -181,7 +183,7 @@ pub async fn list_source_law_paths(
         Some(paths) => paths,
         None => return Ok(Vec::new()),
     };
-    Ok(group_best_versions(&all_paths, base_path, None)
+    Ok(group_best_versions(&all_paths, base_path, None, today)
         .into_iter()
         .map(|(law_id, file)| (law_id, file.path, file.sha))
         .collect())
@@ -251,13 +253,13 @@ fn group_best_versions(
     all_paths: &[TreeFile],
     base_path: &str,
     filter: Option<&HashSet<String>>,
+    today: &str,
 ) -> HashMap<String, TreeFile> {
     let prefix = if base_path.is_empty() {
         String::new()
     } else {
         format!("{}/", base_path)
     };
-    let today = crate::source_map::today_str();
     let mut best_per_law: HashMap<String, TreeFile> = HashMap::new();
 
     for file in all_paths {
@@ -302,7 +304,7 @@ fn group_best_versions(
             let new_wins = crate::source_map::pick_best_version(
                 existing_date.as_deref(),
                 new_date.as_deref(),
-                &today,
+                today,
             );
 
             if new_wins {
@@ -392,7 +394,7 @@ mod tests {
                 sha: Some("def456".to_string()),
             },
         ];
-        let best = group_best_versions(&paths, "", None);
+        let best = group_best_versions(&paths, "", None, "2026-06-01");
         assert_eq!(sorted_ids(&best), vec!["wet_op_de_zorgtoeslag".to_string()]);
         assert!(
             !best.contains_key("zorgtoeslagwet"),
@@ -427,7 +429,7 @@ mod tests {
             auth_ref: None,
             strict_auth: false,
         };
-        let mut map = crate::source_map::SourceMap::new();
+        let mut map = crate::source_map::SourceMap::new("2026-06-01");
         map.load_source(&source).expect("load local source");
         let local_pick = map
             .get_law("test_wet")
@@ -442,7 +444,7 @@ mod tests {
                 sha: None,
             })
             .collect();
-        let tree_pick = group_best_versions(&paths, "", None)
+        let tree_pick = group_best_versions(&paths, "", None, "2026-06-01")
             .get("test_wet")
             .expect("law indexed")
             .path

--- a/packages/corpus/src/registry.rs
+++ b/packages/corpus/src/registry.rs
@@ -139,8 +139,11 @@ impl CorpusRegistry {
     ///
     /// GitHub sources are skipped — use [`index_all_sources_async`] or
     /// [`load_favorites_async`] to include them.
-    pub fn load_local_sources(&self) -> Result<SourceMap> {
-        let mut map = SourceMap::new();
+    ///
+    /// `today` is the date a law's versions are collapsed against; see
+    /// [`SourceMap::new`] for why it is passed in rather than read off a clock.
+    pub fn load_local_sources(&self, today: &str) -> Result<SourceMap> {
+        let mut map = SourceMap::new(today);
         for source in &self.sources {
             match &source.source_type {
                 SourceType::Local { .. } => {
@@ -179,8 +182,9 @@ impl CorpusRegistry {
         &self,
         law_ids: &std::collections::HashSet<String>,
         auth_file: Option<&Path>,
+        today: &str,
     ) -> Result<SourceMap> {
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new(today);
         let client = regelrecht_github::GithubClient::new()?;
 
         // Determine which law_ids are NOT already covered by local sources,
@@ -210,6 +214,7 @@ impl CorpusRegistry {
                     github,
                     token.as_deref(),
                     &missing,
+                    today,
                 )
                 .await?
                 {
@@ -265,8 +270,10 @@ impl CorpusRegistry {
     pub async fn index_all_sources_async(
         &self,
         auth_file: Option<&Path>,
+        today: &str,
     ) -> Result<(SourceMap, Vec<SourceIndexFailure>)> {
-        self.index_all_sources_with_override(auth_file, None).await
+        self.index_all_sources_with_override(auth_file, None, today)
+            .await
     }
 
     /// [`Self::index_all_sources_async`] with an optional per-call
@@ -279,8 +286,9 @@ impl CorpusRegistry {
         &self,
         auth_file: Option<&Path>,
         scan_override: Option<ScanTokenOverride<'_>>,
+        today: &str,
     ) -> Result<(SourceMap, Vec<SourceIndexFailure>)> {
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new(today);
         let client = regelrecht_github::GithubClient::new()?;
         let mut failed: Vec<SourceIndexFailure> = Vec::new();
 
@@ -355,8 +363,10 @@ impl CorpusRegistry {
                         token = Some(o.token.to_string());
                     }
                 }
+                let today = map.reference_date().to_string();
                 for (law_id, path, sha) in
-                    crate::github::list_source_law_paths(client, github, token.as_deref()).await?
+                    crate::github::list_source_law_paths(client, github, token.as_deref(), &today)
+                        .await?
                 {
                     map.load_metadata_entry(
                         &law_id,

--- a/packages/corpus/src/source_map.rs
+++ b/packages/corpus/src/source_map.rs
@@ -520,20 +520,28 @@ impl Default for SourceMap {
 
 /// Extract a YYYY-MM-DD date from the filename component of a path.
 ///
-/// Matches the convention `…/law_id/2025-01-01.yaml`.
-fn extract_date_from_path(path: &str) -> Option<String> {
+/// Matches the convention `…/law_id/2025-01-01.yaml`. The single extractor for
+/// every route that feeds [`pick_best_version`] — local scan and GitHub tree
+/// alike. That comparison is lexicographic, so any stem that is not a date
+/// sorts against real dates by accident: `2025-01-01-concept` is greater than
+/// `2025-01-01` and would win. Returning `None` keeps such a file out of the
+/// running instead.
+pub(crate) fn extract_date_from_path(path: &str) -> Option<String> {
     let filename = path.rsplit('/').next().unwrap_or(path);
     let stem = filename.strip_suffix(".yaml")?;
-    // Validate YYYY-MM-DD pattern
-    if stem.len() == 10
-        && stem.as_bytes()[4] == b'-'
-        && stem.as_bytes()[7] == b'-'
-        && stem.bytes().filter(|b| b.is_ascii_digit()).count() == 8
-    {
-        Some(stem.to_string())
-    } else {
-        None
+    let bytes = stem.as_bytes();
+    if bytes.len() != 10 || bytes[4] != b'-' || bytes[7] != b'-' {
+        return None;
     }
+    if !(0..10).all(|i| i == 4 || i == 7 || bytes[i].is_ascii_digit()) {
+        return None;
+    }
+    let month: u32 = stem.get(5..7)?.parse().ok()?;
+    let day: u32 = stem.get(8..10)?.parse().ok()?;
+    if !(1..=12).contains(&month) || !(1..=31).contains(&day) {
+        return None;
+    }
+    Some(stem.to_string())
 }
 
 /// Return today's date as "YYYY-MM-DD".

--- a/packages/corpus/src/source_map.rs
+++ b/packages/corpus/src/source_map.rs
@@ -93,6 +93,12 @@ pub struct SourceMap {
     versions: HashMap<String, Vec<LoadedLaw>>,
     /// Conflicts that were resolved (for reporting).
     resolved_conflicts: Vec<ConflictResolution>,
+    /// The date "currently in force" is measured against when collapsing a
+    /// law's versions to one. Supplied by the caller rather than read off a
+    /// clock here: this crate deliberately carries no time dependency, and the
+    /// answer is a Dutch calendar date (`regelrecht_shared::dates`), not the
+    /// timezone of whichever machine happens to run the scan.
+    reference_date: String,
 }
 
 /// Record of a conflict that was resolved by priority.
@@ -107,12 +113,18 @@ pub struct ConflictResolution {
 
 impl SourceMap {
     /// Create an empty source map.
-    pub fn new() -> Self {
+    pub fn new(reference_date: impl Into<String>) -> Self {
         Self {
             laws: HashMap::new(),
             versions: HashMap::new(),
             resolved_conflicts: Vec::new(),
+            reference_date: reference_date.into(),
         }
+    }
+
+    /// The date this map resolves "currently in force" against.
+    pub fn reference_date(&self) -> &str {
+        &self.reference_date
     }
 
     /// Load laws from a single source directory.
@@ -226,10 +238,12 @@ impl SourceMap {
                 if existing.source_id == law.source_id {
                     let existing_date = extract_date_from_path(&existing.file_path);
                     let new_date = extract_date_from_path(&law.file_path);
-                    let today = today_str();
 
-                    let new_wins =
-                        pick_best_version(existing_date.as_deref(), new_date.as_deref(), &today);
+                    let new_wins = pick_best_version(
+                        existing_date.as_deref(),
+                        new_date.as_deref(),
+                        &self.reference_date,
+                    );
 
                     if new_wins {
                         tracing::debug!(
@@ -512,12 +526,6 @@ impl SourceMap {
     }
 }
 
-impl Default for SourceMap {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 /// Extract a YYYY-MM-DD date from the filename component of a path.
 ///
 /// Matches the convention `…/law_id/2025-01-01.yaml`. The single extractor for
@@ -542,35 +550,6 @@ pub(crate) fn extract_date_from_path(path: &str) -> Option<String> {
         return None;
     }
     Some(stem.to_string())
-}
-
-/// Return today's date as "YYYY-MM-DD".
-pub(crate) fn today_str() -> String {
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-    // 86400 seconds per day, epoch is 1970-01-01
-    let days = now / 86400;
-    // Simple conversion: count years/months/days from epoch
-    let (y, m, d) = days_to_ymd(days);
-    format!("{y:04}-{m:02}-{d:02}")
-}
-
-/// Convert days since Unix epoch to (year, month, day).
-fn days_to_ymd(mut days: u64) -> (u64, u64, u64) {
-    // Algorithm from https://howardhinnant.github.io/date_algorithms.html
-    days += 719_468;
-    let era = days / 146_097;
-    let doe = days - era * 146_097;
-    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
-    let y = yoe + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    let mp = (5 * doy + 2) / 153;
-    let d = doy - (153 * mp + 2) / 5 + 1;
-    let m = if mp < 10 { mp + 3 } else { mp - 9 };
-    let y = if m <= 2 { y + 1 } else { y };
-    (y, m, d)
 }
 
 /// Decide whether `new_date` should replace `existing_date`.
@@ -1054,7 +1033,7 @@ mod tests {
         write_yaml(dir.path(), "wet/test_wet/2025-01-01.yaml", "test_wet");
 
         let source = make_source("central", "Central", dir.path(), 1);
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         map.load_source(&source).unwrap();
 
         let original = map.get_law("test_wet").unwrap().clone();
@@ -1091,7 +1070,7 @@ mod tests {
         .unwrap();
 
         let source = make_source("central", "Central", dir.path(), 1);
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         map.load_source(&source).unwrap();
         assert_eq!(
             map.get_law("test_wet").unwrap().name.as_deref(),
@@ -1107,7 +1086,7 @@ mod tests {
 
     #[test]
     fn test_update_yaml_content_missing_law_returns_false() {
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         let updated = map.update_yaml_content("nonexistent_law", "$id: foo\n".to_string());
         assert!(!updated, "update should report failure for missing law");
         assert_eq!(map.len(), 0, "missing law should not be inserted");
@@ -1134,7 +1113,7 @@ mod tests {
         write_yaml(dir.path(), "wet/test_wet/2025-01-01.yaml", "test_wet");
 
         let source = make_source("central", "Central", dir.path(), 1);
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         let count = map.load_source(&source).unwrap();
 
         assert_eq!(count, 1);
@@ -1148,7 +1127,7 @@ mod tests {
 
     #[test]
     fn test_metadata_entry_is_unloaded_with_stripped_path() {
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         // `file_path` is the in-repo path; the source is rooted at
         // `regulation/nl`, so the stored relative_path drops that prefix.
         map.load_metadata_entry(
@@ -1186,7 +1165,7 @@ mod tests {
         let source_a = make_source("central", "Central", dir_a.path(), 1);
         let source_b = make_source("gemeente", "Gemeente", dir_b.path(), 10);
 
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         map.load_source(&source_a).unwrap();
         map.load_source(&source_b).unwrap();
 
@@ -1206,7 +1185,7 @@ mod tests {
         let source_a = make_source("central", "Central", dir_a.path(), 1);
         let source_b = make_source("overlap", "Overlap", dir_b.path(), 10);
 
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         map.load_source(&source_a).unwrap();
         map.load_source(&source_b).unwrap();
 
@@ -1229,7 +1208,7 @@ mod tests {
         let source_a = make_source("source-a", "Source A", dir_a.path(), 5);
         let source_b = make_source("source-b", "Source B", dir_b.path(), 5);
 
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         map.load_source(&source_a).unwrap();
         let result = map.load_source(&source_b);
 
@@ -1248,7 +1227,7 @@ mod tests {
         write_yaml(dir.path(), "wet/my_law/2025-01-01.yaml", "my_law");
 
         let source = make_source("local", "Local", dir.path(), 1);
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         let count = map.load_source(&source).unwrap();
 
         // Both files are loaded but only one law in the map
@@ -1269,7 +1248,7 @@ mod tests {
         write_yaml(dir.path(), "wet/my_law/2099-01-01.yaml", "my_law");
 
         let source = make_source("local", "Local", dir.path(), 1);
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         map.load_source(&source).unwrap();
 
         let law = map.get_law("my_law").unwrap();
@@ -1285,7 +1264,7 @@ mod tests {
         write_yaml(dir.path(), "wet/my_law/2025-01-01.yaml", "my_law");
 
         let source = make_source("local", "Local", dir.path(), 1);
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         map.load_source(&source).unwrap();
 
         // `get_law` still collapses to one (the today's-best entry)...
@@ -1316,7 +1295,7 @@ mod tests {
         let local = make_source("local", "Local", local_dir.path(), 1);
         let central = make_source("central", "Central", central_dir.path(), 2);
 
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         map.load_source(&local).unwrap();
         map.load_source(&central).unwrap();
 
@@ -1354,7 +1333,7 @@ mod tests {
         let local = make_source("local", "Local", local_dir.path(), 1);
         let central = make_source("central", "Central", central_dir.path(), 2);
 
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         map.load_source(&central).unwrap();
         map.load_source(&local).unwrap();
 
@@ -1376,7 +1355,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let source = make_source("empty", "Empty", dir.path(), 1);
 
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         let count = map.load_source(&source).unwrap();
 
         assert_eq!(count, 0);
@@ -1387,7 +1366,7 @@ mod tests {
     fn test_nonexistent_directory() {
         let source = make_source("missing", "Missing", Path::new("/nonexistent"), 1);
 
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         let count = map.load_source(&source).unwrap();
 
         assert_eq!(count, 0);
@@ -1405,7 +1384,7 @@ mod tests {
         let source_low = make_source("low", "Low Priority", dir_a.path(), 100);
         let source_high = make_source("high", "High Priority", dir_b.path(), 1);
 
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         map.load_source(&source_low).unwrap();
         map.load_source(&source_high).unwrap();
 
@@ -1477,7 +1456,7 @@ articles:
         fs::write(&path, DERIVED_FIELDS_YAML).unwrap();
 
         let source = make_source("central", "Central", dir.path(), 1);
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         map.load_source(&source).unwrap();
 
         let law = map.get_law("regeling_zorgtoeslag").unwrap();
@@ -1490,7 +1469,7 @@ articles:
 
     #[test]
     fn test_load_fetched_file_precomputes_display_name_and_implements() {
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         map.load_fetched_file(
             DERIVED_FIELDS_YAML,
             "regulation/nl/regeling/regeling_zorgtoeslag/2025-01-01.yaml",
@@ -1514,7 +1493,7 @@ articles:
         fs::write(&path, "$id: kieswet\nname: Kieswet\narticles: []\n").unwrap();
 
         let source = make_source("central", "Central", dir.path(), 1);
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         map.load_source(&source).unwrap();
 
         let law = map.get_law("kieswet").unwrap();
@@ -1528,7 +1507,7 @@ articles:
         // Metadata-only entries have no body to derive from — the fields
         // stay empty until the body is fetched and (in the editor flow)
         // a snapshot rebuild or `update_yaml_content` recomputes them.
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         map.load_metadata_entry(
             "some_wet",
             "regulation/nl/wet/some_wet/2025-01-01.yaml",
@@ -1554,7 +1533,7 @@ articles:
         fs::write(&path, DERIVED_FIELDS_YAML).unwrap();
 
         let source = make_source("central", "Central", dir.path(), 1);
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         map.load_source(&source).unwrap();
 
         // Edit drops the implements block and switches to a literal name:

--- a/packages/corpus/src/validation.rs
+++ b/packages/corpus/src/validation.rs
@@ -214,7 +214,7 @@ mod tests {
             10,
         );
 
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         map.load_source(&source).unwrap();
 
         let warnings = validate_scopes(&map, &[source]);
@@ -237,7 +237,7 @@ mod tests {
             10,
         );
 
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         map.load_source(&source).unwrap();
 
         let warnings = validate_scopes(&map, &[source]);
@@ -254,7 +254,7 @@ mod tests {
         // Empty scopes = unrestricted
         let source = make_scoped_source("central", dir.path(), vec![], 1);
 
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         map.load_source(&source).unwrap();
 
         let warnings = validate_scopes(&map, &[source]);
@@ -276,7 +276,7 @@ mod tests {
             10,
         );
 
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         map.load_source(&source).unwrap();
 
         let warnings = validate_scopes(&map, &[source]);
@@ -298,7 +298,7 @@ mod tests {
             10,
         );
 
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         map.load_source(&source).unwrap();
 
         let warnings = validate_scopes(&map, &[source]);
@@ -329,7 +329,7 @@ mod tests {
             10,
         );
 
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         map.load_source(&source).unwrap();
 
         let warnings = validate_scopes(&map, &[source]);

--- a/packages/corpus/tests/federation.rs
+++ b/packages/corpus/tests/federation.rs
@@ -38,7 +38,7 @@ fn test_single_source_loads_all_laws() {
     let central_dir = fixtures_dir().join("central");
     let source = make_local_source("central", "Central", central_dir, 1);
 
-    let mut map = SourceMap::new();
+    let mut map = SourceMap::new("2026-06-01");
     let count = map.load_source(&source).unwrap();
 
     assert_eq!(count, 1);
@@ -56,7 +56,7 @@ fn test_multi_source_no_overlap() {
     let source_central = make_local_source("central", "Central", central_dir, 1);
     let source_a = make_local_source("gemeente-a", "Gemeente A", gemeente_a_dir, 10);
 
-    let mut map = SourceMap::new();
+    let mut map = SourceMap::new("2026-06-01");
     map.load_source(&source_central).unwrap();
     map.load_source(&source_a).unwrap();
 
@@ -81,7 +81,7 @@ fn test_multi_source_multiple_gemeenten() {
     let source_a = make_local_source("gemeente-a", "Gemeente A", gemeente_a_dir, 10);
     let source_b = make_local_source("gemeente-b", "Gemeente B", gemeente_b_dir, 10);
 
-    let mut map = SourceMap::new();
+    let mut map = SourceMap::new("2026-06-01");
     map.load_source(&source_a).unwrap();
     map.load_source(&source_b).unwrap();
 
@@ -106,7 +106,7 @@ fn test_priority_conflict_central_wins() {
     let source_central = make_local_source("central", "Central", central_dir, 1);
     let source_overlap = make_local_source("overlap", "Overlap", overlap_dir, 10);
 
-    let mut map = SourceMap::new();
+    let mut map = SourceMap::new("2026-06-01");
     map.load_source(&source_central).unwrap();
     map.load_source(&source_overlap).unwrap();
 
@@ -133,7 +133,7 @@ fn test_equal_priority_conflict_is_error() {
     let source_a = make_local_source("source-a", "Source A", central_dir, 5);
     let source_b = make_local_source("source-b", "Source B", overlap_dir, 5);
 
-    let mut map = SourceMap::new();
+    let mut map = SourceMap::new("2026-06-01");
     map.load_source(&source_a).unwrap();
     let result = map.load_source(&source_b);
 
@@ -173,7 +173,7 @@ sources:
 
     let registry = CorpusRegistry::from_yaml(&yaml).unwrap();
 
-    let mut map = SourceMap::new();
+    let mut map = SourceMap::new("2026-06-01");
     for source in registry.sources() {
         map.load_source(source).unwrap();
     }
@@ -190,7 +190,7 @@ fn test_empty_source_no_error() {
     let empty_dir = tempfile::TempDir::new().unwrap();
     let source = make_local_source("empty", "Empty", empty_dir.path().to_path_buf(), 1);
 
-    let mut map = SourceMap::new();
+    let mut map = SourceMap::new("2026-06-01");
     let count = map.load_source(&source).unwrap();
 
     assert_eq!(count, 0);
@@ -207,7 +207,7 @@ fn test_invalid_yaml_skipped() {
     std::fs::write(&bad_file, "this is not valid regulation yaml").unwrap();
 
     let source = make_local_source("bad", "Bad", dir.path().to_path_buf(), 1);
-    let mut map = SourceMap::new();
+    let mut map = SourceMap::new("2026-06-01");
 
     // Should not error — files without $id are just skipped
     let count = map.load_source(&source).unwrap();
@@ -278,7 +278,7 @@ fn test_multi_repo_only_repo1() {
     let repo1 = make_test_source("repo1");
     let source = make_local_source("repo1", "Repo 1", repo1.path().to_path_buf(), 1);
 
-    let mut map = SourceMap::new();
+    let mut map = SourceMap::new("2026-06-01");
     map.load_source(&source).unwrap();
 
     let service = load_into_engine(&map);
@@ -299,7 +299,7 @@ fn test_multi_repo_only_repo2() {
     let repo2 = make_test_source("repo2");
     let source = make_local_source("repo2", "Repo 2", repo2.path().to_path_buf(), 1);
 
-    let mut map = SourceMap::new();
+    let mut map = SourceMap::new("2026-06-01");
     map.load_source(&source).unwrap();
 
     let service = load_into_engine(&map);
@@ -323,7 +323,7 @@ fn test_multi_repo_both_repos_priority_wins() {
     let source1 = make_local_source("repo1", "Repo 1", repo1.path().to_path_buf(), 1);
     let source2 = make_local_source("repo2", "Repo 2", repo2.path().to_path_buf(), 10);
 
-    let mut map = SourceMap::new();
+    let mut map = SourceMap::new("2026-06-01");
     map.load_source(&source1).unwrap();
     map.load_source(&source2).unwrap();
 
@@ -367,7 +367,7 @@ fn test_multi_repo_reversed_priority() {
     let source1 = make_local_source("repo1", "Repo 1", repo1.path().to_path_buf(), 10);
     let source2 = make_local_source("repo2", "Repo 2", repo2.path().to_path_buf(), 1);
 
-    let mut map = SourceMap::new();
+    let mut map = SourceMap::new("2026-06-01");
     map.load_source(&source1).unwrap();
     map.load_source(&source2).unwrap();
 
@@ -407,7 +407,7 @@ fn test_source_map_to_engine() {
     let source_central = make_local_source("central", "Central", central_dir, 1);
     let source_a = make_local_source("gemeente-a", "Gemeente A", gemeente_a_dir, 10);
 
-    let mut map = SourceMap::new();
+    let mut map = SourceMap::new("2026-06-01");
     map.load_source(&source_central).unwrap();
     map.load_source(&source_a).unwrap();
 
@@ -468,7 +468,7 @@ fn test_priority_conflict_correct_law_executes() {
     let source_central = make_local_source("central", "Central", central_dir, 1);
     let source_overlap = make_local_source("overlap", "Overlap", overlap_dir, 10);
 
-    let mut map = SourceMap::new();
+    let mut map = SourceMap::new("2026-06-01");
     map.load_source(&source_central).unwrap();
     map.load_source(&source_overlap).unwrap();
 

--- a/packages/corpus/tests/index_scan_override.rs
+++ b/packages/corpus/tests/index_scan_override.rs
@@ -122,7 +122,10 @@ async fn scan_override_reaches_only_its_source_and_loses_from_server_tokens() {
     // Fase 1: zonder override faalt de token-loze writable-own (404); de
     // seed scant gewoon met z'n servertoken.
     // ------------------------------------------------------------------
-    let (map, failed) = registry.index_all_sources_async(None).await.unwrap();
+    let (map, failed) = registry
+        .index_all_sources_async(None, "2026-06-01")
+        .await
+        .unwrap();
     assert_eq!(failed.len(), 1, "alleen de token-loze own hoort te falen");
     assert_eq!(failed[0].source_id, "traject-own");
     assert!(
@@ -145,6 +148,7 @@ async fn scan_override_reaches_only_its_source_and_loses_from_server_tokens() {
                 source_id: "traject-own",
                 token: "user-token",
             }),
+            "2026-06-01",
         )
         .await
         .unwrap();
@@ -191,6 +195,7 @@ async fn scan_override_reaches_only_its_source_and_loses_from_server_tokens() {
                 source_id: "traject-own",
                 token: "user-token",
             }),
+            "2026-06-01",
         )
         .await
         .unwrap();

--- a/packages/editor-api/Cargo.toml
+++ b/packages/editor-api/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 [dependencies]
 axum = { workspace = true, features = ["multipart"] }
 regelrecht-auth = { path = "../auth" }
-regelrecht-shared = { path = "../shared", features = ["telemetry"] }
+regelrecht-shared = { path = "../shared", features = ["telemetry", "dates"] }
 regelrecht-corpus = { path = "../corpus", features = ["github", "annotation-validation"] }
 regelrecht-github = { path = "../github" }
 regelrecht-law-model = { path = "../law-model" }

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -2881,7 +2881,11 @@ pub async fn reload_corpus(
     }
 
     let new_map = registry
-        .load_favorites_async(&law_ids, auth_file.as_deref())
+        .load_favorites_async(
+            &law_ids,
+            auth_file.as_deref(),
+            &regelrecht_shared::dates::today_str(),
+        )
         .await
         .map_err(|e| {
             tracing::error!(error = %e, "corpus reload failed");

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -761,21 +761,25 @@ async fn init_corpus(favorites: &HashSet<String>) -> CorpusState {
         None
     };
 
-    let source_map = match registry.load_favorites_async(favorites, auth_file).await {
+    let today = regelrecht_shared::dates::today_str();
+    let source_map = match registry
+        .load_favorites_async(favorites, auth_file, &today)
+        .await
+    {
         Ok(map) => {
             tracing::info!(laws = map.len(), "loaded corpus laws");
             map
         }
         Err(e) => {
             tracing::warn!(error = %e, "failed to load favorites from GitHub, falling back to local-only");
-            match registry.load_local_sources() {
+            match registry.load_local_sources(&today) {
                 Ok(map) => {
                     tracing::info!(laws = map.len(), "loaded corpus laws (local-only fallback)");
                     map
                 }
                 Err(e2) => {
                     tracing::warn!(error = %e2, "failed to load local sources");
-                    regelrecht_corpus::SourceMap::new()
+                    regelrecht_corpus::SourceMap::new(regelrecht_shared::dates::today_str())
                 }
             }
         }

--- a/packages/editor-api/src/state.rs
+++ b/packages/editor-api/src/state.rs
@@ -109,7 +109,7 @@ impl CorpusState {
     pub fn empty() -> Self {
         Self {
             registry: regelrecht_corpus::CorpusRegistry::empty(),
-            source_map: SourceMap::new(),
+            source_map: SourceMap::new(regelrecht_shared::dates::today_str()),
             backends: HashMap::new(),
             auth_file: None,
             index_failures: HashMap::new(),

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -1787,9 +1787,10 @@ async fn build_traject_corpus(
         source_id: &writable_own_source_id,
         token,
     });
+    let today = regelrecht_shared::dates::today_str();
     let (source_map, index_failures) = match timing::measure(
         "index",
-        registry.index_all_sources_with_override(auth_file, scan_override),
+        registry.index_all_sources_with_override(auth_file, scan_override, &today),
     )
     .await
     {
@@ -1828,8 +1829,8 @@ async fn build_traject_corpus(
                 .collect();
             (
                 registry
-                    .load_local_sources()
-                    .unwrap_or_else(|_| SourceMap::new()),
+                    .load_local_sources(&today)
+                    .unwrap_or_else(|_| SourceMap::new(regelrecht_shared::dates::today_str())),
                 failures,
             )
         }
@@ -1913,7 +1914,11 @@ async fn refresh_traject_corpus(
         token,
     });
     let (source_map, failed) = registry
-        .index_all_sources_with_override(auth_file.as_deref(), scan_override)
+        .index_all_sources_with_override(
+            auth_file.as_deref(),
+            scan_override,
+            &regelrecht_shared::dates::today_str(),
+        )
         .await?;
     if !failed.is_empty() {
         let details: Vec<String> = failed
@@ -2376,7 +2381,7 @@ mod tests {
     #[test]
     fn cached_corpus_freshness_respects_ttl() {
         let cached = CachedCorpus {
-            corpus: Arc::new(test_corpus(SourceMap::new(), HashMap::new())),
+            corpus: Arc::new(test_corpus(SourceMap::new("2026-06-01"), HashMap::new())),
             built_at: Instant::now(),
         };
         // A just-built snapshot is fresh under the production TTL…
@@ -2389,7 +2394,7 @@ mod tests {
 
     #[tokio::test]
     async fn law_yaml_caches_lazy_fetch_and_prefers_overlay() {
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         metadata_entry(&mut map, "wet_a", "seed");
         let stub = StubBackend::with_files(&[("wet/wet_a/2025-01-01.yaml", "$id: wet_a\n")]);
         let reads = stub.reads.clone();
@@ -2477,7 +2482,7 @@ mod tests {
 
     #[tokio::test]
     async fn law_yaml_forwards_the_read_token_only_to_the_writable_own_source() {
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         metadata_entry(&mut map, "wet_eigen", "own");
         metadata_entry(&mut map, "wet_seed", "seed");
         let backends = HashMap::from([
@@ -2545,7 +2550,7 @@ mod tests {
 
     #[tokio::test]
     async fn implementors_of_builds_index_once_and_reverse_looks_up() {
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         metadata_entry(&mut map, "regeling_a", "seed");
         metadata_entry(&mut map, "wet_hoger", "seed");
         let stub = StubBackend::with_files(&[
@@ -2579,7 +2584,7 @@ mod tests {
 
     #[tokio::test]
     async fn implementors_of_reports_fetch_failures_as_skipped() {
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         metadata_entry(&mut map, "regeling_a", "seed");
         metadata_entry(&mut map, "wet_kapot", "broken");
         let stub = StubBackend::with_files(&[(
@@ -2608,7 +2613,7 @@ mod tests {
         // must be pulled in ONE bulk request, not one fetch per law — this
         // is what stops the cold build 504-ing on large GitHub trajects.
         let n = BULK_FETCH_THRESHOLD;
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         let mut files: Vec<(String, String)> = Vec::new();
         for i in 0..n {
             let law_id = format!("reg_{i}");
@@ -2644,7 +2649,7 @@ mod tests {
 
     #[tokio::test]
     async fn record_save_updates_built_implements_index_in_place() {
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         metadata_entry(&mut map, "regeling_a", "seed");
         let stub = StubBackend::with_files(&[(
             "wet/regeling_a/2025-01-01.yaml",
@@ -2705,7 +2710,7 @@ mod tests {
             strict_auth: false,
         };
         let registry = CorpusRegistry::from_sources(vec![source.clone()]);
-        let source_map = registry.load_local_sources().unwrap();
+        let source_map = registry.load_local_sources("2026-06-01").unwrap();
         let mut backend = create_backend(&source, None).unwrap();
         backend.ensure_ready().await.unwrap();
         let writable = backend.is_writable();
@@ -2847,7 +2852,7 @@ mod tests {
         // implementor lookups from it while another task holds the build
         // lock — the post-refresh lookup herd must never queue behind the
         // rescan (the federated-panel hang of PR #762).
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         metadata_entry(&mut map, "regeling_a", "seed");
         let corpus = Arc::new(test_corpus(
             map,
@@ -2886,7 +2891,7 @@ mod tests {
 
     #[tokio::test]
     async fn rebuild_after_refresh_skips_unchanged_bodies_via_memo() {
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         metadata_entry(&mut map, "regeling_a", "seed");
         metadata_entry(&mut map, "wet_hoger", "seed");
         let stub = StubBackend::with_files(&[
@@ -2915,7 +2920,7 @@ mod tests {
         // TTL refresh with an UNCHANGED enumeration (same blob shas):
         // the post-refresh rebuild must answer entirely from the memo —
         // zero body fetches.
-        let mut same_map = SourceMap::new();
+        let mut same_map = SourceMap::new("2026-06-01");
         metadata_entry(&mut same_map, "regeling_a", "seed");
         metadata_entry(&mut same_map, "wet_hoger", "seed");
         let refreshed = next_snapshot(&old, same_map).await;
@@ -2931,7 +2936,7 @@ mod tests {
 
         // Next refresh where ONE law's sha moved: only that body is
         // refetched.
-        let mut changed_map = SourceMap::new();
+        let mut changed_map = SourceMap::new("2026-06-01");
         metadata_entry_with_sha(
             &mut changed_map,
             "regeling_a",
@@ -3100,7 +3105,7 @@ mod tests {
 
     #[tokio::test]
     async fn expired_changed_cache_serves_stale_and_recomputes_in_background() {
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         metadata_entry(&mut map, "wet_a", "own");
         let corpus = Arc::new(test_corpus(
             map,
@@ -3141,7 +3146,7 @@ mod tests {
 
     #[tokio::test]
     async fn failed_changed_recompute_rearms_stale_and_releases_the_flag() {
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         metadata_entry(&mut map, "wet_a", "own");
         let corpus = Arc::new(test_corpus(
             map,
@@ -3179,7 +3184,7 @@ mod tests {
 
     #[tokio::test]
     async fn record_changed_law_folds_a_save_into_the_cached_diff() {
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         metadata_entry(&mut map, "wet_a", "own");
         let corpus = Arc::new(test_corpus(
             map,
@@ -3214,7 +3219,7 @@ mod tests {
 
     #[tokio::test]
     async fn sidecar_cache_round_trips_and_resets_per_snapshot() {
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         metadata_entry(&mut map, "wet_a", "own");
         let corpus = Arc::new(test_corpus(
             map,
@@ -3307,7 +3312,7 @@ mod tests {
         corpus
             .store_sidecar("scn:wet_a/y.feature".to_string(), None)
             .await;
-        let mut next_map = SourceMap::new();
+        let mut next_map = SourceMap::new("2026-06-01");
         metadata_entry(&mut next_map, "wet_a", "own");
         let next = next_snapshot(&corpus, next_map).await;
         assert!(next.cached_sidecar("scn:wet_a/y.feature").await.is_none());
@@ -3315,7 +3320,7 @@ mod tests {
 
     #[tokio::test]
     async fn stale_read_store_is_dropped_after_a_write_bumps_the_generation() {
-        let mut map = SourceMap::new();
+        let mut map = SourceMap::new("2026-06-01");
         metadata_entry(&mut map, "wet_a", "own");
         let corpus = Arc::new(test_corpus(
             map,

--- a/packages/editor-api/tests/list_scenarios_test.rs
+++ b/packages/editor-api/tests/list_scenarios_test.rs
@@ -213,7 +213,7 @@ async fn list_scenarios_global_returns_target_law_ids() {
     )
     .unwrap();
     let registry = regelrecht_corpus::CorpusRegistry::load(&manifest, None).unwrap();
-    let source_map = registry.load_local_sources().unwrap();
+    let source_map = registry.load_local_sources("2026-06-01").unwrap();
 
     let mut backends = HashMap::new();
     for source in registry.sources() {

--- a/packages/engine/build_codegen/gen_rust.rs
+++ b/packages/engine/build_codegen/gen_rust.rs
@@ -4,6 +4,10 @@ fn emit_rust(grammar: &Grammar) -> String {
     let mut s = String::new();
     s.push_str("// @generated from bdd/grammar.yaml — do not edit.\n");
     s.push_str("use cucumber::{given, when, then};\n\n");
+    s.push_str(&format!(
+        "pub const QUOTED_VALUE_TYPING: &str = {:?};\npub const BARE_VALUE_TYPING: &str = {:?};\npub const TABLE_CELL_VALUE_TYPING: &str = {:?};\n\n",
+        grammar.value_typing.quoted, grammar.value_typing.bare, grammar.value_typing.table_cell
+    ));
     for (i, step) in grammar.steps.iter().enumerate() {
         let fn_name = format!("step_{}_{}", i, step.id);
         let macro_name = step.keyword.as_str(); // given|when|then

--- a/packages/engine/build_codegen/grammar_model.rs
+++ b/packages/engine/build_codegen/grammar_model.rs
@@ -8,6 +8,20 @@ use serde::Deserialize;
 #[derive(Debug, Deserialize)]
 pub struct Grammar {
     pub steps: Vec<Step>,
+    #[serde(default)]
+    pub value_typing: ValueTyping,
+}
+
+/// How a captured value is typed on its way to the engine. Owned by
+/// `bdd/grammar.yaml` so the Rust and JS dispatchers cannot drift apart on it.
+#[derive(Debug, Default, Deserialize)]
+pub struct ValueTyping {
+    #[serde(default)]
+    pub quoted: String,
+    #[serde(default)]
+    pub bare: String,
+    #[serde(default)]
+    pub table_cell: String,
 }
 
 #[derive(Debug, Deserialize)]

--- a/packages/engine/src/context.rs
+++ b/packages/engine/src/context.rs
@@ -102,15 +102,6 @@ impl RuleContext {
         })
     }
 
-    /// Create a context with a default date (today).
-    ///
-    /// Useful for testing.
-    #[allow(clippy::expect_used)]
-    pub fn with_defaults(parameters: BTreeMap<String, Value>) -> Self {
-        let today = chrono::Local::now().format("%Y-%m-%d").to_string();
-        Self::new(parameters, &today).expect("today's date should always be valid")
-    }
-
     /// Set definitions from an article's definitions section.
     ///
     /// Processes the Definition enum to extract actual values.
@@ -799,7 +790,7 @@ mod tests {
 
     #[test]
     fn test_empty_context() {
-        let ctx = RuleContext::with_defaults(BTreeMap::new());
+        let ctx = RuleContext::new(BTreeMap::new(), "2025-01-01").unwrap();
         let result = ctx.resolve("anything");
         assert!(matches!(result, Err(EngineError::VariableNotFound(_))));
     }

--- a/packages/engine/tests/bdd/dispatch.rs
+++ b/packages/engine/tests/bdd/dispatch.rs
@@ -69,21 +69,21 @@ impl RegelrechtWorld {
             "set_parameter" => {
                 let name = args[0].as_str().to_string();
                 let value = match &args[1] {
-                    ArgValue::Num(n) => num_to_value(*n),
-                    ArgValue::Str(s) => convert_gherkin_value(s),
+                    ArgValue::Num(n) => bare_value(*n),
+                    ArgValue::Str(s) => quoted_value(s),
                     ArgValue::Bool(b) => Value::Bool(*b),
                 };
                 self.parameters.insert(name, value);
             }
             "set_parameters_table" => {
-                for (k, v) in rows_to_params(&table.expect("parameters table")) {
+                for (k, v) in rows_to_params(&table.expect("parameters table"), table_cell_value) {
                     self.parameters.insert(k, v);
                 }
             }
             "set_data_source" => {
                 let source = args[0].as_str().to_string();
                 let key = args[1].as_str().to_string();
-                let rows = rows_to_records(&table.expect("data source table"));
+                let rows = rows_to_records(&table.expect("data source table"), table_cell_value);
                 self.data_sources.insert(source, (key, rows));
             }
 
@@ -133,8 +133,8 @@ impl RegelrechtWorld {
             }
             "assert_equals" => {
                 let expected = match &args[1] {
-                    ArgValue::Num(n) => num_to_value(*n),
-                    ArgValue::Str(s) => convert_gherkin_value(s),
+                    ArgValue::Num(n) => bare_value(*n),
+                    ArgValue::Str(s) => quoted_value(s),
                     ArgValue::Bool(b) => Value::Bool(*b),
                 };
                 let actual = self.output_value(args[0].as_str());
@@ -417,6 +417,34 @@ fn num_to_value(n: f64) -> Value {
                 .parse::<Decimal>()
                 .expect("numeric literal parses as Decimal"),
         )
+    }
+}
+
+/// Type a quoted capture. The rule lives in `bdd/grammar.yaml`
+/// (`value_typing.quoted`) and reaches both dispatchers through codegen, so
+/// neither engine can hold its own opinion about what quotes mean.
+fn quoted_value(raw: &str) -> Value {
+    match crate::generated_steps::QUOTED_VALUE_TYPING {
+        "literal" => Value::String(raw.to_string()),
+        "inferred" => convert_gherkin_value(raw),
+        other => panic!("bdd/grammar.yaml: unknown value_typing.quoted '{other}'"),
+    }
+}
+
+/// Type a bare (unquoted) capture; see [`quoted_value`] for where the rule lives.
+fn bare_value(n: f64) -> Value {
+    match crate::generated_steps::BARE_VALUE_TYPING {
+        "number" => num_to_value(n),
+        other => panic!("bdd/grammar.yaml: unknown value_typing.bare '{other}'"),
+    }
+}
+
+/// Type a data-table cell; see [`quoted_value`] for where the rule lives.
+fn table_cell_value(raw: &str) -> Value {
+    match crate::generated_steps::TABLE_CELL_VALUE_TYPING {
+        "inferred" => convert_gherkin_value(raw),
+        "literal" => Value::String(raw.trim().to_string()),
+        other => panic!("bdd/grammar.yaml: unknown value_typing.table_cell '{other}'"),
     }
 }
 

--- a/packages/engine/tests/bdd/helpers/table.rs
+++ b/packages/engine/tests/bdd/helpers/table.rs
@@ -8,7 +8,11 @@ use std::collections::BTreeMap;
 
 use regelrecht_engine::Value;
 
-use super::value_conversion::convert_gherkin_value;
+/// How a single cell becomes a `Value`. Passed in rather than called directly:
+/// the rule lives in `bdd/grammar.yaml` (`value_typing.table_cell`) and reaches
+/// the dispatch through codegen, which this module cannot see — it is also
+/// compiled standalone by `tests/bdd_table.rs`.
+pub type CellFn = fn(&str) -> Value;
 
 /// Table rows straight from cucumber's `gherkin::Step.table.rows`. Whether
 /// `row[0]` is a header depends on the step: a data-source table has one, a
@@ -16,11 +20,11 @@ use super::value_conversion::convert_gherkin_value;
 pub type Rows = Vec<Vec<String>>;
 
 /// Parse a two-column key/value parameter table.
-pub fn rows_to_params(rows: &Rows) -> BTreeMap<String, Value> {
+pub fn rows_to_params(rows: &Rows, cell: CellFn) -> BTreeMap<String, Value> {
     let mut params = BTreeMap::new();
     for row in rows {
         if row.len() >= 2 {
-            params.insert(row[0].trim().to_string(), convert_gherkin_value(&row[1]));
+            params.insert(row[0].trim().to_string(), cell(&row[1]));
         }
     }
     params
@@ -34,7 +38,7 @@ pub fn rows_to_params(rows: &Rows) -> BTreeMap<String, Value> {
 /// dependency we bump, though, and the editor's `tableToRecords` leans on a
 /// different parser with a different fallback. The explicit check makes both
 /// sides fail identically and loudly if either parser ever loosens.
-pub fn rows_to_records(rows: &Rows) -> Vec<BTreeMap<String, Value>> {
+pub fn rows_to_records(rows: &Rows, cell: CellFn) -> Vec<BTreeMap<String, Value>> {
     if rows.len() < 2 {
         return Vec::new();
     }
@@ -51,7 +55,7 @@ pub fn rows_to_records(rows: &Rows) -> Vec<BTreeMap<String, Value>> {
             headers
                 .iter()
                 .zip(row)
-                .map(|(header, cell)| (header.clone(), convert_gherkin_value(cell)))
+                .map(|(header, raw)| (header.clone(), cell(raw)))
                 .collect(),
         );
     }

--- a/packages/engine/tests/bdd_table.rs
+++ b/packages/engine/tests/bdd_table.rs
@@ -12,6 +12,7 @@ mod table;
 
 use regelrecht_engine::Value;
 use table::{rows_to_records, Rows};
+use value_conversion::convert_gherkin_value;
 
 fn rows(raw: &[&[&str]]) -> Rows {
     raw.iter()
@@ -21,10 +22,13 @@ fn rows(raw: &[&[&str]]) -> Rows {
 
 #[test]
 fn records_use_the_header_row() {
-    let records = rows_to_records(&rows(&[
-        &["naam", "leeftijd", "verzekerd"],
-        &["Jansen", "30", "true"],
-    ]));
+    let records = rows_to_records(
+        &rows(&[
+            &["naam", "leeftijd", "verzekerd"],
+            &["Jansen", "30", "true"],
+        ]),
+        convert_gherkin_value,
+    );
 
     assert_eq!(records.len(), 1);
     assert_eq!(
@@ -38,18 +42,21 @@ fn records_use_the_header_row() {
 #[test]
 #[should_panic(expected = "data table row 1 has 2 cells, header row has 3")]
 fn a_short_row_is_rejected_instead_of_dropping_a_column() {
-    rows_to_records(&rows(&[
-        &["naam", "leeftijd", "verzekerd"],
-        &["Jansen", "30"],
-    ]));
+    rows_to_records(
+        &rows(&[&["naam", "leeftijd", "verzekerd"], &["Jansen", "30"]]),
+        convert_gherkin_value,
+    );
 }
 
 #[test]
 #[should_panic(expected = "data table row 2 has 4 cells, header row has 3")]
 fn a_long_row_is_rejected_too() {
-    rows_to_records(&rows(&[
-        &["naam", "leeftijd", "verzekerd"],
-        &["Jansen", "30", "true"],
-        &["De Vries", "40", "false", "extra"],
-    ]));
+    rows_to_records(
+        &rows(&[
+            &["naam", "leeftijd", "verzekerd"],
+            &["Jansen", "30", "true"],
+            &["De Vries", "40", "false", "extra"],
+        ]),
+        convert_gherkin_value,
+    );
 }

--- a/packages/harvester/Cargo.toml
+++ b/packages/harvester/Cargo.toml
@@ -20,7 +20,7 @@ name = "regelrecht_harvester"
 path = "src/lib.rs"
 
 [dependencies]
-regelrecht-shared = { path = "../shared" }
+regelrecht-shared = { path = "../shared", features = ["dates"] }
 serde.workspace = true
 serde_yaml_ng.workspace = true
 thiserror.workspace = true

--- a/packages/harvester/src/cli.rs
+++ b/packages/harvester/src/cli.rs
@@ -87,7 +87,7 @@ async fn download_command(
     // Use today if no date provided
     let effective_date = date
         .map(String::from)
-        .unwrap_or_else(|| chrono::Local::now().format("%Y-%m-%d").to_string());
+        .unwrap_or_else(regelrecht_shared::dates::today_str);
 
     // Validate output directory exists (if specified) before downloading
     if let Some(output_dir) = output {

--- a/packages/harvester/src/config.rs
+++ b/packages/harvester/src/config.rs
@@ -99,7 +99,7 @@ pub fn validate_date(date_str: &str) -> Result<()> {
         .map_err(|_| HarvesterError::InvalidDate(date_str.to_string()))?;
 
     // Reject future dates - BWB won't have consolidated versions for them
-    let today = chrono::Local::now().date_naive();
+    let today = regelrecht_shared::dates::today();
     if parsed_date > today {
         return Err(HarvesterError::InvalidDate(format!(
             "{date_str} is in the future (today is {today})"

--- a/packages/harvester/src/cvdr/mod.rs
+++ b/packages/harvester/src/cvdr/mod.rs
@@ -78,7 +78,7 @@ pub async fn download_cvdr_law(client: &Client, cvdr_id: &str, date: Option<&str
     let effective_date = date
         .map(String::from)
         .or_else(|| metadata_result.effective_date.clone())
-        .unwrap_or_else(|| chrono::Local::now().format("%Y-%m-%d").to_string());
+        .unwrap_or_else(regelrecht_shared::dates::today_str);
 
     let base_url = lokaleregelgeving_url(cvdr_id);
     let parsed = parse_cvdr_articles(&xml_content, &base_url)?;

--- a/packages/harvester/src/source.rs
+++ b/packages/harvester/src/source.rs
@@ -58,7 +58,7 @@ impl LawSource for BwbSource {
         // BWB requires a date; default to today if not provided.
         let effective_date = date
             .map(String::from)
-            .unwrap_or_else(|| chrono::Local::now().format("%Y-%m-%d").to_string());
+            .unwrap_or_else(regelrecht_shared::dates::today_str);
 
         let max_mb = self
             .max_size_mb

--- a/packages/pipeline/Cargo.toml
+++ b/packages/pipeline/Cargo.toml
@@ -29,7 +29,7 @@ regelrecht-corpus = { path = "../corpus" }
 regelrecht-engine = { path = "../engine", features = ["validate"] }
 regelrecht-harvester = { path = "../harvester", default-features = false }
 regelrecht-law-model = { path = "../law-model" }
-regelrecht-shared = { path = "../shared", features = ["telemetry"] }
+regelrecht-shared = { path = "../shared", features = ["telemetry", "dates"] }
 sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls-aws-lc-rs", "postgres", "uuid", "chrono", "json", "migrate"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "process", "time", "fs", "net", "io-util"] }
 serde.workspace = true

--- a/packages/pipeline/src/harvest.rs
+++ b/packages/pipeline/src/harvest.rs
@@ -190,7 +190,7 @@ pub async fn execute_harvest(
             .date
             .clone()
             .or_else(|| law.metadata.effective_date.clone())
-            .unwrap_or_else(|| Utc::now().format("%Y-%m-%d").to_string());
+            .unwrap_or_else(regelrecht_shared::dates::today_str);
         (law, effective_date)
     };
 

--- a/packages/pipeline/src/law_convert.rs
+++ b/packages/pipeline/src/law_convert.rs
@@ -15,7 +15,6 @@
 
 use std::path::Path;
 
-use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 use uuid::Uuid;
@@ -203,7 +202,7 @@ fn build_structure_prompt(source_file: &str, source_is_text: bool, source_url: &
     .map(|(k, v)| format!("   - `{k}`: {v}"))
     .collect::<Vec<_>>()
     .join("\n");
-    let today = Utc::now().format("%Y-%m-%d");
+    let today = regelrecht_shared::dates::today_str();
     format!(
         "You are converting a source document into a regelrecht base-law YAML file — the same \
          article-based format the BWB harvester produces. The document is not necessarily a \

--- a/packages/shared/Cargo.toml
+++ b/packages/shared/Cargo.toml
@@ -12,10 +12,15 @@ keywords = ["law", "legal", "dutch", "regelrecht", "types"]
 [dependencies]
 serde.workspace = true
 tracing-subscriber = { workspace = true, optional = true }
+chrono = { workspace = true, optional = true }
+chrono-tz = { workspace = true, optional = true }
 
 [features]
 default = []
 telemetry = ["dep:tracing-subscriber"]
+# Europe/Amsterdam calendar dates. Optional so the crates that only want the
+# domain types (law-model, and through it corpus) stay free of chrono.
+dates = ["dep:chrono", "dep:chrono-tz"]
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/packages/shared/src/dates.rs
+++ b/packages/shared/src/dates.rs
@@ -1,0 +1,67 @@
+//! Today's calendar date, in the timezone Dutch law is written in.
+//!
+//! Which version of a law is in force, which consolidated text BWB will serve,
+//! which date a harvested file is named after — all of these are statements
+//! about the Dutch calendar. The timezone of the machine doing the asking is an
+//! accident of deployment: containers run UTC, a laptop runs whatever the
+//! traveller's laptop runs. So neither `Local::now()` nor `Utc::now()` answers
+//! the question. `Europe/Amsterdam` does, and it is the only clock this
+//! workspace reads a calendar date off.
+//!
+//! Instants are a different matter. A `last_harvested` stamp or a job timestamp
+//! records a moment, not a calendar day, and those stay `Utc::now()`.
+
+use chrono::{DateTime, NaiveDate, Utc};
+use chrono_tz::Europe::Amsterdam;
+
+/// The calendar date in the Netherlands right now.
+pub fn today() -> NaiveDate {
+    date_at(Utc::now())
+}
+
+/// The calendar date in the Netherlands as `YYYY-MM-DD`.
+pub fn today_str() -> String {
+    today().format("%Y-%m-%d").to_string()
+}
+
+/// The Dutch calendar date an instant falls on. Split out from [`today`] so the
+/// mapping is testable without a clock.
+pub fn date_at(instant: DateTime<Utc>) -> NaiveDate {
+    instant.with_timezone(&Amsterdam).date_naive()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::date_at;
+    use chrono::{NaiveDate, TimeZone, Utc};
+
+    fn utc(y: i32, m: u32, d: u32, h: u32, min: u32) -> chrono::DateTime<Utc> {
+        Utc.with_ymd_and_hms(y, m, d, h, min, 0).single().unwrap()
+    }
+
+    #[test]
+    fn winter_time_runs_an_hour_ahead_of_utc() {
+        // 00:30 CET on new year's day is still 23:30 UTC on the 31st. A UTC
+        // clock names the harvest file after the old year.
+        assert_eq!(
+            date_at(utc(2025, 12, 31, 23, 30)),
+            NaiveDate::from_ymd_opt(2026, 1, 1).unwrap()
+        );
+    }
+
+    #[test]
+    fn summer_time_runs_two_hours_ahead_of_utc() {
+        assert_eq!(
+            date_at(utc(2026, 6, 30, 22, 30)),
+            NaiveDate::from_ymd_opt(2026, 7, 1).unwrap()
+        );
+    }
+
+    #[test]
+    fn midday_utc_lands_on_the_same_day() {
+        assert_eq!(
+            date_at(utc(2026, 6, 30, 12, 0)),
+            NaiveDate::from_ymd_opt(2026, 6, 30).unwrap()
+        );
+    }
+}

--- a/packages/shared/src/lib.rs
+++ b/packages/shared/src/lib.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "dates")]
+pub mod dates;
 pub mod regulatory_layer;
 #[cfg(feature = "telemetry")]
 pub mod telemetry;

--- a/packages/tui/Cargo.toml
+++ b/packages/tui/Cargo.toml
@@ -22,6 +22,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "pr
 # Workspace crates
 regelrecht-engine = { path = "../engine" }
 regelrecht-law-model = { path = "../law-model" }
+regelrecht-shared = { path = "../shared", features = ["dates"] }
 
 # File system
 walkdir.workspace = true

--- a/packages/tui/src/views/engine.rs
+++ b/packages/tui/src/views/engine.rs
@@ -50,7 +50,7 @@ impl EngineView {
                 value: String::new(),
             }],
             param_cursor: 0,
-            date_input: chrono::Local::now().format("%Y-%m-%d").to_string(),
+            date_input: regelrecht_shared::dates::today_str(),
             editing_date: false,
             result: None,
             trace: None,


### PR DESCRIPTION
Vijf plekken uit issue [1182](https://github.com/MinBZK/regelrecht/issues/1182) waar dezelfde regel twee of drie keer bestond en uit elkaar was gelopen: de datumlezer voor versiekeuze (lokaal koos anders dan via GitHub), "vandaag" als Nederlandse kalenderdatum, een bedrag herkennen aan `type_spec.unit` in plaats van aan de veldnaam, de typering van een parameterwaarde, en de versiekeuze in de e2e-corpusmock.

Elk punt heeft een test die zonder de fix omvalt, per punt geverifieerd door de fix terug te draaien.

Eén keuze om te wegen: de typeringsregel in `bdd/grammar.yaml` is `inferred` geworden en niet "aanhalingstekens betekenen tekst". Dat laatste breekt op de editor, die elke boolean als `is "true"` schrijft; die zou dan als string aankomen bij een `Bool`-vergelijking en `EQUALS` is structureel, dus dat gaat stil op onwaar. De prijs is dat een cijferige identifier zijn stringvorm verliest, wat issue 1172 is.