### PR TITLE
ci: dekking terug die met de opt-in previews wegviel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -468,6 +468,20 @@ jobs:
       - name: Run shared-package tests
         run: npm test -w packages/frontend-shared
 
+      # De productiebundel werd tot nu toe alleen in frontend/Dockerfile
+      # gemaakt, en sinds de images uit de standaardloop van een PR zijn
+      # gehaald draaide `vite build` nergens meer. Dit dekt in één stap de
+      # bundel plus de drie scripts die eraan hangen: copy-laws (prebuild),
+      # check-first-load en precompress.
+      #
+      # Na de tests: `prebuild` schrijft in frontend/public/data, en die map
+      # hoort niet onder de vitest-run te veranderen.
+      - name: Build editor bundle
+        run: npm run build -w frontend
+
+      - name: Build lawmaking bundle
+        run: npm run build -w frontend-lawmaking
+
   # Verplichte check op main. De benen hierboven dragen nieuwe namen en mogen
   # dus van vorm veranderen; deze naam moet blijven bestaan, want een required
   # check die niet verschijnt laat elke PR eeuwig hangen. Skipped benen (geen

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -503,18 +503,39 @@ jobs:
   # relevante wijziging) gelden hier als geslaagd.
   test:
     name: Test
-    needs: [rust-tests, frontend-tests]
+    needs:
+      - rust-tests
+      - frontend-tests
+      # Deze vier draaiden al bij elke PR maar blokkeerden niets. Ze hier
+      # aanhangen kost geen runnerminuut en geen nieuwe required context bij
+      # branch protection.
+      - e2e
+      - cross-law-integrity
+      - provenance-checks
+      - docs-a11y
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      # Elke voorganger krijgt een eigen `check`-regel; script/ci-gate.test.mjs
+      # rekent na dat de lijst hieronder en `needs` niet uiteenlopen, en dat
+      # skipped geslaagd blijft.
       - name: Gate
         run: |
-          echo "rust-tests: ${{ needs.rust-tests.result }}"
-          echo "frontend-tests: ${{ needs.frontend-tests.result }}"
-          case "${{ needs.rust-tests.result }} ${{ needs.frontend-tests.result }}" in
-            *failure*|*cancelled*) echo "::error::een testbeen faalde"; exit 1 ;;
-          esac
+          status=0
+          check() {
+            case "$2" in
+              failure|cancelled) echo "::error::$1 gaf $2"; status=1 ;;
+              *) echo "$1: $2" ;;
+            esac
+          }
+          check rust-tests "${{ needs.rust-tests.result }}"
+          check frontend-tests "${{ needs.frontend-tests.result }}"
+          check e2e "${{ needs.e2e.result }}"
+          check cross-law-integrity "${{ needs.cross-law-integrity.result }}"
+          check provenance-checks "${{ needs.provenance-checks.result }}"
+          check docs-a11y "${{ needs.docs-a11y.result }}"
+          exit "$status"
 
   wasm:
     name: WASM Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,6 @@ jobs:
               # copy-laws.js leest het register om te bepalen welke wetten in
               # de bundel meegaan.
               - corpus-registry.yaml
-              # De Dockerfile-consistentietest in de Pre-commit-baan leest de
-              # BIN-build-args hieruit.
-              - .github/workflows/deploy.yml
               # The schema reference doc is version-locked to schema/latest by
               # provenance-checks; edit it and that guard must re-run.
               - docs/src/content/docs/reference/schema.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
     outputs:
       ci: ${{ steps.filter.outputs.ci }}
       docs: ${{ steps.filter.outputs.docs }}
