### PR TITLE
fix(github): productie bouwt en deployt alleen op een groene ci

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -368,12 +368,18 @@ jobs:
         needs.build-lawmaking.result == 'success' ||
         needs.build-docs.result == 'success'
       )
-    permissions: {}
+    permissions:
+      # Voor script/check-deployed-urls.sh onderaan.
+      contents: read
     environment:
       name: production
       url: ${{ steps.editor-url.outputs.url }}
 
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 1
+
       # Faalt één gevraagd image, dan gaat er niets. De conditie hierboven laat
       # de deploy al door zodra één build slaagt, en de lijst hieronder neemt
       # alleen de geslaagde mee: het gevolg was dat een component stil op zijn
@@ -457,6 +463,14 @@ jobs:
         env:
           URLS: ${{ steps.deploy.outputs.urls }}
         run: echo "url=$(jq -r '.editor // empty' <<<"$URLS")" >> "$GITHUB_OUTPUT"
+
+      # De poort vooraan bewaakt dat er niets van een rood commit uitgaat en dat
+      # er geen halve uitrol plaatsvindt. Geen van beide zegt iets over de
+      # uitkomst, en daar bestond verder geen enkele controle voor.
+      - name: Controleer of productie antwoordt
+        env:
+          URLS: ${{ steps.deploy.outputs.urls }}
+        run: script/check-deployed-urls.sh
 
       - name: Verklaar een mislukte deploy
         if: failure() && steps.deploy.outcome == 'failure'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -328,12 +328,53 @@ jobs:
         needs.build-lawmaking.result == 'success' ||
         needs.build-docs.result == 'success'
       )
-    permissions: {}
+    permissions:
+      # Alleen om de CI-run van deze commit te mogen opzoeken.
+      actions: read
+      contents: read
     environment:
       name: production
       url: ${{ steps.editor-url.outputs.url }}
 
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 1
+
+      # ci.yml en deze workflow hangen allebei aan `push` op main en weten niets
+      # van elkaar; er is geen `needs` tussen twee workflows. Op commit 4518c575
+      # (7 augustus 2026) faalde CI op Security Audit en ging deze deploy
+      # diezelfde minuut gewoon door. Deze stap is die ontbrekende koppeling.
+      - name: Wacht op een groene CI voor deze commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: script/require-ci-green.sh
+
+      # Faalt één gevraagd image, dan gaat er niets. De conditie hierboven laat
+      # de deploy al door zodra één build slaagt, en de lijst hieronder neemt
+      # alleen de geslaagde mee: het gevolg was dat een component stil op zijn
+      # vorige image bleef staan terwijl de rest meeschoof. De editor en
+      # editor-api delen een contract, dus dat is geen halve deploy maar een
+      # inconsistente. Nooit gebeurd in de laatste honderd runs op main, en dat
+      # is precies waarom het onopgemerkt kon blijven.
+      - name: Weiger een halve deploy
+        env:
+          RESULTS: >-
+            ${{ needs.build.result }} ${{ needs.build-admin.result }}
+            ${{ needs.build-harvester-worker.result }} ${{ needs.build-enrich-worker.result }}
+            ${{ needs.build-pipeline-api.result }} ${{ needs.build-grafana.result }}
+            ${{ needs.build-lawmaking.result }} ${{ needs.build-docs.result }}
+        run: |
+          case " $RESULTS " in
+            *" failure "*|*" cancelled "*)
+              echo "::error title=Deploy-poort::Niet elk gevraagd image is gebouwd ($RESULTS). Een deploy zou de rest vooruit zetten en het gevallen component op zijn vorige image laten staan; er gaat daarom niets naar productie."
+              exit 1
+              ;;
+          esac
+          echo "Geen gevallen build; alle gevraagde images staan klaar."
+
       - name: Get short SHA
         id: sha
         run: echo "short=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,9 +85,49 @@ jobs:
         id: filter
         run: node script/deploy-filters.mjs --from-file changed.txt
 
