### PR TITLE
fix(github): een lege conclusie schuift de url niet meer op

### DIFF
--- a/script/require-ci-green.sh
+++ b/script/require-ci-green.sh
@@ -45,7 +45,7 @@ latest_run() {
         --jq "[.workflow_runs[] | select(.name == \"${WORKFLOW}\")]
               | sort_by(.run_started_at) | last
               | select(. != null)
-              | \"\(.status)\t\(.conclusion // \"\")\t\(.html_url)\"" 2>"$ERRFILE"
+              | \"\(.status)\n\(.conclusion // \"\")\n\(.html_url)\"" 2>"$ERRFILE"
 }
 
 waited=0
@@ -69,7 +69,12 @@ while :; do
             fail "geen enkele ${WORKFLOW}-run gevonden voor ${SHA} binnen ${MAX_WAIT_SECONDS}s. Zonder run is er niets nagekeken; er gaat niets naar productie."
         fi
     else
-        IFS=$'\t' read -r status conclusion url <<<"$run"
+        # Eén veld per regel, en met `read` per regel in plaats van veldsplitsing
+        # op een scheidingsteken. Een tab telt voor IFS als whitespace, dus een
+        # lege conclusie (bij een lopende run) klapte weg en schoof de URL een
+        # veld op. Dat bleef vandaag cosmetisch, maar bij een afgeronde run
+        # zonder conclusie zou de poort blokkeren met de URL als reden.
+        { read -r status; read -r conclusion; read -r url; } <<<"$run"
 
         if [ "$status" = "completed" ]; then
             case "$conclusion" in

--- a/script/require-ci-green.test.sh
+++ b/script/require-ci-green.test.sh
@@ -94,6 +94,14 @@ check "lopende CI laat de deploy niet door" 1 \
     "[$(run in_progress null 2026-08-07T10:00:00Z)]" \
     "nog niet klaar"
 
+# Bij een lopende run is de conclusie leeg. Ging de scheiding op tabs, dan klapte
+# dat lege veld weg (tab is whitespace voor IFS) en schoof de URL een veld op:
+# de melding verloor zijn link, en een afgeronde run zonder conclusie zou
+# blokkeren met die URL als reden.
+check "een lege conclusie schuift de url niet op" 1 \
+    "[$(run in_progress null 2026-08-07T10:00:00Z)]" \
+    "geduld: u"
+
 # De nieuwste run is de laatste uitspraak; een oudere groene run mag een
 # nieuwere rode niet overstemmen.
 check "de nieuwste run beslist, niet de eerste" 1 \


### PR DESCRIPTION
De deploy-poort las status, conclusie en URL uit één regel met tabs. Een tab telt voor `IFS` als whitespace, dus bij een lopende run klapte de lege conclusie weg en schoof de URL een veld op. In de eerste main-run met deze poort (`c2098af5`) was dat te zien: elke wachtregel eindigde op "geduld:" zonder link.

Cosmetisch zolang de conclusie alleen leeg is bij een lopende run. Bij een afgeronde run zonder conclusie zou de `case` op de URL vallen en blokkeren met die URL als reden, en dat is een melding die een oorzaak noemt die niet getoetst is.

Nu één veld per regel. De test dekt het geval, en met de tabs terug vallen er zeven van de elf om.
