### PR TITLE
ci(github): een security-update van dependabot mergt pas na goedkeuring

### DIFF
--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -13,6 +13,7 @@ jobs:
       pull-requests: write
       issues: read
       id-token: write
+      security-events: read
 
     steps:
       - name: Checkout repository
@@ -49,6 +50,20 @@ jobs:
               gh api -X DELETE "repos/${REPO}/issues/comments/${comment_id}" 2>/dev/null || true
             done
 
+      # Of dit een security-update is, wordt hier vastgesteld en niet aan het
+      # oordeel van de review overgelaten: het is een feit uit de API en de
+      # tekst van Dependabot, en de merge-beslissing hieronder hangt eraan.
+      # Handhaven doet deze stap niet — dat is de check `Security update
+      # approved` uit `security-update-gate.yml`.
+      - name: Is this a security update?
+        id: security
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          ENFORCE: 'false'
+        run: script/require-security-approval.sh
+
       - name: Run Claude Dependabot Review
         id: claude-dependabot
         uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b  # v1
@@ -59,6 +74,19 @@ jobs:
           claude_args: "--allowedTools Bash,Read,Glob,Grep"
           prompt: |
             Review Dependabot PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.
+
+            SECURITY_UPDATE: ${{ steps.security.outputs.is_security }}
+
+            ## Hard rule
+
+            If SECURITY_UPDATE is `true`, you do NOT merge and you do NOT approve
+            this PR, whatever the rest of your assessment says. A security update
+            bypasses the five-day cooldown in `dependabot.yml`, so the new
+            version can be hours old and nobody has looked at it. The required
+            check `Security update approved` blocks the merge until an engineer
+            with write access approves. Your job on such a PR is to write the
+            assessment that engineer reads: what the advisory is, what the diff
+            actually changes, and whether anything about the release looks off.
 
             ## Task
 
@@ -86,6 +114,7 @@ jobs:
             5. **Decision**:
 
                **Auto-approve and merge** (squash) if ALL of these are true:
+               - SECURITY_UPDATE is `false`
                - It is a patch or minor version bump
                - CI checks all pass
                - No breaking changes indicated in the changelog
@@ -93,6 +122,7 @@ jobs:
                  warrant extra scrutiny even for minor bumps)
 
                **Flag for human review** if ANY of these are true:
+               - SECURITY_UPDATE is `true`
                - It is a major version bump
                - CI checks fail
                - Breaking changes are mentioned