+  # ci.yml en deze workflow hangen allebei aan `push` op main en weten niets van
+  # elkaar; er is geen `needs` tussen twee workflows. Op commit 4518c575 faalde
+  # CI op Security Audit en ging de productie-deploy diezelfde minuut door.
+  #
+  # Deze baan staat vóór de builds en niet vóór de deploy. build-image.yml tagt
+  # op main `latest` en pusht die naar GHCR; stond de poort achteraan, dan was
+  # dat image van een rood commit al gepubliceerd en scant de wekelijkse scan
+  # precies die tag.
+  #
+  # Geen job-level `if:`, maar guards per stap, zodat de baan op een pull request
+  # gewoon rapporteert in plaats van over te slaan. Een overgeslagen voorganger
+  # zou anders elke build meeslepen.
+  ci-green:
+    name: Wacht op een groene CI
+    runs-on: ubuntu-latest
+    # Ruim boven MAX_WAIT_SECONDS hieronder, zodat het script zelf stopt met een
+    # leesbare melding in plaats van dat Actions de job afkapt.
+    timeout-minutes: 25
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        with:
+          fetch-depth: 1
+
+      - name: Wacht op een groene CI voor deze commit
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          MAX_WAIT_SECONDS: '1200'
+        run: script/require-ci-green.sh
+
+      - name: Niet van toepassing
+        if: "!(github.ref == 'refs/heads/main' && github.event_name == 'push')"
+        run: echo "Alleen een push op main wacht op CI; een preview bouwt op verzoek."
+
   # -- Build jobs --
   build:
