### PR TITLE
fix(github): de opruiming meldt geen succes meer als er niets weg is

### DIFF
--- a/.github/workflows/scheduled-cleanup.yml
+++ b/.github/workflows/scheduled-cleanup.yml
@@ -22,8 +22,16 @@ jobs:
       deployments: write
       packages: write
       actions: write
+      # Voor `gh pr list` in de controlestap onderaan.
+      pull-requests: read
 
     steps:
+      # Voor script/check-preview-environments.sh onderaan; de opruimactie zelf
+      # heeft de boom niet nodig.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 1
+
       - name: Cleanup stale ZAD deployments and GitHub environments
         uses: RijksICTGilde/zad-actions/scheduled-cleanup@13434cd415db0cd195a2c5f12bf67645acfcb635  # v4.0.6
         with:
@@ -36,6 +44,22 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           dry-run: ${{ inputs.dry-run || false }}
           github-admin-token: ${{ secrets.ADMIN_TOKEN }}
+
+      # De opruimactie hierboven meldt succes op basis van alleen de ZAD-kant:
+      # in zad-actions zet stap 1 `ENV_SUCCESS`, en de stappen die de
+      # GitHub-environment, de deployments en de images verwijderen raken die
+      # variabele nergens aan. Op 7 augustus 2026 sloot de run af met
+      # "Successfully cleaned 773 environment(s)" terwijl alle 773 met 404
+      # faalden. Deze stap telt de uitkomst in plaats van de melding.
+      #
+      # Op een dry-run overslaan: die verwijdert per definitie niets, dus zou
+      # hij hier altijd omvallen.
+      - name: Controleer wat er is achtergebleven
+        if: ${{ !(inputs.dry-run || false) }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: script/check-preview-environments.sh
 
       - name: Cleanup stale container images
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,6 +105,12 @@ repos:
         language: system
         pass_filenames: false
         files: ^(script/check-deployed-urls(\.test)?\.sh|\.github/workflows/deploy\.yml)$
+      - id: preview-environments-tests
+        name: Controle op achtergebleven previews doet wat hij belooft
+        entry: script/check-preview-environments.test.sh
+        language: system
+        pass_filenames: false
+        files: ^(script/check-preview-environments(\.test)?\.sh|\.github/workflows/scheduled-cleanup\.yml)$
 
       - id: skills-no-casus
         name: Skills blijven dossier-agnostisch (geen casus-inhoud)

--- a/Justfile
+++ b/Justfile
@@ -126,12 +126,17 @@ deploy-gate-test:
 [doc("Check the post-deploy health check")]
 deployed-urls-test:
     script/check-deployed-urls.test.sh
+# De controle die telt wat de nachtelijke opruiming heeft achtergelaten. `gh`
+# staat in de test als stub op PATH, dus er gaat geen verkeer naar GitHub.
+[doc("Check the guard on leftover preview environments")]
+preview-environments-test:
+    script/check-preview-environments.test.sh
 
 # Run all quality checks, exactly what CI runs. Needs Docker for the
 # container-backed suites; on a machine without a daemon, swap `test` for
 # `test-no-docker`.
 [doc("Run all quality checks, exactly what CI runs (needs Docker)")]
-check: format lint build-check validate validate-annotations deploy-filters-test precompress-test security-headers-test first-load-test ci-gate-test dockerfile-consistency-test deploy-gate-test deployed-urls-test test
+check: format lint build-check validate validate-annotations deploy-filters-test precompress-test security-headers-test first-load-test ci-gate-test dockerfile-consistency-test deploy-gate-test deployed-urls-test preview-environments-test test
 
 # --- Tests ---
 

--- a/script/check-preview-environments.sh
+++ b/script/check-preview-environments.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Controleert wat de nachtelijke opruiming heeft achtergelaten: geen enkele
+# `prN`-environment mag nog bij een gesloten pull request horen.
+#
+# De opruimactie meldt zelf succes op basis van alleen de ZAD-kant. In
+# `zad-actions/scheduled-cleanup` zet stap 1 `ENV_SUCCESS`, en de stappen die
+# de GitHub-environment, de deployments en de images verwijderen raken die
+# variabele nergens aan. De run van 7 augustus 2026 sloot daardoor af met
+# "Successfully cleaned 773 environment(s)" terwijl alle 773 verwijderingen met
+# 404 waren gefaald, en dat stond verstopt in een log van 4351 regels.
+#
+# Deze poort telt de uitkomst in plaats van de melding, en hij hoort dus na de
+# opruiming te draaien en niet ervoor. Zie issue #1213 voor de oorzaak: het
+# admin-token mist repo-admin, en `DELETE /repos/{owner}/{repo}/environments/…`
+# antwoordt dan met 404 in plaats van 403.
+set -uo pipefail
+
+: "${REPO:?REPO is verplicht}"
+
+# Alle environments met de naamvorm die de previews gebruiken.
+mapfile -t envs < <(
+    gh api "repos/${REPO}/environments" --paginate \
+        --jq '.environments[].name' 2>/dev/null | grep -E '^pr[0-9]+$' | sort -u
+)
+
+# Eén aanroep in plaats van één per environment. Open PR's zijn precies degene
+# waarvan de preview mag blijven staan.
+mapfile -t open_prs < <(
+    gh pr list --repo "${REPO}" --state open --limit 1000 --json number \
+        --jq '.[] | "pr\(.number)"' 2>/dev/null | sort -u
+)
+
+if [ "${#open_prs[@]}" -eq 0 ]; then
+    # Nul open PR's kan kloppen, maar het is ook wat een mislukte aanroep
+    # oplevert, en dan zou elke environment hieronder ten onrechte als
+    # achtergebleven gelden.
+    echo "::error title=Preview-opruiming::kon de open pull requests niet opvragen; de controle zegt zonder die lijst niets."
+    exit 1
+fi
+
+stale=()
+for env in "${envs[@]}"; do
+    keep=false
+    for open in "${open_prs[@]}"; do
+        [ "$env" = "$open" ] && keep=true && break
+    done
+    [ "$keep" = false ] && stale+=("$env")
+done
+
+echo "prN-environments: ${#envs[@]}, waarvan bij een open PR: $((${#envs[@]} - ${#stale[@]}))"
+
+if [ "${#stale[@]}" -gt 0 ]; then
+    echo "::error title=Preview-opruiming::${#stale[@]} environment(s) horen bij een gesloten pull request en staan er nog. De opruimstap hiervoor meldt succes op basis van alleen de ZAD-kant, dus een groene job zegt hier niets over. Zie issue #1213."
+    printf '  %s\n' "${stale[@]}"
+    exit 1
+fi
+
+echo "Niets achtergebleven."

--- a/script/check-preview-environments.test.sh
+++ b/script/check-preview-environments.test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Dekt elk pad dat groen of rood beslist in script/check-preview-environments.sh,
+# met een `gh`-stub op PATH. Zonder deze test is een controle die altijd
+# doorlaat niet te onderscheiden van een die werkt, en dat is precies de fout
+# die deze controle bij de opruimactie zelf blootlegt.
+set -uo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+gate="$here/check-preview-environments.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+pass=0
+fail=0
+
+# $1 = environmentnamen (spatiegescheiden), $2 = open PR-nummers.
+stub_gh() {
+    cat >"$tmp/gh" <<STUB
+#!/usr/bin/env bash
+case "\$1" in
+  api) for e in $1; do echo "\$e"; done ;;
+  pr)  for n in $2; do echo "pr\$n"; done ;;
+esac
+STUB
+    chmod +x "$tmp/gh"
+}
+
+check() { # naam, verwachte exit, envs, open-prs, patroon
+    local name="$1" want="$2" envs="$3" prs="$4" needle="${5:-}"
+    stub_gh "$envs" "$prs"
+    local out status
+    out="$(PATH="$tmp:$PATH" REPO=o/r bash "$gate" 2>&1)"
+    status=$?
+
+    if [ "$status" -ne "$want" ]; then
+        echo "FAIL: $name — exit $status, verwacht $want"
+        echo "$out" | sed 's/^/    /'
+        fail=$((fail + 1))
+        return
+    fi
+    if [ -n "$needle" ] && ! grep -qF "$needle" <<<"$out"; then
+        echo "FAIL: $name — '$needle' niet in de uitvoer"
+        echo "$out" | sed 's/^/    /'
+        fail=$((fail + 1))
+        return
+    fi
+    echo "ok: $name"
+    pass=$((pass + 1))
+}
+
+check "alleen environments van open PR's is schoon" 0 \
+    "pr10 pr11" "10 11" "Niets achtergebleven"
+
+check "een environment van een gesloten PR is rood" 1 \
+    "pr10 pr99" "10" "pr99"
+
+check "helemaal geen environments is schoon" 0 \
+    "" "10" "Niets achtergebleven"
+
+# De naamvorm doet ertoe: production en github-pages mogen nooit meetellen.
+check "niet-preview-environments tellen niet mee" 0 \
+    "production github-pages pr10" "10" "Niets achtergebleven"
+
+# Een mislukte gh-aanroep geeft een lege PR-lijst, en dan zou elke environment
+# ten onrechte als achtergebleven gelden. Blokkeren in plaats van rood melden
+# op de verkeerde grond.
+check "geen open PR's opgehaald blokkeert met een eigen reden" 1 \
+    "pr10" "" "kon de open pull requests niet opvragen"
+
+echo
+echo "$pass geslaagd, $fail mislukt"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
De nachtelijke opruiming sloot af met "Successfully cleaned 773 environment(s)" terwijl alle 773 verwijderingen met 404 faalden. De teller in `zad-actions` kijkt alleen naar de ZAD-kant; de GitHub-kant kan falen zonder dat het meetelt.

Er staat nu een stap achter die telt wat er is achtergebleven: geen enkele `prN`-environment mag nog bij een gesloten pull request horen. Een lege lijst open PR's is een eigen fout, geen groen.

De oorzaak zit in #1213: `ADMIN_TOKEN` mist repo-admin. Tot dat gerepareerd is wordt deze job elke nacht rood, en dat is de bedoeling.