+      rust-image: ${{ steps.filter.outputs.rust-image }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
@@ -66,6 +67,17 @@ jobs:
               - .github/workflows/ci.yml
             docs:
               - docs/**
+              - .github/workflows/ci.yml
+            # Wat de bouw van een Rust-image kan breken. Smaller dan `ci`: een
+            # wijziging in frontend/ of bdd/ raakt deze Dockerfiles niet, en die
+            # build kost 4,5 minuut.
+            rust-image:
+              - packages/**
+              # De Dockerfile doet `COPY schema/ /schema/`; de engine leest die
+              # paden met include_str!, en die kloppen in de image om een andere
+              # reden dan in de repo.
+              - schema/**
+              - rust-toolchain.toml
               - .github/workflows/ci.yml
 
   protect-schema:
@@ -513,6 +525,7 @@ jobs:
       - cross-law-integrity
       - provenance-checks
       - docs-a11y
+      - rust-image
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -549,6 +562,7 @@ jobs:
           check cross-law-integrity "${{ needs.cross-law-integrity.result }}"
           check provenance-checks "${{ needs.provenance-checks.result }}"
           check docs-a11y "${{ needs.docs-a11y.result }}"
+          check rust-image "${{ needs.rust-image.result }}"
           exit "$status"
 
   wasm:
@@ -593,6 +607,69 @@ jobs:
       - name: Skip (no relevant changes)
         if: needs.changes.outputs.ci != 'true'
         run: echo "No relevant changes, skipping WASM build"
+
+  # Sinds de previews opt-in werden (#1204) bouwt een PR geen images meer, dus
+  # of een Rust-image überhaupt bouwt bleek pas op main, met deploy-production
+  # er direct achteraan. De machinerie die daar stuk kan: de musl-toolchain, het
+  # release-profiel, de cargo-chef-lagen, de `COPY schema/` waar include_str!
+  # aan hangt, en de bin-naam in `COPY --from=builder`.
+  #
+  # Eén image is genoeg. De drie Rust-Dockerfiles delen deze hele machinerie en
+  # verschillen alleen in welke members ze kopiëren en welke binary ze eruit
+  # halen; dat verschil dekt script/dockerfile-consistency.test.mjs statisch af.
+  # pipeline-api is de goedkoopste van de drie: gemeten 4,4 tot 4,8 minuut met
+  # warme cache.
+  #
+  # Hij hangt aan de `Test`-poort en blokkeert dus. Een build waarop gewacht
+  # wordt maar die niets tegenhoudt kost de wandklok zonder de garantie te
+  # leveren; dan kun je hem net zo goed niet draaien.
+  rust-image:
+    name: Rust image build
+    needs: changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      # Alleen lezen: deze build duwt niets naar GHCR. Zie `push: false`.
+      packages: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        if: needs.changes.outputs.rust-image == 'true'
+
+      - name: Set up Docker Buildx
+        if: needs.changes.outputs.rust-image == 'true'
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
+
+      # Nodig om de buildcache uit GHCR te mogen lezen; zonder login bouwt hij
+      # alles koud en loopt de job richting het kwartier.
+      - name: Log in to Container Registry
+        if: needs.changes.outputs.rust-image == 'true'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Dezelfde inputs als build-pipeline-api in deploy.yml, op push na. Lopen
+      # die twee uiteen, dan bewijst deze baan iets anders dan er gedeployd
+      # wordt; script/dockerfile-consistency.test.mjs bewaakt de namen.
+      - name: Build pipeline-api image
+        if: needs.changes.outputs.rust-image == 'true'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+        with:
+          context: .
+          file: packages/pipeline/Dockerfile
+          target: pipeline-api
+          build-args: BIN=regelrecht-pipeline-api
+          # Niets pushen en niets in de daemon laden: het gaat om de bouw, niet
+          # om het artefact. Ook geen cache-to, want alleen main schrijft cache.
+          push: false
+          load: false
+          cache-from: type=registry,ref=ghcr.io/minbzk/regelrecht-buildcache:pipeline-api
+
+      - name: Skip (no relevant changes)
+        if: needs.changes.outputs.rust-image != 'true'
+        run: echo "Geen wijziging die een Rust-image raakt, image-build overgeslagen"
 
   # De enige job die de editor in een echte browser laadt. Unit-tests draaien op
   # happy-dom, en die ziet het WASM-laadpad in

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,6 +501,9 @@ jobs:
   test:
     name: Test
     needs:
+      # Niet als voorganger die iets test, maar omdat elke baan hieronder eraan
+      # hangt: valt `changes` om, dan slaan ze allemaal over.
+      - changes
       - rust-tests
       - frontend-tests
       # Deze vier draaiden al bij elke PR maar blokkeerden niets. Ze hier
@@ -526,6 +529,20 @@ jobs:
               *) echo "$1: $2" ;;
             esac
           }
+          # `changes` is de enige voorganger die geslaagd MOET zijn. Overgeslagen
+          # geldt hieronder als geslaagd, en terecht: een PR die geen Rust raakt
+          # hoort niet te blijven hangen op een testbaan die niets te doen had.
+          # Maar valt `changes` zelf om, dan slaan al zijn afhankelijken over om
+          # een heel andere reden, en zou de poort die zes stuk voor stuk als
+          # geslaagd lezen. De hele required set wordt dan groen terwijl er niets
+          # gedraaid is.
+          require() {
+            case "$2" in
+              success) echo "$1: $2" ;;
+              *) echo "::error::$1 gaf $2, dus de banen erachter zijn nooit gedraaid"; status=1 ;;
+            esac
+          }
+          require changes "${{ needs.changes.result }}"
           check rust-tests "${{ needs.rust-tests.result }}"
           check frontend-tests "${{ needs.frontend-tests.result }}"
           check e2e "${{ needs.e2e.result }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,26 @@ jobs:
               # Alle crates; een handmatige opsomming dreef eerder weg.
               - packages/**
               - frontend/**
+              - frontend-lawmaking/**
               - packages/frontend-shared/**
               - bdd/**
               - corpus/regulation/**
               - schema/**
               - script/**
+              # De npm-workspace zelf: een dependency-bump raakt alleen deze
+              # drie bestanden en zou anders elke frontend-, e2e- en wasm-baan
+              # overslaan.
+              - package.json
+              - package-lock.json
+              - .npmrc
+              # De Rust-versie waarop alle Rust-banen draaien.
+              - rust-toolchain.toml
+              # copy-laws.js leest het register om te bepalen welke wetten in
+              # de bundel meegaan.
+              - corpus-registry.yaml
+              # De Dockerfile-consistentietest in de Pre-commit-baan leest de
+              # BIN-build-args hieruit.
+              - .github/workflows/deploy.yml
               # The schema reference doc is version-locked to schema/latest by
               # provenance-checks; edit it and that guard must re-run.
               - docs/src/content/docs/reference/schema.md

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,6 +85,13 @@ repos:
         pass_filenames: false
         files: ^(\.github/workflows/ci\.yml|script/ci-gate\.test\.mjs)$
 
+      - id: dockerfile-consistency
+        name: Rust-Dockerfiles blijven bij de cargo-workspace
+        entry: just dockerfile-consistency-test
+        language: system
+        pass_filenames: false
+        files: ^(frontend/Dockerfile|packages/(admin|pipeline)/Dockerfile|packages/Cargo\.toml|rust-toolchain\.toml|\.github/workflows/deploy\.yml|script/dockerfile-consistency\.test\.mjs)$
+
       - id: skills-no-casus
         name: Skills blijven dossier-agnostisch (geen casus-inhoud)
         entry: script/check-skills-no-casus.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,6 +78,13 @@ repos:
         pass_filenames: false
         files: ^(script/await-claude-review(\.test)?\.sh|\.github/workflows/claude-code-review\.yml)$
 
+      - id: ci-gate-tests
+        name: Test-poort in ci.yml blokkeert op een gevallen voorganger
+        entry: just ci-gate-test
+        language: system
+        pass_filenames: false
+        files: ^(\.github/workflows/ci\.yml|script/ci-gate\.test\.mjs)$
+
       - id: skills-no-casus
         name: Skills blijven dossier-agnostisch (geen casus-inhoud)
         entry: script/check-skills-no-casus.sh

--- a/Justfile
+++ b/Justfile
@@ -107,11 +107,18 @@ first-load-test:
 ci-gate-test:
     node --test script/ci-gate.test.mjs
 
+# Houdt de drie Rust-Dockerfiles bij de workspace: elke member wordt ge-COPYd
+# of weggeknipt, de rust-tag volgt rust-toolchain.toml en elke binary-naam
+# bestaat. Die drie zijn stringliteralen die verder niets nakijkt.
+[doc("Check the Rust Dockerfiles against the cargo workspace")]
+dockerfile-consistency-test:
+    node --test script/dockerfile-consistency.test.mjs
+
 # Run all quality checks, exactly what CI runs. Needs Docker for the
 # container-backed suites; on a machine without a daemon, swap `test` for
 # `test-no-docker`.
 [doc("Run all quality checks, exactly what CI runs (needs Docker)")]
-check: format lint build-check validate validate-annotations deploy-filters-test precompress-test security-headers-test first-load-test ci-gate-test test
+check: format lint build-check validate validate-annotations deploy-filters-test precompress-test security-headers-test first-load-test ci-gate-test dockerfile-consistency-test test
 
 # --- Tests ---
 

--- a/Justfile
+++ b/Justfile
@@ -100,11 +100,18 @@ security-headers-test:
 first-load-test:
     node --test frontend/scripts/check-first-load.test.mjs
 
+# Draait het shellfragment van de `Test`-poort uit ci.yml met echte
+# resultaatwaarden. Zonder dit is een voorganger die wel in `needs` staat maar
+# niet gelezen wordt niet van een werkende poort te onderscheiden.
+[doc("Check that the Test gate in ci.yml blocks on a failed predecessor")]
+ci-gate-test:
+    node --test script/ci-gate.test.mjs
+
 # Run all quality checks, exactly what CI runs. Needs Docker for the
 # container-backed suites; on a machine without a daemon, swap `test` for
 # `test-no-docker`.
 [doc("Run all quality checks, exactly what CI runs (needs Docker)")]
-check: format lint build-check validate validate-annotations deploy-filters-test precompress-test security-headers-test first-load-test test
+check: format lint build-check validate validate-annotations deploy-filters-test precompress-test security-headers-test first-load-test ci-gate-test test
 
 # --- Tests ---
 

--- a/script/ci-gate.test.mjs
+++ b/script/ci-gate.test.mjs
@@ -1,0 +1,144 @@
+// De `Test`-poort in .github/workflows/ci.yml is de enige required check die
+// het testwerk afdekt. Hij is één shellfragment met een `case`, en die vorm
+// faalt stil op twee manieren: een voorganger die wel in `needs` staat maar
+// niet in het fragment wordt nooit gelezen, en een `case` die `skipped` niet
+// als geslaagd behandelt laat elke PR omvallen die een baan overslaat.
+//
+// Deze test knipt het fragment uit de workflow, vult echte resultaatwaarden in
+// en draait het. Node's ingebouwde runner, geen dependency: de Pre-commit-baan
+// heeft Node maar geen node_modules.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const WORKFLOW = fileURLToPath(new URL('../.github/workflows/ci.yml', import.meta.url));
+const source = readFileSync(WORKFLOW, 'utf8');
+const lines = source.split('\n');
+
+/** Regelnummers waarop een baan op het bovenste niveau van `jobs:` begint. */
+function jobStarts() {
+  const starts = new Map();
+  let inJobs = false;
+  for (const [index, line] of lines.entries()) {
+    if (/^jobs:\s*$/.test(line)) { inJobs = true; continue; }
+    if (!inJobs) continue;
+    if (/^\S/.test(line)) break;
+    const match = /^ {2}([A-Za-z0-9_-]+):\s*$/.exec(line);
+    if (match) starts.set(match[1], index);
+  }
+  return starts;
+}
+
+const JOBS = jobStarts();
+
+/** De regels van één baan, tot aan de volgende baan. */
+function jobBody(name) {
+  const start = JOBS.get(name);
+  assert.ok(start !== undefined, `baan ${name} bestaat niet in ci.yml`);
+  const next = [...JOBS.values()].filter((i) => i > start).sort((a, b) => a - b)[0];
+  return lines.slice(start + 1, next ?? lines.length);
+}
+
+/** De namen in `needs:` van de poort, in beide YAML-vormen. */
+function gateNeeds() {
+  const body = jobBody('test');
+  const index = body.findIndex((line) => /^ {4}needs:/.test(line));
+  assert.ok(index !== -1, 'de poort heeft geen needs:');
+
+  const inline = /^ {4}needs:\s*\[(.+)\]\s*$/.exec(body[index]);
+  if (inline) return inline[1].split(',').map((n) => n.trim());
+
+  const names = [];
+  for (const line of body.slice(index + 1)) {
+    if (/^\s*#/.test(line) || line.trim() === '') continue;
+    const item = /^ {6}-\s*([A-Za-z0-9_-]+)\s*$/.exec(line);
+    if (!item) break;
+    names.push(item[1]);
+  }
+  return names;
+}
+
+/** Het shellfragment onder `run:` van de Gate-stap. */
+function gateScript() {
+  const body = jobBody('test');
+  const index = body.findIndex((line) => /^ {8}run: \|\s*$/.test(line));
+  assert.ok(index !== -1, 'de Gate-stap heeft geen `run: |`-blok');
+
+  const script = [];
+  for (const line of body.slice(index + 1)) {
+    if (line.trim() !== '' && !line.startsWith('          ')) break;
+    script.push(line.slice(10));
+  }
+  return script.join('\n');
+}
+
+const NEEDS = gateNeeds();
+const SCRIPT = gateScript();
+
+/**
+ * Draai de poort met een resultaat per voorganger. `${{ needs.X.result }}`
+ * wordt vervangen zoals Actions dat doet: platte tekstsubstitutie vóór de shell
+ * het fragment ziet.
+ */
+function runGate(results) {
+  const filled = SCRIPT.replace(/\$\{\{\s*needs\.([A-Za-z0-9_-]+)\.result\s*\}\}/g, (_, job) => {
+    assert.ok(job in results, `geen resultaat opgegeven voor ${job}`);
+    return results[job];
+  });
+  return spawnSync('bash', ['-c', filled], { encoding: 'utf8' });
+}
+
+const withAll = (value) => Object.fromEntries(NEEDS.map((job) => [job, value]));
+
+test('de poort hangt aan de vier checks die tot nu toe niets blokkeerden', () => {
+  for (const job of ['e2e', 'cross-law-integrity', 'provenance-checks', 'docs-a11y']) {
+    assert.ok(NEEDS.includes(job), `${job} hangt niet aan de poort`);
+    assert.ok(JOBS.has(job), `${job} bestaat niet als baan in ci.yml`);
+  }
+});
+
+test('elke voorganger uit needs wordt in het fragment ook echt gelezen', () => {
+  // Zonder deze assertie levert een vergeten regel een groene poort op voor een
+  // baan die rood is.
+  const read = new Set([...SCRIPT.matchAll(/needs\.([A-Za-z0-9_-]+)\.result/g)].map((m) => m[1]));
+  for (const job of NEEDS) {
+    assert.ok(read.has(job), `${job} staat in needs maar wordt niet gelezen door de poort`);
+  }
+  for (const job of read) {
+    assert.ok(NEEDS.includes(job), `de poort leest ${job} maar heeft hem niet in needs`);
+  }
+});
+
+test('alles geslaagd laat de poort door', () => {
+  assert.equal(runGate(withAll('success')).status, 0);
+});
+
+test('alles overgeslagen laat de poort door', () => {
+  // Een PR die alleen docs raakt slaat elke testbaan over. Zou skipped hier
+  // rood worden, dan blokkeert de required check zo'n PR voorgoed.
+  assert.equal(runGate(withAll('skipped')).status, 0);
+});
+
+test('een gevallen voorganger laat de poort omvallen, welke dan ook', () => {
+  for (const job of NEEDS) {
+    const result = runGate({ ...withAll('success'), [job]: 'failure' });
+    assert.equal(result.status, 1, `${job} op failure liet de poort door`);
+    assert.match(result.stdout, new RegExp(`::error::${job} gaf failure`));
+  }
+});
+
+test('een afgebroken voorganger laat de poort omvallen, welke dan ook', () => {
+  for (const job of NEEDS) {
+    const result = runGate({ ...withAll('skipped'), [job]: 'cancelled' });
+    assert.equal(result.status, 1, `${job} op cancelled liet de poort door`);
+  }
+});
+
+test('een gevallen voorganger tussen overgeslagen banen valt niet weg', () => {
+  const [first] = NEEDS;
+  const result = runGate({ ...withAll('skipped'), [first]: 'failure' });
+  assert.equal(result.status, 1);
+});

--- a/script/ci-gate.test.mjs
+++ b/script/ci-gate.test.mjs
@@ -93,7 +93,13 @@ function runGate(results) {
   return spawnSync('bash', ['-e', '-o', 'pipefail', '-c', filled], { encoding: 'utf8' });
 }
 
-const withAll = (value) => Object.fromEntries(NEEDS.map((job) => [job, value]));
+// De baan die bepaalt of de rest überhaupt draait. Hij hoort niet in de
+// skipped-is-geslaagd-regel thuis en heeft daarom zijn eigen assertie.
+const STRICT = 'changes';
+
+/** Alle voorgangers op `value`, behalve `changes`: die blijft geslaagd. */
+const withAll = (value) =>
+  Object.fromEntries(NEEDS.map((job) => [job, job === STRICT ? 'success' : value]));
 
 test('de poort hangt aan de vier checks die tot nu toe niets blokkeerden', () => {
   for (const job of ['e2e', 'cross-law-integrity', 'provenance-checks', 'docs-a11y']) {
@@ -122,6 +128,19 @@ test('alles overgeslagen laat de poort door', () => {
   // Een PR die alleen docs raakt slaat elke testbaan over. Zou skipped hier
   // rood worden, dan blokkeert de required check zo'n PR voorgoed.
   assert.equal(runGate(withAll('skipped')).status, 0);
+});
+
+test('de poort hangt aan changes en leest hem strikt', () => {
+  assert.ok(NEEDS.includes(STRICT), `${STRICT} hangt niet aan de poort`);
+  assert.ok(JOBS.has(STRICT), `${STRICT} bestaat niet als baan in ci.yml`);
+
+  // Overgeslagen of gefaald hoort hier rood te zijn, ook al is skipped voor elke
+  // andere voorganger geslaagd: de rest heeft dan niet gedraaid.
+  for (const result of ['skipped', 'failure', 'cancelled']) {
+    const run = runGate({ ...withAll('skipped'), [STRICT]: result });
+    assert.equal(run.status, 1, `changes op ${result} liet de poort door`);
+    assert.match(run.stdout, /::error::changes gaf/);
+  }
 });
 
 test('een gevallen voorganger laat de poort omvallen, welke dan ook', () => {

--- a/script/ci-gate.test.mjs
+++ b/script/ci-gate.test.mjs
@@ -88,7 +88,9 @@ function runGate(results) {
     assert.ok(job in results, `geen resultaat opgegeven voor ${job}`);
     return results[job];
   });
-  return spawnSync('bash', ['-c', filled], { encoding: 'utf8' });
+  // Dezelfde shellvlaggen als de standaardshell van Actions (`bash -e -o
+  // pipefail`), anders bewijst een groene test niets over de echte run.
+  return spawnSync('bash', ['-e', '-o', 'pipefail', '-c', filled], { encoding: 'utf8' });
 }
 
 const withAll = (value) => Object.fromEntries(NEEDS.map((job) => [job, value]));

--- a/script/dockerfile-consistency.test.mjs
+++ b/script/dockerfile-consistency.test.mjs
@@ -1,0 +1,155 @@
+// De Rust-Dockerfiles knippen workspace-members weg met een letterlijke `sed`.
+// Komt er een member bij die niet wordt ge-COPY'd én niet wordt weggeknipt,
+// dan sterft `cargo chef prepare` — en sinds de images uit de standaardloop van
+// een PR zijn gehaald merkt niemand dat op de PR zelf. Hetzelfde geldt voor de
+// binary-namen: `--build-arg BIN=` en het `COPY --from=builder`-pad zijn
+// stringliteralen die niets nakijkt.
+//
+// Node's ingebouwde runner, geen dependency: dit draait in de Pre-commit-baan,
+// die Node en cargo heeft maar geen node_modules.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
+
+const root = fileURLToPath(new URL('../', import.meta.url));
+const read = (path) => readFileSync(join(root, path), 'utf8');
+
+const DOCKERFILES = [
+  'packages/admin/Dockerfile',
+  'packages/pipeline/Dockerfile',
+  'frontend/Dockerfile',
+];
+
+/** De members uit packages/Cargo.toml, in de multiline vorm die de `sed` aanneemt. */
+function workspaceMembers() {
+  const manifest = read('packages/Cargo.toml');
+  const block = /^members = \[$([\s\S]*?)^\]$/m.exec(manifest);
+  assert.ok(block, 'packages/Cargo.toml heeft geen meerregelige members-array');
+  return block[1]
+    .split('\n')
+    .map((line) => /^\s*"([^"]+)",?\s*$/.exec(line))
+    .filter(Boolean)
+    .map((match) => match[1]);
+}
+
+/**
+ * De bouwtrappen van een Dockerfile die de workspace bijknippen: alles tussen
+ * een `FROM` en de volgende, mits er een `sed -i` op Cargo.toml in staat.
+ */
+function trimStages(path) {
+  const stages = [];
+  let current = null;
+  for (const line of read(path).split('\n')) {
+    if (/^FROM /.test(line)) {
+      if (current) stages.push(current);
+      const named = / AS (\S+)\s*$/.exec(line);
+      current = { name: named ? named[1] : line.trim(), lines: [] };
+    } else if (current) {
+      current.lines.push(line);
+    }
+  }
+  if (current) stages.push(current);
+
+  return stages
+    .map((stage) => {
+      const body = stage.lines.join('\n');
+      if (!/sed -i .*Cargo\.toml/.test(body)) return null;
+      const sed = /sed -i '([^']*)' Cargo\.toml/.exec(body);
+      assert.ok(sed, `${path} (${stage.name}): sed-opdracht niet te lezen`);
+      const dropped = [...sed[1].matchAll(/\/"([^"]+)"\/d/g)].map((m) => m[1]);
+      const copied = [...body.matchAll(/^COPY packages\/([a-z0-9-]+)\/ \1\/$/gm)].map((m) => m[1]);
+      return { where: `${path} (${stage.name})`, dropped, copied };
+    })
+    .filter(Boolean);
+}
+
+const MEMBERS = workspaceMembers();
+const STAGES = DOCKERFILES.flatMap(trimStages);
+
+/** De bin-targets van de workspace volgens cargo zelf. */
+function binTargets() {
+  const meta = JSON.parse(
+    execFileSync('cargo', ['metadata', '--no-deps', '--format-version', '1'], {
+      cwd: join(root, 'packages'),
+      maxBuffer: 64 * 1024 * 1024,
+      encoding: 'utf8',
+    }),
+  );
+  const bins = new Set();
+  for (const pkg of meta.packages) {
+    for (const target of pkg.targets) {
+      if (target.kind.includes('bin')) bins.add(target.name);
+    }
+  }
+  return bins;
+}
+
+test('elke bouwtrap die knipt is ook gevonden', () => {
+  // Zonder deze ondergrens zou een stukgelopen parser als een groene test
+  // langskomen: nul trappen halen elke assertie hieronder vacuüm.
+  assert.ok(STAGES.length >= 4, `slechts ${STAGES.length} knippende bouwtrappen gevonden`);
+  assert.ok(MEMBERS.length >= 12, `slechts ${MEMBERS.length} members gelezen`);
+});
+
+test('elke workspace-member is in elke Rust-Dockerfile ge-COPYd of weggeknipt', () => {
+  for (const stage of STAGES) {
+    const accounted = new Set([...stage.dropped, ...stage.copied]);
+    for (const member of MEMBERS) {
+      assert.ok(
+        accounted.has(member),
+        `${stage.where}: member "${member}" wordt niet ge-COPYd en niet weggeknipt — cargo chef prepare faalt hierop`,
+      );
+    }
+    for (const name of stage.dropped) {
+      assert.ok(MEMBERS.includes(name), `${stage.where}: knipt "${name}" weg, maar die member bestaat niet`);
+      assert.ok(!stage.copied.includes(name), `${stage.where}: "${name}" wordt zowel weggeknipt als ge-COPYd`);
+    }
+    for (const name of stage.copied) {
+      assert.ok(MEMBERS.includes(name), `${stage.where}: COPYt "${name}", maar die member bestaat niet`);
+    }
+  }
+});
+
+test('de rust-tag van elk basisimage volgt rust-toolchain.toml', () => {
+  const channel = /^channel = "([^"]+)"$/m.exec(read('rust-toolchain.toml'));
+  assert.ok(channel, 'rust-toolchain.toml heeft geen channel');
+  const [major, minor] = channel[1].split('.');
+
+  let seen = 0;
+  for (const path of DOCKERFILES) {
+    for (const [, tag] of read(path).matchAll(/^FROM rust:([0-9]+\.[0-9]+(?:\.[0-9]+)?)/gm)) {
+      seen += 1;
+      assert.ok(
+        tag === `${major}.${minor}` || tag === channel[1],
+        `${path}: FROM rust:${tag} wijkt af van channel ${channel[1]} in rust-toolchain.toml`,
+      );
+    }
+  }
+  assert.ok(seen >= 3, `slechts ${seen} rust-basisimages gevonden`);
+});
+
+test('elke BIN-build-arg in deploy.yml bestaat als bin-target', () => {
+  const bins = binTargets();
+  const args = [...read('.github/workflows/deploy.yml').matchAll(/BIN=([A-Za-z0-9_-]+)/g)].map((m) => m[1]);
+  assert.ok(args.length >= 3, `slechts ${args.length} BIN-build-args gevonden`);
+  for (const bin of args) {
+    assert.ok(bins.has(bin), `deploy.yml bouwt BIN=${bin}, maar dat is geen bin-target van de workspace`);
+  }
+});
+
+test('elk binary-pad dat een runtime-trap kopieert bestaat als bin-target', () => {
+  const bins = binTargets();
+  let seen = 0;
+  for (const path of DOCKERFILES) {
+    const copies = read(path).matchAll(/^COPY --from=builder \/build\/target\/release\/([A-Za-z0-9_-]+)/gm);
+    for (const [, bin] of copies) {
+      seen += 1;
+      assert.ok(bins.has(bin), `${path}: kopieert ${bin}, maar dat is geen bin-target van de workspace`);
+    }
+  }
+  assert.ok(seen >= 4, `slechts ${seen} binary-kopieën gevonden`);
+});


### PR DESCRIPTION
Nu de images alleen nog op het `preview`-label bouwen, draaide `vite build` van beide frontends nergens meer; die twee builds staan nu in de `Frontend tests`-baan, samen ongeveer een halve minuut. Het padfilter zag `frontend-lawmaking/` niet, en ook `package.json`, `package-lock.json`, `.npmrc`, `rust-toolchain.toml` en `corpus-registry.yaml` niet: een PR die alleen daaraan komt sloeg elke testbaan over en werd groen.

E2E (mocked), Cross-law integrity, Provenance checks en Docs accessibility hangen nu aan de `needs` van de `Test`-poort. Dat kost geen runnerminuut en registreert geen nieuwe required context; `script/ci-gate.test.mjs` draait het shellfragment van de poort met echte resultaatwaarden, zodat skipped geslaagd blijft en een gevallen voorganger rood wordt. Daarnaast pint `script/dockerfile-consistency.test.mjs` de drie Rust-Dockerfiles op de cargo-workspace: elke member wordt ge-COPYd of weggeknipt, de `FROM rust:`-tag volgt `rust-toolchain.toml` en elke binary-naam bestaat echt.