-    needs: changes
+    needs: [changes, ci-green]
     if: >-
       github.event.action != 'closed' &&
       (
@@ -105,7 +145,7 @@ jobs:
     # Only GITHUB_TOKEN is needed; it is automatically available to called workflows
 
   build-admin:
-    needs: changes
+    needs: [changes, ci-green]
     if: github.event.action != 'closed' && needs.changes.outputs.admin == 'true'
     permissions:
       contents: read
@@ -118,7 +158,7 @@ jobs:
     # Only GITHUB_TOKEN is needed; it is automatically available to called workflows
 
   build-harvester-worker:
-    needs: changes
+    needs: [changes, ci-green]
     if: github.event.action != 'closed' && needs.changes.outputs.harvester-worker == 'true'
     permissions:
       contents: read
@@ -133,7 +173,7 @@ jobs:
     # Only GITHUB_TOKEN is needed; it is automatically available to called workflows
 
   build-enrich-worker:
-    needs: changes
+    needs: [changes, ci-green]
     if: >-
       github.event.action != 'closed' &&
       (
@@ -153,7 +193,7 @@ jobs:
     # Only GITHUB_TOKEN is needed; it is automatically available to called workflows
 
   build-pipeline-api:
-    needs: changes
+    needs: [changes, ci-green]
     if: github.event.action != 'closed' && needs.changes.outputs.pipeline-api == 'true'
     permissions:
       contents: read
@@ -167,7 +207,7 @@ jobs:
       cache-scope: pipeline-api
 
   build-grafana:
-    needs: changes
+    needs: [changes, ci-green]
     if: >-
       github.ref == 'refs/heads/main' && github.event_name == 'push' &&
       needs.changes.outputs.grafana == 'true'
@@ -183,7 +223,7 @@ jobs:
     # Only GITHUB_TOKEN is needed; it is automatically available to called workflows
 
   build-lawmaking:
-    needs: changes
+    needs: [changes, ci-green]
     if: github.event.action != 'closed' && needs.changes.outputs.lawmaking == 'true'
     permissions:
       contents: read
@@ -196,7 +236,7 @@ jobs:
     # Only GITHUB_TOKEN is needed; it is automatically available to called workflows
 
   build-docs:
-    needs: changes
+    needs: [changes, ci-green]
     if: github.event.action != 'closed' && needs.changes.outputs.docs == 'true'
     permissions:
       contents: read
@@ -328,30 +368,12 @@ jobs:
         needs.build-lawmaking.result == 'success' ||
         needs.build-docs.result == 'success'
       )
-    permissions:
-      # Alleen om de CI-run van deze commit te mogen opzoeken.
-      actions: read
-      contents: read
+    permissions: {}
     environment:
       name: production
       url: ${{ steps.editor-url.outputs.url }}
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-        with:
-          fetch-depth: 1
-
-      # ci.yml en deze workflow hangen allebei aan `push` op main en weten niets
-      # van elkaar; er is geen `needs` tussen twee workflows. Op commit 4518c575
-      # (7 augustus 2026) faalde CI op Security Audit en ging deze deploy
-      # diezelfde minuut gewoon door. Deze stap is die ontbrekende koppeling.
-      - name: Wacht op een groene CI voor deze commit
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          SHA: ${{ github.sha }}
-        run: script/require-ci-green.sh
-
       # Faalt één gevraagd image, dan gaat er niets. De conditie hierboven laat
       # de deploy al door zodra één build slaagt, en de lijst hieronder neemt
       # alleen de geslaagde mee: het gevolg was dat een component stil op zijn

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,6 +99,13 @@ repos:
         pass_filenames: false
         files: ^(script/require-ci-green(\.test)?\.sh|\.github/workflows/deploy\.yml)$
 
+      - id: deployed-urls-tests
+        name: Productiecontrole na de deploy doet wat hij belooft
+        entry: script/check-deployed-urls.test.sh
+        language: system
+        pass_filenames: false
+        files: ^(script/check-deployed-urls(\.test)?\.sh|\.github/workflows/deploy\.yml)$
+
       - id: skills-no-casus
         name: Skills blijven dossier-agnostisch (geen casus-inhoud)
         entry: script/check-skills-no-casus.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,6 +92,13 @@ repos:
         pass_filenames: false
         files: ^(frontend/Dockerfile|packages/(admin|pipeline)/Dockerfile|packages/Cargo\.toml|rust-toolchain\.toml|\.github/workflows/deploy\.yml|script/dockerfile-consistency\.test\.mjs)$
 
+      - id: deploy-gate-tests
+        name: Deploy-poort op een groene CI doet wat hij belooft
+        entry: script/require-ci-green.test.sh
+        language: system
+        pass_filenames: false
+        files: ^(script/require-ci-green(\.test)?\.sh|\.github/workflows/deploy\.yml)$
+
       - id: skills-no-casus
         name: Skills blijven dossier-agnostisch (geen casus-inhoud)
         entry: script/check-skills-no-casus.sh

--- a/Justfile
+++ b/Justfile
@@ -114,11 +114,18 @@ ci-gate-test:
 dockerfile-consistency-test:
     node --test script/dockerfile-consistency.test.mjs
 
+# De poort die productie op een groene CI laat wachten. Zonder deze test is een
+# poort die alles doorlaat niet te onderscheiden van een die werkt; `gh` staat
+# hier als stub op PATH, dus er gaat geen verkeer naar GitHub.
+[doc("Check the gate that holds production to a green CI")]
+deploy-gate-test:
+    script/require-ci-green.test.sh
+
 # Run all quality checks, exactly what CI runs. Needs Docker for the
 # container-backed suites; on a machine without a daemon, swap `test` for
 # `test-no-docker`.
 [doc("Run all quality checks, exactly what CI runs (needs Docker)")]
-check: format lint build-check validate validate-annotations deploy-filters-test precompress-test security-headers-test first-load-test ci-gate-test dockerfile-consistency-test test
+check: format lint build-check validate validate-annotations deploy-filters-test precompress-test security-headers-test first-load-test ci-gate-test dockerfile-consistency-test deploy-gate-test test
 
 # --- Tests ---
 

--- a/Justfile
+++ b/Justfile
@@ -121,11 +121,17 @@ dockerfile-consistency-test:
 deploy-gate-test:
     script/require-ci-green.test.sh
 
+# De controle die na de uitrol nakijkt of productie antwoordt. `curl` staat in
+# de test als stub op PATH, dus er gaat geen verkeer naar buiten.
+[doc("Check the post-deploy health check")]
+deployed-urls-test:
+    script/check-deployed-urls.test.sh
+
 # Run all quality checks, exactly what CI runs. Needs Docker for the
 # container-backed suites; on a machine without a daemon, swap `test` for
 # `test-no-docker`.
 [doc("Run all quality checks, exactly what CI runs (needs Docker)")]
-check: format lint build-check validate validate-annotations deploy-filters-test precompress-test security-headers-test first-load-test ci-gate-test dockerfile-consistency-test deploy-gate-test test
+check: format lint build-check validate validate-annotations deploy-filters-test precompress-test security-headers-test first-load-test ci-gate-test dockerfile-consistency-test deploy-gate-test deployed-urls-test test
 
 # --- Tests ---
 

--- a/script/check-deployed-urls.sh
+++ b/script/check-deployed-urls.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Controleert of de zojuist uitgerolde componenten antwoorden.
+#
+# Na een deploy kijkt niets of productie leeft. De poort ervoor bewaakt dat er
+# niets van een rood commit uitgaat en dat er geen halve uitrol plaatsvindt;
+# geen van beide zegt iets over de uitkomst.
+#
+# De lijst URL's komt uit de deploy-action zelf (`urls`-output), niet uit een
+# opsomming hier. Een hostnamenlijst in dit bestand zou wegdrijven zodra er een
+# component bijkomt, en hij zou componenten controleren die deze run niet heeft
+# aangeraakt.
+set -uo pipefail
+
+: "${URLS:?URLS is verplicht (JSON-object component -> url)}"
+
+ATTEMPTS="${ATTEMPTS:-10}"
+DELAY="${DELAY:-15}"
+
+if ! echo "$URLS" | jq -e 'type == "object"' >/dev/null 2>&1; then
+    echo "::error title=Productiecontrole::URLS is geen JSON-object; er valt niets te controleren."
+    exit 1
+fi
+
+count=$(jq -r 'length' <<<"$URLS")
+if [ "$count" -eq 0 ]; then
+    echo "::error title=Productiecontrole::de deploy leverde geen enkele URL op, dus of er iets draait is niet vastgesteld."
+    exit 1
+fi
+
+status=0
+
+while IFS=$'\t' read -r naam url; do
+    [ -z "$url" ] && continue
+    code=""
+    for _ in $(seq 1 "$ATTEMPTS"); do
+        code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 -L "$url" 2>/dev/null)
+        case "$code" in
+            # 2xx en 3xx: bereikbaar. 401 en 403: de dienst leeft en stuurt je
+            # naar de aanmelding, wat voor de meeste van deze componenten de
+            # normale uitkomst is zonder sessie.
+            2?? | 3?? | 401 | 403)
+                echo "  ${naam}: ${code}  ${url}"
+                break
+                ;;
+        esac
+        sleep "$DELAY"
+    done
+
+    case "$code" in
+        2?? | 3?? | 401 | 403) ;;
+        *)
+            echo "::error title=Productiecontrole::${naam} antwoordt niet (${code:-geen verbinding}) op ${url}"
+            status=1
+            ;;
+    esac
+done < <(jq -r 'to_entries[] | "\(.key)\t\(.value)"' <<<"$URLS")
+
+if [ "$status" -eq 0 ]; then
+    echo "${count} component(en) bereikbaar."
+fi
+exit "$status"

