### PR TITLE
fix(deps): audit vindt de lockfiles zelf, en draait de cargo-deny van ci

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -185,6 +185,25 @@ updates:
       # Our own design package — bump manually, not via Dependabot
       - dependency-name: '@nldd/design-system'
 
+  - package-ecosystem: npm
+    directory: /packages/arch-extract/ui
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 5
+    commit-message:
+      prefix: chore(deps)
+      prefix-development: chore(deps)
+    labels:
+      - dependencies
+      - javascript
+    groups:
+      npm-minor-patch:
+        update-types:
+          - minor
+          - patch
+
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/Justfile
+++ b/Justfile
@@ -278,13 +278,11 @@ bench-compare BASE:
 # Run security audit on all dependencies (vulnerabilities, licenses, sources)
 audit:
     cd packages && cargo deny check --config ../deny.toml
-    # One npm workspace at the repo root covers all three frontends + the shared
-    # package, so audit/license-check the whole hoisted tree once. (license-checker
-    # drops --production because the workspace root has no production deps of its
-    # own; the whole-tree scan is strictly broader coverage.)
-    npm audit
+    script/npm-audit-all.sh
+    # license-checker draait alleen over de workspace in de root; die drops
+    # --production omdat de root geen eigen productie-deps heeft, en de
+    # hele-boom-scan is strikt ruimer.
     npx license-checker --failOn "GPL-2.0;GPL-3.0;AGPL-1.0;AGPL-3.0;SSPL-1.0;BUSL-1.1"
-    cd docs && npm audit
 
 # --- Admin ---
 

--- a/Justfile
+++ b/Justfile
@@ -277,7 +277,7 @@ bench-compare BASE:
 
 # Run security audit on all dependencies (vulnerabilities, licenses, sources)
 audit:
-    cd packages && cargo deny check --config ../deny.toml
+    script/cargo-deny.sh
     script/npm-audit-all.sh
     # license-checker draait alleen over de workspace in de root; die drops
     # --production omdat de root geen eigen productie-deps heeft, en de

--- a/packages/arch-extract/ui/package-lock.json
+++ b/packages/arch-extract/ui/package-lock.json
@@ -2212,9 +2212,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/script/cargo-deny.sh
+++ b/script/cargo-deny.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Draait cargo-deny op de versie die CI ook draait.
+#
+# De aanroep verschilt per versie: 0.19 wil `check --config <pad>`, 0.20 wil
+# `--config <pad> check`. Eén aanroep die op beide werkt bestaat niet, dus wie
+# cargo-deny vers installeert kreeg `unexpected argument '--config' found` in
+# plaats van een audit. Versie en checksum staan in ci.yml en worden hier
+# gelezen, zodat er niet twee plekken zijn die uiteen kunnen lopen.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+root=$PWD
+workflow=.github/workflows/ci.yml
+
+version=$(sed -n 's/^ *CARGO_DENY_VERSION="\(.*\)"$/\1/p' "$workflow" | head -1)
+sha=$(sed -n 's/^ *CARGO_DENY_SHA256="\(.*\)"$/\1/p' "$workflow" | head -1)
+
+if [ -z "$version" ] || [ -z "$sha" ]; then
+    echo "FOUT: kon CARGO_DENY_VERSION/CARGO_DENY_SHA256 niet uit ${workflow} lezen" >&2
+    exit 1
+fi
+
+cache="${XDG_CACHE_HOME:-$HOME/.cache}/regelrecht"
+binary="${cache}/cargo-deny-${version}"
+
+if [ ! -x "$binary" ]; then
+    if [ "$(uname -s)" != "Linux" ] || [ "$(uname -m)" != "x86_64" ]; then
+        installed=$(cargo deny --version 2>/dev/null | awk '{print $2}')
+        if [ "$installed" != "$version" ]; then
+            echo "FOUT: deze repo draait cargo-deny ${version}, hier staat ${installed:-niets}." >&2
+            echo "      Er is geen prebuilt binary voor $(uname -s)/$(uname -m); installeer met:" >&2
+            echo "      cargo install cargo-deny --locked --version ${version}" >&2
+            exit 1
+        fi
+        binary=$(command -v cargo-deny)
+    else
+        echo "cargo-deny ${version} ophalen (eenmalig, naar ${cache})"
+        mkdir -p "$cache"
+        tarball="cargo-deny-${version}-x86_64-unknown-linux-musl"
+        tmp=$(mktemp -d)
+        trap 'rm -rf "$tmp"' EXIT
+        curl -sSL "https://github.com/EmbarkStudios/cargo-deny/releases/download/${version}/${tarball}.tar.gz" \
+            -o "$tmp/cargo-deny.tar.gz"
+        echo "${sha}  $tmp/cargo-deny.tar.gz" | sha256sum -c -
+        tar -xz --strip-components=1 -C "$tmp" -f "$tmp/cargo-deny.tar.gz" "${tarball}/cargo-deny"
+        install -m0755 "$tmp/cargo-deny" "$binary"
+    fi
+fi
+
+cd packages
+exec "$binary" check --config "${root}/deny.toml"