--- a/.github/workflows/security-update-gate.yml
+++ b/.github/workflows/security-update-gate.yml
@@ -1,0 +1,175 @@
+---
+name: Security Update Gate
+
+# Een security-update van Dependabot valt buiten de cooldown van vijf dagen uit
+# `dependabot.yml` en komt dus binnen op het moment dat de versie verschijnt.
+# Deze poort zorgt dat zo'n PR pas mergebaar is als een engineer hem heeft
+# goedgekeurd, zonder daarvoor `required_approving_review_count` op alle PR's te
+# zetten — dat kan branch protection niet per auteur.
+#
+# `pull_request_review` staat erbij omdat een goedkeuring anders geen nieuwe run
+# oplevert: de check blijft dan rood staan op de laatste `pull_request`-run,
+# hoeveel er ook is goedgekeurd.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, closed]
+  pull_request_review:
+    types: [submitted, dismissed]
+
+permissions: {}
+
+jobs:
+  # Geen `if:` — deze job moet op elke PR draaien en rapporteren, ook op forks
+  # en op PR's van mensen, want een verplichte check die soms niet rapporteert
+  # blokkeert zo'n PR voor altijd. Voor alles wat niet van Dependabot komt geeft
+  # het script meteen groen.
+  security-gate:
+    name: Security update approved
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: read
+      security-events: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 1
+
+      # Dezelfde reden als bij de review-poort: een PR die het script naar
+      # `exit 0` verandert zou anders per definitie groen zijn. Terugvallen op
+      # de versie uit de PR is precies de bypass die dit dichtzet.
+      - name: Take the gate script from the base branch
+        id: base
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GATE: script/require-security-approval.sh
+        run: |
+          set -uo pipefail
+          fail() {
+            echo "::error title=Security update approved::$1"
+            exit 1
+          }
+          git fetch --depth=1 origin "$BASE_SHA" ||
+            fail "base-commit ${BASE_SHA} is niet op te halen, dus de versie van de poort is niet vast te stellen. Draai deze job opnieuw."
+          # Staat het script niet op de base-branch, dan is dit de pull request
+          # die de poort invoert (of een die haar weghaalt): er is dan op main
+          # nog niets wat deze check beschermt. Dat is het enige geval waarin
+          # niet-draaien juist is; overslaan bij een leesfout zou de bypass zijn
+          # die de rest van deze stap dichtzet.
+          if ! git cat-file -e "${BASE_SHA}:${GATE}" 2>/dev/null; then
+            echo "bootstrap=true" >>"$GITHUB_OUTPUT"
+            echo "::notice title=Security update approved::${GATE} staat nog niet op de base-branch (${BASE_SHA}); deze pull request voert de poort zelf in. Er valt hier niets te bewaken."
+            exit 0
+          fi
+          git checkout "$BASE_SHA" -- "$GATE" ||
+            fail "${GATE} is niet uit ${BASE_SHA} te checkouten, dus de poort zou de versie uit deze PR draaien. Draai deze job opnieuw."
+          echo "Poort draait de versie van ${BASE_SHA}."
+
+      - name: Require an engineer's approval on a security update
+        if: steps.base.outputs.bootstrap != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Een gesloten PR merget niet meer; de poort rapporteert daar alleen
+          # nog wat ze ziet, zodat de meldstap eronder kan draaien.
+          ENFORCE: ${{ github.event.action != 'closed' }}
+        run: script/require-security-approval.sh
+
+  # De melding draait het script zelf opnieuw in plaats van de uitkomst van de
+  # poort over te nemen: die poort staat rood zolang er niets is goedgekeurd, en
+  # juist dan valt er iets te melden.
+  notify-mattermost:
+    name: Mattermost-melding
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: >-
+      github.event_name == 'pull_request'
+      && github.event.pull_request.user.login == 'dependabot[bot]'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && (github.event.action == 'opened'
+          || github.event.action == 'reopened'
+          || (github.event.action == 'closed' && github.event.pull_request.merged))
+    permissions:
+      contents: read
+      pull-requests: read
+      security-events: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 1
+
+      - name: Take the gate script from the base branch
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GATE: script/require-security-approval.sh
+        run: |
+          set -uo pipefail
+          git fetch --depth=1 origin "$BASE_SHA" &&
+            git checkout "$BASE_SHA" -- "$GATE" || {
+            echo "::error title=Mattermost-melding::${GATE} is niet uit ${BASE_SHA} te halen; er is niets vastgesteld en er is niets gemeld."
+            exit 1
+          }
+
+      - name: Is this a security update?
+        id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          ENFORCE: 'false'
+        run: script/require-security-approval.sh
+
+      # Dependabot start deze run, en dan leest `secrets.*` uit de
+      # Dependabot-secretstore, niet uit die van Actions. Staat de webhook-URL
+      # alleen bij Actions, dan is hij hier leeg en zou de melding stil
+      # wegvallen — vandaar de expliciete fout in plaats van een `curl` naar
+      # niets.
+      - name: Send the Mattermost message
+        if: steps.detect.outputs.is_security == 'true'
+        env:
+          WEBHOOK: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          MERGED: ${{ github.event.action == 'closed' }}
+          ADVISORIES: ${{ steps.detect.outputs.advisories }}
+          DEPENDENCY: ${{ steps.detect.outputs.dependency }}
+        run: |
+          set -uo pipefail
+          if [ -z "${WEBHOOK}" ]; then
+            echo "::error title=Mattermost-melding::MATTERMOST_WEBHOOK_URL is leeg. Deze run is door Dependabot gestart en leest secrets uit de Dependabot-secretstore; zet de webhook-URL daar ook neer (Settings → Secrets and variables → Dependabot)."
+            exit 1
+          fi
+
+          advisories="${ADVISORIES:-geen advisory-nummer in de PR}"
+          detail=$(printf '%s\nAfhankelijkheid: `%s` · %s' "${PR_TITLE}" "${DEPENDENCY}" "${advisories}")
+          if [ "${MERGED}" = "true" ]; then
+            kop=":white_check_mark: **Security-update gemerged**"
+            slot=""
+          else
+            kop=":lock: **Security-update wacht op goedkeuring**"
+            slot=$'\n'"Deze PR valt buiten de cooldown van vijf dagen. De check \`Security update approved\` blijft rood tot een engineer met schrijfrechten hem goedkeurt."
+          fi
+          text=$(printf '%s — [%s#%s](%s)\n%s%s' \
+            "${kop}" "${REPO}" "${PR_NUMBER}" "${PR_URL}" "${detail}" "${slot}")
+
+          # De titel komt uit de PR en gaat daarom door jq de JSON in, niet via
+          # string-plakwerk.
+          jq -n --arg text "$text" '{text: $text, username: "regelrecht"}' >payload.json
+
+          code=$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
+            --max-time 30 --header 'Content-Type: application/json' \
+            --data @payload.json "${WEBHOOK}")
+          if [ "$code" != "200" ]; then
+            echo "::error title=Mattermost-melding::De webhook antwoordde met HTTP ${code}; er is geen bericht in het kanaal beland."
+            exit 1
+          fi
+          echo "Melding verstuurd (HTTP ${code})."

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,6 +78,13 @@ repos:
         pass_filenames: false
         files: ^(script/await-claude-review(\.test)?\.sh|\.github/workflows/claude-code-review\.yml)$
 