--- a/script/check-deployed-urls.test.sh
+++ b/script/check-deployed-urls.test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Dekt elk pad dat groen of rood beslist in script/check-deployed-urls.sh, met
+# een `curl`-stub op PATH. Zonder deze test is een controle die alles doorlaat
+# niet te onderscheiden van een die werkt.
+set -uo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+gate="$here/check-deployed-urls.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+pass=0
+fail=0
+
+# $1 = de code die de stub voor elke URL teruggeeft; leeg betekent geen
+# verbinding (curl faalt).
+stub_curl() {
+    cat >"$tmp/curl" <<STUB
+#!/usr/bin/env bash
+if [ -z "$1" ]; then
+    echo "curl: (7) Failed to connect" >&2
+    exit 7
+fi
+printf '%s' "$1"
+STUB
+    chmod +x "$tmp/curl"
+}
+
+check() { # naam, verwachte exit, code, urls-json, patroon
+    local naam="$1" want="$2" code="$3" urls="$4" needle="${5:-}"
+    stub_curl "$code"
+    local out st
+    out="$(PATH="$tmp:$PATH" URLS="$urls" ATTEMPTS=1 DELAY=0 bash "$gate" 2>&1)"
+    st=$?
+
+    if [ "$st" -ne "$want" ]; then
+        echo "FAIL: $naam — exit $st, verwacht $want"
+        echo "$out" | sed 's/^/    /'
+        fail=$((fail + 1))
+        return
+    fi
+    if [ -n "$needle" ] && ! grep -qF "$needle" <<<"$out"; then
+        echo "FAIL: $naam — '$needle' niet in de uitvoer"
+        echo "$out" | sed 's/^/    /'
+        fail=$((fail + 1))
+        return
+    fi
+    echo "ok: $naam"
+    pass=$((pass + 1))
+}
+
+twee='{"editor":"https://editor.example","docs":"https://docs.example"}'
+
+check "200 op alles is groen" 0 200 "$twee" "2 component(en) bereikbaar"
+check "een omleiding telt als bereikbaar" 0 302 "$twee" "bereikbaar"
+check "401 telt als bereikbaar, de dienst leeft" 0 401 "$twee" "bereikbaar"
+check "500 is rood" 1 500 "$twee" "antwoordt niet (500)"
+check "404 is rood" 1 404 "$twee" "antwoordt niet (404)"
+check "geen verbinding is rood" 1 "" "$twee" "geen verbinding"
+
+# Een lege lijst betekent dat de deploy niets opleverde. Dat leest anders als
+# "alles in orde", en dat is precies de faalvorm die deze controle moet dichten.
+check "een lege lijst is rood" 1 200 '{}' "geen enkele URL"
+check "geen JSON-object is rood" 1 200 'null' "geen JSON-object"
+
+echo
+echo "$pass geslaagd, $fail mislukt"
+[ "$fail" -eq 0 ]

