### PR TITLE
ci: dicht het changes-gat in de poort en bouw weer een Rust-image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
     outputs:
       ci: ${{ steps.filter.outputs.ci }}
       docs: ${{ steps.filter.outputs.docs }}
+      rust-image: ${{ steps.filter.outputs.rust-image }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
@@ -66,6 +67,17 @@ jobs:
               - .github/workflows/ci.yml
             docs:
               - docs/**
+              - .github/workflows/ci.yml
+            # Wat de bouw van een Rust-image kan breken. Smaller dan `ci`: een
+            # wijziging in frontend/ of bdd/ raakt deze Dockerfiles niet, en die
+            # build kost 4,5 minuut.
+            rust-image:
+              - packages/**
+              # De Dockerfile doet `COPY schema/ /schema/`; de engine leest die
+              # paden met include_str!, en die kloppen in de image om een andere
+              # reden dan in de repo.
+              - schema/**
+              - rust-toolchain.toml
               - .github/workflows/ci.yml
 
   protect-schema:
@@ -513,6 +525,7 @@ jobs:
       - cross-law-integrity
       - provenance-checks
       - docs-a11y
+      - rust-image
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -549,6 +562,7 @@ jobs:
           check cross-law-integrity "${{ needs.cross-law-integrity.result }}"
           check provenance-checks "${{ needs.provenance-checks.result }}"
           check docs-a11y "${{ needs.docs-a11y.result }}"
+          check rust-image "${{ needs.rust-image.result }}"
           exit "$status"
 
   wasm:
@@ -593,6 +607,69 @@ jobs:
       - name: Skip (no relevant changes)
         if: needs.changes.outputs.ci != 'true'
         run: echo "No relevant changes, skipping WASM build"
+
+  # Sinds de previews opt-in werden (#1204) bouwt een PR geen images meer, dus
+  # of een Rust-image überhaupt bouwt bleek pas op main, met deploy-production
+  # er direct achteraan. De machinerie die daar stuk kan: de musl-toolchain, het
+  # release-profiel, de cargo-chef-lagen, de `COPY schema/` waar include_str!
+  # aan hangt, en de bin-naam in `COPY --from=builder`.
+  #
+  # Eén image is genoeg. De drie Rust-Dockerfiles delen deze hele machinerie en
+  # verschillen alleen in welke members ze kopiëren en welke binary ze eruit
+  # halen; dat verschil dekt script/dockerfile-consistency.test.mjs statisch af.
+  # pipeline-api is de goedkoopste van de drie: gemeten 4,4 tot 4,8 minuut met
+  # warme cache.
+  #
+  # Hij hangt aan de `Test`-poort en blokkeert dus. Een build waarop gewacht
+  # wordt maar die niets tegenhoudt kost de wandklok zonder de garantie te
+  # leveren; dan kun je hem net zo goed niet draaien.
+  rust-image:
+    name: Rust image build
+    needs: changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      # Alleen lezen: deze build duwt niets naar GHCR. Zie `push: false`.
+      packages: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        if: needs.changes.outputs.rust-image == 'true'
+
+      - name: Set up Docker Buildx
+        if: needs.changes.outputs.rust-image == 'true'
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
+
+      # Nodig om de buildcache uit GHCR te mogen lezen; zonder login bouwt hij
+      # alles koud en loopt de job richting het kwartier.
+      - name: Log in to Container Registry
+        if: needs.changes.outputs.rust-image == 'true'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Dezelfde inputs als build-pipeline-api in deploy.yml, op push na. Lopen
+      # die twee uiteen, dan bewijst deze baan iets anders dan er gedeployd
+      # wordt; script/dockerfile-consistency.test.mjs bewaakt de namen.
+      - name: Build pipeline-api image
+        if: needs.changes.outputs.rust-image == 'true'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+        with:
+          context: .
+          file: packages/pipeline/Dockerfile
+          target: pipeline-api
+          build-args: BIN=regelrecht-pipeline-api
+          # Niets pushen en niets in de daemon laden: het gaat om de bouw, niet
+          # om het artefact. Ook geen cache-to, want alleen main schrijft cache.
+          push: false
+          load: false
+          cache-from: type=registry,ref=ghcr.io/minbzk/regelrecht-buildcache:pipeline-api
+
+      - name: Skip (no relevant changes)
+        if: needs.changes.outputs.rust-image != 'true'
+        run: echo "Geen wijziging die een Rust-image raakt, image-build overgeslagen"
 
   # De enige job die de editor in een echte browser laadt. Unit-tests draaien op
   # happy-dom, en die ziet het WASM-laadpad in

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,6 +501,9 @@ jobs:
   test:
     name: Test
     needs:
+      # Niet als voorganger die iets test, maar omdat elke baan hieronder eraan
+      # hangt: valt `changes` om, dan slaan ze allemaal over.
+      - changes
       - rust-tests
       - frontend-tests
       # Deze vier draaiden al bij elke PR maar blokkeerden niets. Ze hier
@@ -526,6 +529,20 @@ jobs:
               *) echo "$1: $2" ;;
             esac
           }
+          # `changes` is de enige voorganger die geslaagd MOET zijn. Overgeslagen
+          # geldt hieronder als geslaagd, en terecht: een PR die geen Rust raakt
+          # hoort niet te blijven hangen op een testbaan die niets te doen had.
+          # Maar valt `changes` zelf om, dan slaan al zijn afhankelijken over om
+          # een heel andere reden, en zou de poort die zes stuk voor stuk als
+          # geslaagd lezen. De hele required set wordt dan groen terwijl er niets
+          # gedraaid is.
+          require() {
+            case "$2" in
+              success) echo "$1: $2" ;;
+              *) echo "::error::$1 gaf $2, dus de banen erachter zijn nooit gedraaid"; status=1 ;;
+            esac
+          }
+          require changes "${{ needs.changes.result }}"
           check rust-tests "${{ needs.rust-tests.result }}"
           check frontend-tests "${{ needs.frontend-tests.result }}"
           check e2e "${{ needs.e2e.result }}"

--- a/script/ci-gate.test.mjs
+++ b/script/ci-gate.test.mjs
@@ -93,7 +93,13 @@ function runGate(results) {
   return spawnSync('bash', ['-e', '-o', 'pipefail', '-c', filled], { encoding: 'utf8' });
 }
 
-const withAll = (value) => Object.fromEntries(NEEDS.map((job) => [job, value]));
+// De baan die bepaalt of de rest überhaupt draait. Hij hoort niet in de
+// skipped-is-geslaagd-regel thuis en heeft daarom zijn eigen assertie.
+const STRICT = 'changes';
+
+/** Alle voorgangers op `value`, behalve `changes`: die blijft geslaagd. */
+const withAll = (value) =>
+  Object.fromEntries(NEEDS.map((job) => [job, job === STRICT ? 'success' : value]));
 
 test('de poort hangt aan de vier checks die tot nu toe niets blokkeerden', () => {
   for (const job of ['e2e', 'cross-law-integrity', 'provenance-checks', 'docs-a11y']) {
@@ -122,6 +128,19 @@ test('alles overgeslagen laat de poort door', () => {
   // Een PR die alleen docs raakt slaat elke testbaan over. Zou skipped hier
   // rood worden, dan blokkeert de required check zo'n PR voorgoed.
   assert.equal(runGate(withAll('skipped')).status, 0);
+});
+
+test('de poort hangt aan changes en leest hem strikt', () => {
+  assert.ok(NEEDS.includes(STRICT), `${STRICT} hangt niet aan de poort`);
+  assert.ok(JOBS.has(STRICT), `${STRICT} bestaat niet als baan in ci.yml`);
+
+  // Overgeslagen of gefaald hoort hier rood te zijn, ook al is skipped voor elke
+  // andere voorganger geslaagd: de rest heeft dan niet gedraaid.
+  for (const result of ['skipped', 'failure', 'cancelled']) {
+    const run = runGate({ ...withAll('skipped'), [STRICT]: result });
+    assert.equal(run.status, 1, `changes op ${result} liet de poort door`);
+    assert.match(run.stdout, /::error::changes gaf/);
+  }
 });
 
 test('een gevallen voorganger laat de poort omvallen, welke dan ook', () => {


### PR DESCRIPTION
Gestapeld op PR 1210; dit gaat over de poort die die PR neerzet. GitHub richt hem vanzelf om naar main zodra 1210 gemerged is.

## Poort werd groen als er niets gedraaid was

Faalt `changes`, dan slaan al zijn afhankelijken over. De poort telt overgeslagen als geslaagd, en terecht: een PR die geen Rust raakt hoort niet te blijven hangen op een testbaan die niets te doen had. Maar daardoor werd de hele required set groen op het moment dat er juist niets gedraaid was.

`changes` is nu de enige voorganger die `success` moet zijn. De poorttest dekt beide richtingen af: hij valt om als de strikte regel weer een gewone `check` wordt, en ook als `changes` helemaal uit `needs` verdwijnt.

## Eén Rust-image bouwt weer op een PR

Sinds de previews opt-in werden (#1204) bouwt een PR geen images meer. Een kapotte image-build kwam daardoor pas op main aan het licht, met `deploy-production` er direct achteraan. De machinerie die daar stuk kan is niet triviaal: de musl-toolchain, het release-profiel, de cargo-chef-lagen, de `COPY schema/` waar `include_str!` aan hangt, en de bin-naam in `COPY --from=builder`.

Eén image volstaat. De drie Rust-Dockerfiles delen die hele machinerie en verschillen alleen in welke members ze kopiëren en welke binary ze eruit halen; dat verschil dekt `script/dockerfile-consistency.test.mjs` statisch af. `pipeline-api` is de goedkoopste van de drie, gemeten 4,4 tot 4,8 minuut met warme cache.

Hij hangt aan de `Test`-poort en blokkeert dus, zonder nieuwe required context bij branch protection. Een build waarop een treintje wacht maar die niets tegenhoudt kost de wandklok zonder de garantie te leveren; dan kun je hem net zo goed niet draaien.

Een eigen padfilter, smaller dan `ci`: een wijziging in `frontend/` of `bdd/` raakt deze Dockerfiles niet.

## Nog onbewezen

De image-build zelf draait voor het eerst in deze run. Yamllint, de poorttest en de Dockerfile-consistentietest zijn lokaal groen; Docker draait niet op de ontwikkelmachine.