+      - id: security-approval-gate-tests
+        name: Merge-poort op een goedgekeurde security-update doet wat hij belooft
+        entry: script/require-security-approval.test.sh
+        language: system
+        pass_filenames: false
+        files: ^(script/require-security-approval(\.test)?\.sh|\.github/workflows/(security-update-gate|claude-dependabot)\.yml)$
+
       - id: ci-gate-tests
         name: Test-poort in ci.yml blokkeert op een gevallen voorganger
         entry: just ci-gate-test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,6 +311,63 @@ The logic lives in `script/await-claude-review.sh`, with
 `script/await-claude-review.test.sh` (a `gh` stub) covering every path that
 decides green versus red; the tests run as a pre-commit hook.
 
+### De goedkeuringspoort op security-updates
+
+Dependabot-security-updates vallen buiten de `cooldown` van vijf dagen in
+`dependabot.yml`: ze komen binnen op het moment dat de versie verschijnt. De
+check **Security update approved** (`security-update-gate.yml`) laat zo'n PR pas
+mergen als een engineer met schrijfrechten hem heeft goedgekeurd.
+
+Dat het een check is en geen branch protection, is geen omweg maar de enige
+route. `required_approving_review_count` hangt aan een branch, niet aan een
+auteur of een label, ook niet in een ruleset, waar de condities alleen over
+refs gaan. Repobreed aanzetten zou betekenen dat niemand nog een eigen PR kan mergen,
+want GitHub laat de auteur zijn eigen wijziging niet goedkeuren. De voorwaarde
+hoort dus in de check, precies zoals bij `Claude review completed`.
+
+Wat een security-update is, staat in geen enkel API-veld. De poort leest drie
+onafhankelijke signalen: een open Dependabot-alert voor precies het pakket dat
+de PR bumpt, Dependabots eigen regel "This update includes a security fix", en
+een GHSA- of CVE-nummer in de aanhef van de PR-body, de tekst tot aan het
+eerste `<details>`-blok: daarachter staan geciteerde changelogs die net zo
+goed over een ander pakket kunnen gaan. Eén signaal is genoeg. Een vals positief
+kost een goedkeuring die niet nodig was; een vals negatief laat een
+security-patch ongezien door, dus de poort leunt naar het eerste.
+
+Een goedkeuring telt alleen op de commit waarop ze is gegeven. `dismiss_stale_reviews`
+werkt pas bij `required_approving_review_count > 0` en dat staat hier op 0, dus
+die binding zit in het script: na een rebase of een push is er niets meer
+goedgekeurd. Goedkeuringen van bots tellen niet, en van iemand zonder
+schrijfrechten (`author_association` buiten OWNER/MEMBER/COLLABORATOR) evenmin.
+
+`claude-dependabot.yml` stelt met hetzelfde script vast of een PR een
+security-update is en mergt die dan niet meer zelf; de review blijft er wel op
+draaien, als input voor de engineer die goedkeurt. Handhaven doet die workflow
+niet; dat doet de check.
+
+Er zit geen ouderdomsdrempel op. Die drempel bestaat omdat niemand naar een
+routinebump kijkt, en dat is precies wat de goedkeuring wegneemt; hem er
+bovenop zetten zou een actief misbruikte kwetsbaarheid vijf dagen laten liggen
+*plus* de wachttijd op een mens. De publicatiedatum van de nieuwe versie is een
+van de dingen waar de goedkeurder naar kijkt, niet iets wat de poort voor hem
+afkapt.
+
+De melding naar Mattermost zit in dezelfde workflow en gaat uit bij het openen
+en het mergen van een security-PR, over `MATTERMOST_WEBHOOK_URL`. Die run wordt
+door Dependabot gestart, en dan leest `secrets.*` uit de
+Dependabot-secretstore in plaats van die van Actions: staat de webhook-URL
+alleen bij Actions, dan valt de melding stil weg. De stap faalt daarom hard op
+een lege URL.
+
+De logica staat in `script/require-security-approval.sh`, met
+`script/require-security-approval.test.sh` (een `gh`-stub) over elk pad dat
+groen of rood beslist; de tests draaien als pre-commit-hook. De poort draait de
+kopie van dat script van de base-branch en niet die uit de pull request. Staat
+het er niet, dan is dat geen leesfout maar de pull request die de poort invoert
+of weghaalt; er is dan op main nog niets wat deze check beschermt, dus de job
+meldt dat en laat door. Dezelfde beperking als bij de review-poort geldt hier:
+de job staat in het workflowbestand dat de PR meebrengt.
+
 ### Deployed Components
 
 | Component | Image | Production URL |