--- a/script/require-ci-green.sh
+++ b/script/require-ci-green.sh
@@ -29,19 +29,39 @@ fail() {
     exit 1
 }
 
-# Status en conclusie van de nieuwste run van $WORKFLOW voor deze commit.
-# Leeg wanneer er geen run is.
+# Foutuitvoer van de laatste API-aanroep. Een bestand en geen variabele: de
+# aanroep hieronder staat in een command-substitution, dus een variabele die de
+# functie zet gaat met die subshell verloren.
+ERRFILE=$(mktemp)
+trap 'rm -f "$ERRFILE"' EXIT
+
+# Status en conclusie van de nieuwste run van $WORKFLOW voor deze commit. Leeg
+# wanneer er geen run is; exitcode 1 wanneer de aanroep zelf mislukte. Dat
+# onderscheid is nodig: een tokenfout, rate limit of netwerkstoring mag niet als
+# "er is geen run" gelezen worden, want dan noemt de poort een oorzaak die hij
+# niet getoetst heeft.
 latest_run() {
     gh api "repos/${REPO}/actions/runs?head_sha=${SHA}&per_page=100" \
         --jq "[.workflow_runs[] | select(.name == \"${WORKFLOW}\")]
               | sort_by(.run_started_at) | last
               | select(. != null)
-              | \"\(.status)\t\(.conclusion // \"\")\t\(.html_url)\"" 2>/dev/null
+              | \"\(.status)\t\(.conclusion // \"\")\t\(.html_url)\"" 2>"$ERRFILE"
 }
 
 waited=0
 while :; do