--- a/script/npm-audit-all.sh
+++ b/script/npm-audit-all.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Zoekt elke package-lock.json in de boom en auditeert hem.
+#
+# Een handmatige opsomming dreef twee keer weg: docs/ viel jarenlang buiten de
+# scan, en packages/arch-extract/ui kwam pas boven toen Dependabot er zelf een
+# advisory op vond.
+#
+# Een lockfile met een eigen naam (opencode-plugins-package-lock.json) heeft geen
+# package.json naast zich. `npm audit` in die map auditeert dan een lege boom en
+# meldt nul kwetsbaarheden, wat niet van een echte schone uitslag te
+# onderscheiden is. Zo'n paar gaat daarom onder standaardnamen naar een tijdelijke
+# map.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+root=$PWD
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+status=0
+found=0
+
+audit_in() {
+    echo "== npm audit: $1 =="
+    (cd "$2" && npm audit) || status=1
+}
+
+while IFS= read -r lock; do
+    found=$((found + 1))
+    dir=$(dirname "$lock")
+    base=$(basename "$lock")
+
+    if [ "$base" = "package-lock.json" ]; then
+        audit_in "$dir" "$root/$dir"
+        continue
+    fi
+
+    manifest="${dir}/${base%-lock.json}.json"
+    if [ ! -f "$manifest" ]; then
+        echo "FOUT: $lock heeft geen bijbehorende $manifest, dus er valt niets te auditeren" >&2
+        status=1
+        continue
+    fi
+
+    work="$tmp/$(echo "$lock" | tr / _)"
+    mkdir -p "$work"
+    cp "$root/$manifest" "$work/package.json"
+    cp "$root/$lock" "$work/package-lock.json"
+    audit_in "$lock" "$work"
+done < <(git ls-files '*package-lock.json')
+
+if [ "$found" -eq 0 ]; then
+    echo "FOUT: geen enkele package-lock.json gevonden; de scan zegt zo niets" >&2
+    exit 1
+fi
+
+echo "${found} lockfile(s) geauditeerd"
+exit "$status"


### PR DESCRIPTION
Direct na de merge van #1221 opende Dependabot een security-update voor `nanoid` in `packages/arch-extract/ui`: een derde npm-project dat noch in `just audit` noch in `dependabot.yml` stond, en dat dus nog op de kwetsbare 3.3.16 zat terwijl de andere twee gerepareerd waren.

De opsomming was toen al twee keer weggedreven. `docs/` viel er eerder ook buiten, dat kwam in #1221 boven.

## Zoeken in plaats van opsommen

`script/npm-audit-all.sh` loopt over `git ls-files '*package-lock.json'`. Dat leverde meteen een vierde op: `packages/pipeline/opencode-plugins-package-lock.json`, die via `docs/Dockerfile` de enrich-worker-image in gaat.

Die vierde legde ook een valse groen bloot. Er staat geen `package.json` naast, alleen `opencode-plugins-package.json`, dus `npm audit` in die map auditeerde een lege boom en meldde nul kwetsbaarheden. Van een echte schone uitslag is dat niet te onderscheiden. Zo'n paar gaat nu onder standaardnamen naar een tijdelijke map, en een lockfile zonder bijbehorend manifest is voortaan een harde fout in plaats van een stille nul.

De scan faalt ook als hij nul lockfiles vindt, want ook dat leest anders als schoon.

## Verder

De bump van `nanoid` naar 3.3.18 in `packages/arch-extract/ui`, en een `dependabot.yml`-blok voor die map.

## cargo-deny lokaal gepind

`just audit` viel lokaal om op `cargo deny check --config`. De aanroep verschilt per versie: 0.19 wil `check --config <pad>`, 0.20 wil `--config <pad> check`. Een aanroep die op allebei werkt bestaat niet, dus wie cargo-deny vers installeerde kreeg `unexpected argument '--config' found` in plaats van een audit, en het verschil tussen lokaal en CI groeide stil.

`script/cargo-deny.sh` leest versie en checksum uit `ci.yml` en haalt die binary eenmalig naar `~/.cache/regelrecht`. De pin staat daarmee op één plek en niemand hoeft iets te installeren. Buiten linux/x86_64 is er geen prebuilt binary; daar controleert het script de geïnstalleerde versie en noemt het het commando om hem goed te zetten.

Het optrekken van die pin naar 0.20 is een eigen besluit en zit hier niet in.