--- a/script/require-security-approval.sh
+++ b/script/require-security-approval.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# Merge-poort: een security-update van Dependabot komt pas door als een engineer
+# hem heeft goedgekeurd.
+#
+# De eis geldt uitsluitend voor security-PR's van Dependabot. Dat is niet met
+# branch protection of een ruleset te maken: `required_approving_review_count`
+# hangt aan een branch, niet aan een auteur of een label, en zou dus elke PR
+# treffen. Voor een repo waarin de auteur van een PR zijn eigen wijziging niet
+# mag goedkeuren betekent dat: alles op slot. Daarom is de eis een *check*, met
+# de voorwaarde erin, precies zoals `Claude review completed` dat doet.
+#
+# Wat de poort als feit behandelt, haalt zij zelf op. Uit de omgeving komen
+# alleen de coördinaten (repository, PR-nummer); auteur, tekst, reviews en
+# alerts komen van de API.
+#
+# Wanneer is een Dependabot-PR een security-update? Er is geen veld in de API
+# dat dat zegt, dus de poort leest drie onafhankelijke signalen:
+#
+#   1. een open Dependabot-alert voor precies het pakket dat deze PR bumpt;
+#   2. Dependabots eigen regel "This update includes a security fix." in de
+#      body;
+#   3. een GHSA- of CVE-nummer in Dependabots eigen tekst — dat is de body tot
+#      aan het eerste `<details>`-blok, want daarna staan release notes en
+#      changelogs die net zo goed over de beveiliging van een *ander* pakket
+#      kunnen gaan.
+#
+# Eén signaal is genoeg. Ze staan er los van elkaar omdat het eerste een
+# token-scope nodig heeft die een door Dependabot gestarte run niet altijd
+# heeft, en het tweede en derde afhangen van een formulering die GitHub kan
+# wijzigen. Een vals positief kost een goedkeuring die niet nodig was; een vals
+# negatief laat een security-patch ongezien door. De poort leunt dus naar het
+# eerste.
+#
+# Wat dit niet dekt: deze job staat in het workflowbestand dat de PR meebrengt.
+# Dependabot raakt `.github/workflows/` alleen aan in het `github-actions`-
+# ecosysteem, en zulke PR's zijn geen security-updates van npm of cargo, maar
+# de bypass bestaat op papier — net als bij de review-poort. Sluiten kan alleen
+# met een regel buiten de pull request om.
+set -uo pipefail
+
+: "${REPO:?REPO is verplicht}"
+: "${PR_NUMBER:?PR_NUMBER is verplicht}"
+
+# Uit staat de poort alleen daar waar hij niets te blokkeren heeft: de
+# dependabot-review gebruikt hem om te wéten of dit een security-PR is, en de
+# meldstap om te weten of er iets te melden valt.
+ENFORCE="${ENFORCE:-true}"
+GITHUB_OUTPUT="${GITHUB_OUTPUT:-/dev/null}"
+GITHUB_STEP_SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+readonly BOT='dependabot[bot]'
+
+summary() { printf '%s\n' "$1" >>"$GITHUB_STEP_SUMMARY"; }
+output() { printf '%s=%s\n' "$1" "$2" >>"$GITHUB_OUTPUT"; }
+
+# Foutuitvoer van `gh` apart houden: een waarschuwing op een verder geslaagde
+# aanroep zou de payload onparseerbaar maken, en dat kwam dan naar buiten als
+# een uitspraak over de PR in plaats van als leesprobleem.
+gh_stderr=$(mktemp "${TMPDIR:-/tmp}/security-gate-stderr.XXXXXX")
+trap 'rm -f "$gh_stderr"' EXIT
+
+green() {
+    echo "::notice title=Security update approved::$1"
+    summary "### Security-goedkeuring: niet nodig of aanwezig"
+    summary ""
+    summary "$1"
+    exit 0
+}
+
+blocked() {
+    if [ "$ENFORCE" != "true" ]; then
+        echo "::notice title=Security update approved::$1 (deze stap handhaaft niet)"
+        summary "### Security-goedkeuring: nog niet gegeven"
+        summary ""
+        summary "$1"
+        exit 0
+    fi
+    echo "::error title=Security update approved::$1"
+    summary "### Security-goedkeuring: geblokkeerd"
+    summary ""
+    summary "$1"
+    exit 1
+}
+
+# Een leesfout is geen uitspraak over de PR. Hij blokkeert wel, want doorlaten
+# zou betekenen dat de poort groen geeft over iets wat ze niet gezien heeft.
+unreadable() {
+    echo "::error title=Security update approved::$1"
+    summary "### Security-goedkeuring: niet vast te stellen"
+    summary ""
+    summary "$1"
+    exit 1
+}
+
+if ! pr=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" 2>"$gh_stderr") ||
+    ! head_sha=$(jq -er '.head.sha' <<<"$pr" 2>/dev/null); then
+    unreadable "Pull request ${PR_NUMBER} in ${REPO} is niet op te halen, dus of dit een security-update is valt niet vast te stellen. Draai deze job opnieuw. Foutmelding: $(tr '\n' ' ' <"$gh_stderr")"
+fi
+
+pr_field() { jq -r "${1} // \"\"" <<<"$pr"; }
+
+title=$(pr_field '.title')
+body=$(pr_field '.body')
+
+output 'head_sha' "$head_sha"
+output 'title' "$title"
+
+if [ "$(pr_field '.user.login')" != "$BOT" ]; then
+    output 'is_security' 'false'
+    output 'approved' 'false'
+    output 'advisories' ''
+    green "Deze PR komt niet van ${BOT}. De goedkeuringseis geldt alleen voor de security-updates die Dependabot zelf opent; een PR van een mens loopt langs de gewone review."
+fi
+
+# "bump serde from 1.0.1 to 1.0.2" → serde. Leestekens waarmee Dependabot de
+# naam soms omgeeft gaan eraf, zodat de vergelijking met de alert klopt.
+dependency=$(sed -nE 's/.*[Bb]umps? (\S+) from \S+ to \S+.*/\1/p' <<<"$title" | head -1)
+dependency=${dependency//[\`\[\]\*]/}
+output 'dependency' "$dependency"
+
+# Alleen Dependabots eigen tekst; alles vanaf het eerste `<details>` is
+# geciteerde changelog.
+own_text=${body%%<details>*}
+
+advisories=$(grep -oiE 'GHSA-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}|CVE-[0-9]{4}-[0-9]+' <<<"$body" |
+    tr '[:lower:]' '[:upper:]' | sort -u | paste -sd, -)
+output 'advisories' "$advisories"
+
+is_security=false
+signal=''
+
+# Het sterkste signaal, want het komt van de API en niet uit tekst die van
+# formulering kan veranderen. Mislukt de aanroep — een door Dependabot gestarte
+# run krijgt een token met minder rechten — dan is dat geen "geen alert": de
+# poort zegt het en valt terug op de twee tekstsignalen.
+if alerts=$(gh api "repos/${REPO}/dependabot/alerts?state=open&per_page=100" \
+    --jq '.[].security_vulnerability.package.name' 2>"$gh_stderr"); then
+    if [ -n "$dependency" ] && grep -qixF "$dependency" <<<"$alerts"; then
+        is_security=true
+        signal="er staat een open Dependabot-alert voor \`${dependency}\`"
+    fi
+else
+    echo "::warning title=Security update approved::De Dependabot-alerts zijn niet op te halen ($(tr '\n' ' ' <"$gh_stderr")). De poort beoordeelt deze PR op de tekst van Dependabot alleen."
+fi
+
+if [ "$is_security" = false ] && grep -qiF 'This update includes a security fix' <<<"$own_text"; then
+    is_security=true
+    signal='Dependabot noemt deze bump zelf een security fix'
+fi
+
+if [ "$is_security" = false ] &&
+    grep -qiE 'GHSA-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}|CVE-[0-9]{4}-[0-9]+' <<<"$own_text"; then
+    is_security=true
+    signal="Dependabot noemt een advisory (${advisories}) in de aanhef van deze PR"
+fi
+
+output 'is_security' "$is_security"
+
+if [ "$is_security" = false ]; then
+    output 'approved' 'false'
+    green "Dit is een gewone versie-bump van Dependabot, geen security-update: geen open alert voor \`${dependency:-het gebumpte pakket}\` en geen advisory in de aanhef. Die PR's vallen onder de cooldown van vijf dagen en mogen zonder goedkeuring mergen."
+fi
+
+# Een goedkeuring telt alleen voor de commit waarop ze is gegeven. Branch
+# protection dismist stale reviews pas bij `required_approving_review_count > 0`
+# en dat staat hier op 0, dus die binding moet hiervandaan komen: na een rebase
+# of een nieuwe push is er niets meer goedgekeurd.
+if ! reviews=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" --paginate 2>"$gh_stderr"); then
+    unreadable "De reviews van pull request ${PR_NUMBER} zijn niet op te halen, dus of deze security-update is goedgekeurd valt niet vast te stellen. Draai deze job opnieuw. Foutmelding: $(tr '\n' ' ' <"$gh_stderr")"
+fi
+
+# Een goedkeuring van een bot is geen menselijke blik, en een goedkeuring van
+# een willekeurige buitenstaander evenmin: iedereen met een account kan een
+# review achterlaten, dus alleen wie schrijfrechten heeft telt.
+approver=$(jq -r --arg sha "$head_sha" '
+    [ .[]
+      | select(.state == "APPROVED")
+      | select(.commit_id == $sha)
+      | select(.user.login | endswith("[bot]") | not)
+      | select(.author_association == "OWNER"
+               or .author_association == "MEMBER"
+               or .author_association == "COLLABORATOR")
+    ] | last | .user.login // ""' <<<"$reviews")
+
+if [ -n "$approver" ]; then
+    output 'approved' 'true'
+    output 'approver' "$approver"
+    green "Security-update (${signal}), goedgekeurd door @${approver} op commit \`${head_sha:0:7}\`.${advisories:+ Advisories: ${advisories}.}"
+fi
+
+output 'approved' 'false'
+blocked "Dit is een security-update (${signal})${advisories:+, advisories: ${advisories}}. Zulke PR's vallen buiten de cooldown van vijf dagen: de nieuwe versie kan uren oud zijn en niemand anders heeft ernaar gekeken. Een engineer met schrijfrechten moet deze PR goedkeuren op commit \`${head_sha:0:7}\`; kijk daarbij naar de advisory, de diff van het lockfile en de publicatiedatum van de nieuwe versie. Een push naar de branch verlaat de goedkeuring."

--- a/script/require-security-approval.test.sh
+++ b/script/require-security-approval.test.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# Dekt elk pad dat groen of rood beslist in script/require-security-approval.sh,
+# met een `gh`-stub op PATH. Zonder deze test is een poort die altijd doorlaat
+# niet te onderscheiden van een die werkt — en dat is precies het geval dat een
+# security-patch ongezien naar main brengt.
+set -uo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+gate="$here/require-security-approval.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+pass=0
+fail=0
+
+# De stub bedient de drie endpoints die de poort aanroept en leest per endpoint
+# een fixture. Staat er `FAIL` in de fixture, dan faalt die aanroep, zodat een
+# API-fout op één endpoint los te testen is van de rest.
+cat >"$tmp/gh" <<'STUB'
+#!/usr/bin/env bash
+endpoint=""
+filter=""
+for ((i = 1; i <= $#; i++)); do
+    case "${!i}" in
+    --jq)
+        j=$((i + 1))
+        filter="${!j}"
+        ;;
+    repos/*) endpoint="${!i}" ;;
+    esac
+done
+
+case "$endpoint" in
+*/dependabot/alerts*) file="$FIXTURES/alerts.json" ;;
+*/reviews*) file="$FIXTURES/reviews.json" ;;
+*) file="$FIXTURES/pr.json" ;;
+esac
+
+if [ ! -f "$file" ] || grep -q '^FAIL' "$file"; then
+    echo "gh: stub-fout op ${endpoint}" >&2
+    exit 1
+fi
+
+if [ -n "$filter" ]; then
+    jq -r "$filter" <"$file"
+else
+    cat "$file"
+fi
+STUB
+chmod +x "$tmp/gh"
+
+pr_json() { # $1 = auteur, $2 = titel, $3 = body
+    jq -n --arg u "$1" --arg t "$2" --arg b "$3" \
+        '{head: {sha: "cafebabe1234567"}, user: {login: $u}, title: $t, body: $b}'
+}
+
+review() { # $1 = login, $2 = state, $3 = commit, $4 = association
+    jq -n --arg l "$1" --arg s "$2" --arg c "$3" --arg a "$4" \
+        '{user: {login: $l}, state: $s, commit_id: $c, author_association: $a}'
+}
+
+# $1 = naam, $2 = verwachte exitcode, $3 = pr.json, $4 = alerts.json,
+# $5 = reviews.json, $6 = optioneel patroon in de uitvoer,
+# $7 = optioneel patroon in $GITHUB_OUTPUT
+check() {
+    local name="$1" want="$2" needle="${6:-}" out_needle="${7:-}"
+    printf '%s' "$3" >"$tmp/pr.json"
+    printf '%s' "$4" >"$tmp/alerts.json"
+    printf '%s' "$5" >"$tmp/reviews.json"
+    : >"$tmp/outputs"
+
+    local out status
+    out="$(PATH="$tmp:$PATH" FIXTURES="$tmp" ENFORCE="${ENFORCE:-true}" \
+        REPO=o/r PR_NUMBER=42 GITHUB_OUTPUT="$tmp/outputs" \
+        bash "$gate" 2>&1)"
+    status=$?
+
+    if [ "$status" -ne "$want" ]; then
+        echo "FAIL: $name — exit $status, verwacht $want"
+        sed 's/^/    /' <<<"$out"
+        fail=$((fail + 1))
+        return
+    fi
+    if [ -n "$needle" ] && ! grep -qF "$needle" <<<"$out"; then
+        echo "FAIL: $name — '$needle' niet in de uitvoer"
+        sed 's/^/    /' <<<"$out"
+        fail=$((fail + 1))
+        return
+    fi
+    if [ -n "$out_needle" ] && ! grep -qxF "$out_needle" "$tmp/outputs"; then
+        echo "FAIL: $name — '$out_needle' niet in \$GITHUB_OUTPUT"
+        sed 's/^/    /' "$tmp/outputs"
+        fail=$((fail + 1))
+        return
+    fi
+    echo "ok: $name"
+    pass=$((pass + 1))
+}
+
+no_alerts='[]'
+no_reviews='[]'
+alert_serde='[{"security_vulnerability": {"package": {"name": "serde"}}}]'
+
+marker='Bumps serde from 1.0.1 to 1.0.2. **This update includes a security fix.**'
+plain='Bumps serde from 1.0.1 to 1.0.2.'
+changelog_only="$plain
+<details><summary>Changelog</summary>fixes GHSA-aaaa-bbbb-cccc in an unrelated package</details>"
+advisory_in_lead="Bumps serde from 1.0.1 to 1.0.2, tegen GHSA-aaaa-bbbb-cccc.
+<details><summary>Changelog</summary>niets</details>"
+
+check "PR van een mens valt buiten de eis" 0 \
+    "$(pr_json someone 'fix(deps): dompurify naar 3.4.13' "$marker")" \
+    "$alert_serde" "$no_reviews" \
+    'komt niet van dependabot' 'is_security=false'
+
+check "gewone bump van dependabot mag zonder goedkeuring mergen" 0 \
+    "$(pr_json 'dependabot[bot]' 'chore(deps): bump serde from 1.0.1 to 1.0.2' "$plain")" \
+    "$no_alerts" "$no_reviews" \
+    'gewone versie-bump' 'is_security=false'
+
+check "een advisory in een geciteerde changelog maakt er nog geen security-update van" 0 \
+    "$(pr_json 'dependabot[bot]' 'chore(deps): bump serde from 1.0.1 to 1.0.2' "$changelog_only")" \
+    "$no_alerts" "$no_reviews" \
+    'gewone versie-bump' 'is_security=false'
+
+check "security-update zonder goedkeuring blokkeert" 1 \
+    "$(pr_json 'dependabot[bot]' 'chore(deps): bump serde from 1.0.1 to 1.0.2' "$marker")" \
+    "$no_alerts" "$no_reviews" \
+    'moet deze PR goedkeuren' 'is_security=true'
+
+check "een open alert voor het gebumpte pakket is genoeg signaal" 1 \
+    "$(pr_json 'dependabot[bot]' 'chore(deps): bump serde from 1.0.1 to 1.0.2' "$plain")" \
+    "$alert_serde" "$no_reviews" \
+    'open Dependabot-alert' 'is_security=true'
+
+check "een advisory in de aanhef van dependabot is genoeg signaal" 1 \
+    "$(pr_json 'dependabot[bot]' 'chore(deps): bump serde from 1.0.1 to 1.0.2' "$advisory_in_lead")" \
+    "$no_alerts" "$no_reviews" \
+    'GHSA-AAAA-BBBB-CCCC' 'advisories=GHSA-AAAA-BBBB-CCCC'
+
+check "een alert voor een ander pakket telt niet mee" 0 \
+    "$(pr_json 'dependabot[bot]' 'chore(deps): bump tokio from 1.0.1 to 1.0.2' "$plain")" \
+    "$alert_serde" "$no_reviews" \
+    'gewone versie-bump' 'is_security=false'
+
+check "goedkeuring van een engineer op deze commit laat door" 0 \
+    "$(pr_json 'dependabot[bot]' 'chore(deps): bump serde from 1.0.1 to 1.0.2' "$marker")" \
+    "$no_alerts" "[$(review eelco APPROVED cafebabe1234567 MEMBER)]" \
+    'goedgekeurd door @eelco' 'approved=true'
+
+check "goedkeuring op een oudere commit telt niet" 1 \
+    "$(pr_json 'dependabot[bot]' 'chore(deps): bump serde from 1.0.1 to 1.0.2' "$marker")" \
+    "$no_alerts" "[$(review eelco APPROVED 0000000deadbeef MEMBER)]" \
+    'moet deze PR goedkeuren' 'approved=false'
+
+check "goedkeuring van een bot telt niet" 1 \
+    "$(pr_json 'dependabot[bot]' 'chore(deps): bump serde from 1.0.1 to 1.0.2' "$marker")" \
+    "$no_alerts" "[$(review 'claude[bot]' APPROVED cafebabe1234567 MEMBER)]" \
+    'moet deze PR goedkeuren' 'approved=false'
+
+check "goedkeuring van iemand zonder schrijfrechten telt niet" 1 \
+    "$(pr_json 'dependabot[bot]' 'chore(deps): bump serde from 1.0.1 to 1.0.2' "$marker")" \
+    "$no_alerts" "[$(review buitenstaander APPROVED cafebabe1234567 NONE)]" \
+    'moet deze PR goedkeuren' 'approved=false'
+
+check "een becommentarieerde review is geen goedkeuring" 1 \
+    "$(pr_json 'dependabot[bot]' 'chore(deps): bump serde from 1.0.1 to 1.0.2' "$marker")" \
+    "$no_alerts" "[$(review eelco COMMENTED cafebabe1234567 MEMBER)]" \
+    'moet deze PR goedkeuren' 'approved=false'
+
+check "een ingetrokken goedkeuring telt niet" 1 \
+    "$(pr_json 'dependabot[bot]' 'chore(deps): bump serde from 1.0.1 to 1.0.2' "$marker")" \
+    "$no_alerts" "[$(review eelco DISMISSED cafebabe1234567 MEMBER)]" \
+    'moet deze PR goedkeuren' 'approved=false'
+
+check "onbereikbare alerts blokkeren niet, maar worden wel gemeld" 1 \
+    "$(pr_json 'dependabot[bot]' 'chore(deps): bump serde from 1.0.1 to 1.0.2' "$marker")" \
+    'FAIL' "$no_reviews" \
+    'alerts zijn niet op te halen' 'is_security=true'
+
+check "een onleesbare PR blokkeert en noemt geen oorzaak die niet getoetst is" 1 \
+    'FAIL' "$no_alerts" "$no_reviews" \
+    'niet op te halen'
+
+check "onleesbare reviews blokkeren" 1 \
+    "$(pr_json 'dependabot[bot]' 'chore(deps): bump serde from 1.0.1 to 1.0.2' "$marker")" \
+    "$no_alerts" 'FAIL' \
+    'reviews van pull request 42 zijn niet op te halen'
+
+ENFORCE=false check "zonder handhaving blijft de uitkomst leesbaar en groen" 0 \
+    "$(pr_json 'dependabot[bot]' 'chore(deps): bump serde from 1.0.1 to 1.0.2' "$marker")" \
+    "$no_alerts" "$no_reviews" \
+    'handhaaft niet' 'is_security=true'
+
+echo
+echo "${pass} geslaagd, ${fail} gefaald"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Een security-update van Dependabot valt buiten de cooldown van vijf dagen en komt binnen op het moment dat de versie verschijnt; met deze PR is zo'n update pas mergebaar nadat een engineer hem heeft goedgekeurd. De nieuwe check `Security update approved` stelt zelf vast of een PR een security-update is (een open Dependabot-alert voor het gebumpte pakket, Dependabots eigen "This update includes a security fix", of een GHSA/CVE in de aanhef van de body) en eist dan een goedkeuring van iemand met schrijfrechten op precies de commit die gemerged wordt, zodat een push de goedkeuring verlaat. Dat het een check is en geen `required_approving_review_count`, is geen omweg maar de enige route: die instelling hangt aan een branch en niet aan een auteur, ook niet in een ruleset, en repobreed aanzetten zou betekenen dat niemand nog een eigen PR kan mergen. `claude-dependabot.yml` stelt met hetzelfde script vast of het om een security-update gaat en mergt die niet meer zelf; de beoordeling blijft draaien als input voor wie goedkeurt. Een ouderdomsdrempel zit er bewust niet op, want de goedkeuring vervangt hem en samen zouden ze een actief misbruikte kwetsbaarheid vijf dagen laten liggen bovenop de wachttijd op een mens; bij het openen en het mergen van zo'n PR gaat er een bericht naar Mattermost.

Drie dingen moet jij zelf zetten, want het zijn repo-instellingen:

- Dependabot security updates weer aanzetten (Settings → Code security).
- `Security update approved` toevoegen aan de verplichte checks van `main`. Tot dat gebeurt rapporteert de poort wel, maar blokkeert ze niets.
- `MATTERMOST_WEBHOOK_URL` als secret, zowel bij Actions als bij Dependabot. Een run die door Dependabot is gestart leest secrets uit de Dependabot-store; staat de URL daar niet, dan faalt de meldstap hard in plaats van stil weg te vallen.

Twee dingen heb ik niet kunnen toetsen. Er staat nu geen Dependabot-security-PR open, dus de drie signalen zijn geverifieerd tegen fixtures in `script/require-security-approval.test.sh` en niet tegen een echte PR. En of een door Dependabot gestarte run `security-events: read` krijgt, blijkt pas bij de eerste; lukt het niet, dan meldt de poort dat en beoordeelt ze op de tekst van Dependabot alleen.