-    run="$(latest_run)"
+    if ! run="$(latest_run)"; then
+        melding=$(tr '\n' ' ' <"$ERRFILE")
+        # Blijven proberen zolang er tijd is: een rate limit trekt vanzelf bij.
+        # Blijft het mislukken, dan is dat de melding, en niet "geen run".
+        if [ "$waited" -ge "$MAX_WAIT_SECONDS" ]; then
+            fail "de GitHub-API blijft fouten geven, dus of CI geslaagd is voor ${SHA} is niet vast te stellen: ${melding}"
+        fi
+        echo "API-fout, opnieuw proberen: ${melding}"
+        sleep "$POLL_SECONDS"
+        waited=$((waited + POLL_SECONDS))
+        continue
+    fi
 
     if [ -z "$run" ]; then
         # Kan een race zijn met het aanmaken van de run, dus even wachten mag.

--- a/script/require-ci-green.sh
+++ b/script/require-ci-green.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Deploy-poort: blokkeer tot de CI van déze commit klaar is, en laat alleen
+# groen door.
+#
+# `ci.yml` en `deploy.yml` hangen allebei aan `push` op main en weten niets van
+# elkaar. Op 7 augustus 2026 faalde CI op commit 4518c575 (Security Audit) en
+# ging deploy-production diezelfde minuut gewoon door. Er is geen `needs` tussen
+# twee workflows, dus die koppeling moet hiervandaan komen.
+#
+# De poort leest de CI-run op naam en head-SHA, niet op run-id: deploy kent het
+# run-id van CI niet, en beide runs starten uit dezelfde push. Dat betekent wel
+# dat er meerdere runs kunnen staan (een handmatige rerun, een `workflow_dispatch`);
+# de nieuwste telt, want dat is de laatste uitspraak over deze commit.
+#
+# Afwezig is niet hetzelfde als geslaagd. Staat er voor deze SHA geen CI-run,
+# dan blokkeert de poort in plaats van door te rollen: dat is precies het geval
+# waarin niemand iets heeft nagekeken.
+set -uo pipefail
+
+: "${REPO:?REPO is verplicht}"
+: "${SHA:?SHA is verplicht}"
+
+WORKFLOW="${WORKFLOW:-CI}"
+MAX_WAIT_SECONDS="${MAX_WAIT_SECONDS:-2400}"
+POLL_SECONDS="${POLL_SECONDS:-20}"
+
+fail() {
+    echo "::error title=Deploy-poort::$1"
+    exit 1
+}
+
+# Status en conclusie van de nieuwste run van $WORKFLOW voor deze commit.
+# Leeg wanneer er geen run is.
+latest_run() {
+    gh api "repos/${REPO}/actions/runs?head_sha=${SHA}&per_page=100" \
+        --jq "[.workflow_runs[] | select(.name == \"${WORKFLOW}\")]
+              | sort_by(.run_started_at) | last
+              | select(. != null)
+              | \"\(.status)\t\(.conclusion // \"\")\t\(.html_url)\"" 2>/dev/null
+}
+
+waited=0
+while :; do
+    run="$(latest_run)"
+
+    if [ -z "$run" ]; then
+        # Kan een race zijn met het aanmaken van de run, dus even wachten mag.
+        if [ "$waited" -ge "$MAX_WAIT_SECONDS" ]; then
+            fail "geen enkele ${WORKFLOW}-run gevonden voor ${SHA} binnen ${MAX_WAIT_SECONDS}s. Zonder run is er niets nagekeken; er gaat niets naar productie."
+        fi
+    else
+        IFS=$'\t' read -r status conclusion url <<<"$run"
+
+        if [ "$status" = "completed" ]; then
+            case "$conclusion" in
+                success)
+                    echo "${WORKFLOW} voor ${SHA} is geslaagd: ${url}"
+                    exit 0
+                    ;;
+                # Een overgeslagen CI-run betekent dat de workflow niet van
+                # toepassing was, niet dat het werk goedgekeurd is.
+                *)
+                    fail "${WORKFLOW} voor ${SHA} eindigde als '${conclusion}', dus er gaat niets naar productie. Zie ${url}"
+                    ;;
+            esac
+        fi
+
+        echo "${WORKFLOW} voor ${SHA} is '${status}', nog $((MAX_WAIT_SECONDS - waited))s geduld: ${url}"
+    fi
+
+    if [ "$waited" -ge "$MAX_WAIT_SECONDS" ]; then
+        fail "${WORKFLOW} voor ${SHA} was na ${MAX_WAIT_SECONDS}s nog niet klaar. Draai deze job opnieuw zodra CI af is."
+    fi
+
+    sleep "$POLL_SECONDS"
+    waited=$((waited + POLL_SECONDS))
+done

