### PR TITLE
fix(deps): nanoid naar 3.3.18 tegen GHSA-2v37-7h3g-55p8

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -284,6 +284,7 @@ audit:
     # own; the whole-tree scan is strictly broader coverage.)
     npm audit
     npx license-checker --failOn "GPL-2.0;GPL-3.0;AGPL-1.0;AGPL-3.0;SSPL-1.0;BUSL-1.1"
+    cd docs && npm audit
 
 # --- Admin ---
 

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8578,9 +8578,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3309,9 +3309,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Een high-severity advisory op `nanoid <3.3.17`: een custom generator kan eindeloos doorlopen bij size nul ([GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8)). `Security Audit` is een required check, dus dit blokkeerde elke openstaande pull request.

Beide lockfiles stonden op 3.3.16, via postcss. Nu 3.3.18.

## Waarom docs er ook op stond

`just audit` scande alleen de npm-workspace in de root. `docs/` heeft een eigen `package.json` en een eigen lockfile en viel daarbuiten, dus de afhankelijkheden van de gepubliceerde docs-site werden nooit gecontroleerd. Zonder deze PR was die kant blijven staan op de kwetsbare versie terwijl de root allang gerepareerd was, en had niets dat gemeld.

`cd docs && npm audit` staat er nu bij.