--- a/script/require-ci-green.test.sh
+++ b/script/require-ci-green.test.sh
@@ -104,6 +104,31 @@ check "een rerun die groen werd laat alsnog door" 0 \
     "[$(run completed '"failure"' 2026-08-07T10:00:00Z),$(run completed '"success"' 2026-08-07T11:00:00Z)]" \
     "is geslaagd"
 
+# Een mislukte API-aanroep is iets anders dan een ontbrekende run. Zonder dit
+# onderscheid meldt de poort een oorzaak die hij niet getoetst heeft.
+stub_gh_fails() {
+    cat >"$tmp/gh" <<'STUB'
+#!/usr/bin/env bash
+echo "gh: HTTP 401: Bad credentials" >&2
+exit 1
+STUB
+    chmod +x "$tmp/gh"
+}
+
+stub_gh_fails
+out=$(PATH="$tmp:$PATH" REPO=o/r SHA=deadbeef MAX_WAIT_SECONDS=0 POLL_SECONDS=0 \
+    bash "$gate" 2>&1)
+status=$?
+if [ "$status" -eq 1 ] && grep -qF "Bad credentials" <<<"$out" \
+    && ! grep -qF "geen enkele CI-run" <<<"$out"; then
+    echo "ok: een API-fout wordt niet gemeld als een ontbrekende run"
+    pass=$((pass + 1))
+else
+    echo "FAIL: een API-fout wordt niet gemeld als een ontbrekende run — exit $status"
+    echo "$out" | sed 's/^/    /'
+    fail=$((fail + 1))
+fi
+
 echo
 echo "$pass geslaagd, $fail mislukt"
 [ "$fail" -eq 0 ]

--- a/script/require-ci-green.test.sh
+++ b/script/require-ci-green.test.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Dekt elk pad dat groen of rood beslist in script/require-ci-green.sh, met een
+# `gh`-stub op PATH. Zonder deze test is een poort die per ongeluk altijd
+# doorlaat niet te onderscheiden van een die werkt.
+set -uo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+gate="$here/require-ci-green.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+pass=0
+fail=0
+
+# Bouwt een `gh`-stub die één runs-antwoord teruggeeft. $1 is de JSON-array met
+# workflow_runs; de stub voert de meegegeven --jq erop uit met de echte jq.
+stub_gh() {
+    cat >"$tmp/gh" <<STUB
+#!/usr/bin/env bash
+# Alleen de aanroep die de poort doet: api ... --jq <filter>
+filter=""
+for ((i = 1; i <= \$#; i++)); do
+    if [ "\${!i}" = "--jq" ]; then
+        j=\$((i + 1))
+        filter="\${!j}"
+    fi
+done
+printf '%s' '{"workflow_runs": $1}' | jq -r "\$filter"
+STUB
+    chmod +x "$tmp/gh"
+}
+
+# $1 = naam, $2 = verwachte exitcode, $3 = workflow_runs-JSON,
+# $4 = optioneel: patroon dat in de uitvoer moet staan.
+check() {
+    local name="$1" want="$2" runs="$3" needle="${4:-}"
+    stub_gh "$runs"
+    local out status
+    out="$(PATH="$tmp:$PATH" REPO=o/r SHA=deadbeef MAX_WAIT_SECONDS=0 POLL_SECONDS=0 \
+        bash "$gate" 2>&1)"
+    status=$?
+
+    if [ "$status" -ne "$want" ]; then
+        echo "FAIL: $name — exit $status, verwacht $want"
+        echo "$out" | sed 's/^/    /'
+        fail=$((fail + 1))
+        return
+    fi
+    if [ -n "$needle" ] && ! grep -qF "$needle" <<<"$out"; then
+        echo "FAIL: $name — '$needle' niet in de uitvoer"
+        echo "$out" | sed 's/^/    /'
+        fail=$((fail + 1))
+        return
+    fi
+    echo "ok: $name"
+    pass=$((pass + 1))
+}
+
+run() { # status, conclusion, gestart-op
+    printf '{"name":"CI","status":"%s","conclusion":%s,"run_started_at":"%s","html_url":"u"}' \
+        "$1" "$2" "$3"
+}
+
+check "geslaagde CI laat de deploy door" 0 \
+    "[$(run completed '"success"' 2026-08-07T10:00:00Z)]" \
+    "is geslaagd"
+
+check "gefaalde CI blokkeert" 1 \
+    "[$(run completed '"failure"' 2026-08-07T10:00:00Z)]" \
+    "eindigde als 'failure'"
+
+check "afgebroken CI blokkeert" 1 \
+    "[$(run completed '"cancelled"' 2026-08-07T10:00:00Z)]" \
+    "eindigde als 'cancelled'"
+
+# Een overgeslagen run betekent dat de workflow niet van toepassing was, niet
+# dat het werk is nagekeken.
+check "overgeslagen CI blokkeert" 1 \
+    "[$(run completed '"skipped"' 2026-08-07T10:00:00Z)]" \
+    "eindigde als 'skipped'"
+
+check "geen CI-run blokkeert" 1 "[]" \
+    "geen enkele CI-run gevonden"
+
+# Alleen runs van deze commit tellen; een andere workflow op dezelfde SHA is
+# geen uitspraak over CI.
+check "andere workflow op dezelfde SHA telt niet" 1 \
+    '[{"name":"Build and Deploy","status":"completed","conclusion":"success","run_started_at":"2026-08-07T10:00:00Z","html_url":"u"}]' \
+    "geen enkele CI-run gevonden"
+
+# Nog niet klaar: de poort wacht, en met MAX_WAIT_SECONDS=0 valt hij meteen om
+# in plaats van door te rollen.
+check "lopende CI laat de deploy niet door" 1 \
+    "[$(run in_progress null 2026-08-07T10:00:00Z)]" \
+    "nog niet klaar"
+
+# De nieuwste run is de laatste uitspraak; een oudere groene run mag een
+# nieuwere rode niet overstemmen.
+check "de nieuwste run beslist, niet de eerste" 1 \
+    "[$(run completed '"success"' 2026-08-07T10:00:00Z),$(run completed '"failure"' 2026-08-07T11:00:00Z)]" \
+    "eindigde als 'failure'"
+
+check "een rerun die groen werd laat alsnog door" 0 \
+    "[$(run completed '"failure"' 2026-08-07T10:00:00Z),$(run completed '"success"' 2026-08-07T11:00:00Z)]" \
+    "is geslaagd"
+
+echo
+echo "$pass geslaagd, $fail mislukt"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
`ci.yml` en `deploy.yml` hangen allebei aan `push` op main en weten niets van elkaar. Op commit 4518c575 faalde CI op Security Audit en ging de productie-deploy diezelfde minuut door.

Er staat nu een `ci-green`-baan vóór de builds waar elke build aan hangt. Vóór de builds en niet vóór de deploy, omdat `build-image.yml` op main `latest` naar GHCR pusht: met de poort achteraan was het image van een rood commit al gepubliceerd. Daarnaast gaat er niets naar productie zodra één gevraagd image niet gebouwd is, en controleert een stap na de uitrol of de gedeployde componenten antwoorden. Die URL's komen uit de deploy-action zelf, dus die lijst kan niet wegdrijven.

Beide poorten hebben een testsuite met een `gh`- respectievelijk `curl`-stub over elk pad dat groen of rood beslist; een ontbrekende CI-run en een mislukte API-aanroep tellen allebei niet als geslaagd.
