### PR TITLE
ci: advisories uit de blokkerende poort naar een eigen periodieke controle

### DIFF
--- a/.github/workflows/security-advisories.yml
+++ b/.github/workflows/security-advisories.yml
@@ -1,0 +1,108 @@
+---
+# De tijdsafhankelijke helft van de security-audit, weg uit de PR-poort.
+#
+# `Security Audit` in ci.yml blijft verplicht, maar draait sinds deze splitsing
+# alleen nog wat deterministisch is: bans, licenses en sources uit deny.toml
+# plus license-checker. Dezelfde commit geeft daar altijd dezelfde uitslag, dus
+# rood betekent daar altijd dat de pull request zelf iets fout doet.
+#
+# Advisories werken anders. Ze verschijnen buiten de repo om en maken elke
+# openstaande pull request rood zonder dat iemand iets veranderde: op 7 augustus
+# 2026 gebeurde dat twee keer op een dag, met veertig openstaande PR's en de
+# runnerpool als knelpunt. Ze zijn wel echt signaal, dus ze verdwijnen niet —
+# ze verhuizen hierheen.
+#
+# Wat de melding hard maakt is niet dit ene mechanisme maar de stapeling:
+# de run zelf valt om (GitHub mailt bij een falende scheduled workflow, en
+# Actions zet een banner bij een workflow die op main faalt), de bevinding komt
+# als issue in de repo met een eigen label, en dat issue laat elke week van zich
+# horen zolang het open staat. Alleen een issue zou te makkelijk wegzakken;
+# alleen een rode run zou na een week niemand meer opvallen.
+name: Security Advisories
+
+on:
+  schedule:
+    - cron: '0 5 * * *'  # Elke ochtend om 5:00 UTC
+  workflow_dispatch:
+  # Ook op main, zodat een bump het issue binnen minuten sluit in plaats van
+  # bij de volgende nachtrun, en een advisory die met een merge binnenkomt
+  # meteen zichtbaar is.
+  push:
+    branches: [main]
+    paths:
+      - '**/package-lock.json'
+      - 'packages/Cargo.lock'
+      - 'deny.toml'
+      - 'script/audit-advisories.sh'
+      - 'script/report-advisories.sh'
+      - 'script/cargo-deny.sh'
+      - 'script/npm-audit-all.sh'
+      - '.github/workflows/security-advisories.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-advisories
+  cancel-in-progress: false
+
+jobs:
+  advisories:
+    name: Advisories in afhankelijkheden
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      # Voor de melding: het issue aanmaken, sluiten en van een herinnering
+      # voorzien.
+      issues: write
+    env:
+      ADVISORY_OUT: ${{ runner.temp }}/advisories
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Install Rust toolchain
+        # cargo-deny leest de crate-graph via `cargo metadata`.
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7  # stable
+
+      - name: Cache cargo registry (shared)
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('packages/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-registry-
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
+        with:
+          node-version: '22'
+          registry-url: https://npm.pkg.github.com
+
+      - name: Install just
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
+
+      # De versie van cargo-deny komt uit ci.yml; script/cargo-deny.sh haalt hem
+      # daar op met checksum, zodat deze workflow die pin niet dubbel opschrijft.
+      - name: Advisories opzoeken
+        id: audit
+        run: |
+          set +e
+          just audit-advisories
+          echo "status=$?" >> "$GITHUB_OUTPUT"
+
+      - name: De uitkomst melden
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: script/report-advisories.sh
+
+      # Na de melding, niet ervoor: een rode stap hiervoor zou het issue laten
+      # liggen, en dan is er alleen een runlog dat niemand opent.
+      - name: Rood op openstaande advisories
+        if: steps.audit.outputs.status != '0'
+        run: |
+          echo "::error title=Advisories::Er staan advisories open in de afhankelijkheden. Ze blokkeren geen pull request; de bevinding staat in het issue met label security-advisory."
+          exit 1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -119,6 +119,13 @@ repos:
         pass_filenames: false
         files: ^(script/check-preview-environments(\.test)?\.sh|\.github/workflows/scheduled-cleanup\.yml)$
 
+      - id: advisories-report-tests
+        name: Advisory-melding komt aan en niet dubbel
+        entry: script/report-advisories.test.sh
+        language: system
+        pass_filenames: false
+        files: ^(script/(report-advisories(\.test)?|audit-advisories)\.sh|\.github/workflows/security-advisories\.yml)$
+
       - id: skills-no-casus
         name: Skills blijven dossier-agnostisch (geen casus-inhoud)
         entry: script/check-skills-no-casus.sh

--- a/Justfile
+++ b/Justfile
@@ -136,7 +136,7 @@ preview-environments-test:
 # container-backed suites; on a machine without a daemon, swap `test` for
 # `test-no-docker`.
 [doc("Run all quality checks, exactly what CI runs (needs Docker)")]
-check: format lint build-check validate validate-annotations deploy-filters-test precompress-test security-headers-test first-load-test ci-gate-test dockerfile-consistency-test deploy-gate-test deployed-urls-test preview-environments-test test
+check: format lint build-check validate validate-annotations deploy-filters-test precompress-test security-headers-test first-load-test ci-gate-test dockerfile-consistency-test deploy-gate-test deployed-urls-test preview-environments-test advisories-report-test test
 
 # --- Tests ---
 
@@ -307,14 +307,27 @@ bench-compare BASE:
 
 # --- Security ---
 
-# Run security audit on all dependencies (vulnerabilities, licenses, sources)
+# De deterministische helft van de security-audit, en de enige die een pull
+# request blokkeert. Bans, licenses en sources hangen alleen aan wat er in de
+# lockfiles staat: dezelfde commit geeft vandaag en over een maand dezelfde
+# uitslag. Kwetsbaarheden horen daar niet bij, want die komen van buiten en
+# maken een PR rood zonder dat er iets aan die PR veranderd is; die staan in
+# `just audit-advisories`.
 audit:
-    script/cargo-deny.sh
-    script/npm-audit-all.sh
+    script/cargo-deny.sh bans licenses sources
     # license-checker draait alleen over de workspace in de root; die drops
     # --production omdat de root geen eigen productie-deps heeft, en de
     # hele-boom-scan is strikt ruimer.
     npx license-checker --failOn "GPL-2.0;GPL-3.0;AGPL-1.0;AGPL-3.0;SSPL-1.0;BUSL-1.1"
+
+# De tijdsafhankelijke helft: advisories uit RustSec en npm. Draait periodiek
+# in .github/workflows/security-advisories.yml en meldt zich daar als issue.
+audit-advisories:
+    script/audit-advisories.sh
+
+# De meldlogica van de advisory-controle
+advisories-report-test:
+    script/report-advisories.test.sh
 
 # --- Admin ---
 

--- a/script/audit-advisories.sh
+++ b/script/audit-advisories.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# De tijdsafhankelijke helft van de security-audit: kwetsbaarheden in
+# afhankelijkheden, uit de RustSec-database en uit de npm-advisory-database.
+#
+# Deze controle staat bewust buiten de PR-poort. Een nieuwe advisory verandert
+# niets aan de pull request, maar maakt hem wel rood: op 7 augustus 2026 legde
+# dompurify overdag elke openstaande PR stil en nanoid 's avonds de hele repo,
+# beide keren zonder dat iemand iets had gewijzigd. Wat deterministisch is
+# (`bans`, `licenses`, `sources`, license-checker) blijft in `just audit` en
+# blijft dus blokkeren; dit deel hangt aan de buitenwereld en draait periodiek.
+#
+# De uitkomst gaat naar twee bestanden in $ADVISORY_OUT, want een uitslag die
+# alleen in een runlog staat wordt door niemand opgepakt:
+#   advisories.ids  één regel per bevinding: "<tool> <id>", de vingerafdruk
+#                   waarop script/report-advisories.sh dubbele meldingen
+#                   herkent.
+#   advisories.md   het lichaam van de melding.
+#
+# Exitcode 0 = schoon, 1 = bevindingen.
+set -uo pipefail
+
+cd "$(dirname "$0")/.."
+
+out="${ADVISORY_OUT:-$(mktemp -d)}"
+mkdir -p "$out"
+ids="$out/advisories.ids"
+body="$out/advisories.md"
+: >"$ids"
+
+cargo_log="$out/cargo-deny.log"
+npm_log="$out/npm-audit.log"
+
+echo "== cargo-deny advisories =="
+script/cargo-deny.sh advisories 2>&1 | tee "$cargo_log"
+cargo_status=${PIPESTATUS[0]}
+
+echo
+echo "== npm audit =="
+script/npm-audit-all.sh 2>&1 | tee "$npm_log"
+npm_status=${PIPESTATUS[0]}
+
+# Een tool die omvalt zonder een advisory-id te noemen (een yanked crate, een
+# onbereikbare database) is óók een bevinding: stil doorlaten is precies wat
+# deze controle moet uitsluiten. Zo'n geval krijgt het vaste id `onbekend`, en
+# niet de foutmelding zelf, zodat een storing die zich dagelijks herhaalt op
+# hetzelfde issue landt in plaats van elke nacht een nieuw issue te openen.
+verzamel() { # tool, logbestand, exitcode, patroon
+    local tool="$1" log="$2" status="$3" patroon="$4" gevonden
+    gevonden=$(grep -oE "$patroon" "$log" | sort -u)
+    if [ -n "$gevonden" ]; then
+        while IFS= read -r id; do echo "$tool $id"; done <<<"$gevonden" >>"$ids"
+    elif [ "$status" -ne 0 ]; then
+        echo "$tool onbekend" >>"$ids"
+    fi
+}
+
+verzamel cargo-deny "$cargo_log" "$cargo_status" 'RUSTSEC-[0-9]{4}-[0-9]{4}'
+verzamel npm "$npm_log" "$npm_status" 'GHSA-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}'
+
+sort -u -o "$ids" "$ids"
+
+{
+    if [ ! -s "$ids" ]; then
+        echo "Geen openstaande advisories in de afhankelijkheden."
+    else
+        echo "De periodieke advisory-controle vond kwetsbaarheden in de"
+        echo "afhankelijkheden. Ze blokkeren geen pull request; dit issue is de"
+        echo "enige plek waar ze staan."
+        echo
+        echo "| Bron | Advisory |"
+        echo "| --- | --- |"
+        while read -r tool id; do
+            if [ "$id" = "onbekend" ]; then
+                echo "| \`$tool\` | viel om zonder advisory-id, zie het log hieronder |"
+            else
+                echo "| \`$tool\` | \`$id\` |"
+            fi
+        done <"$ids"
+        echo
+        echo "<details><summary>cargo-deny advisories</summary>"
+        echo
+        echo '```'
+        # De kop, niet de staart: cargo-deny zet de foutblokken vooraan en laat
+        # daar een inclusion-graph op volgen die het scherm vult.
+        head -80 "$cargo_log"
+        echo '```'
+        echo
+        echo "</details>"
+        echo
+        echo "<details><summary>npm audit</summary>"
+        echo
+        echo '```'
+        head -80 "$npm_log"
+        echo '```'
+        echo
+        echo "</details>"
+        echo
+        echo "Een advisory in een Rust-crate gaat weg met een bump in"
+        echo "\`packages/Cargo.lock\`, of anders met een onderbouwde \`ignore\` in"
+        echo "\`deny.toml\`. Voor npm doet \`npm audit fix\` in de map van de"
+        echo "betreffende lockfile het meeste; wat overblijft is een handmatige"
+        echo "bump. Reproduceren kan met \`just audit-advisories\`."
+    fi
+} >"$body"
+
+echo
+if [ -s "$ids" ]; then
+    echo "Advisories gevonden: $(wc -l <"$ids")"
+    cat "$ids"
+    exit 1
+fi
+
+echo "Geen advisories."
+exit 0

--- a/script/cargo-deny.sh
+++ b/script/cargo-deny.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # Draait cargo-deny op de versie die CI ook draait.
 #
+# Welke checks er draaien geef je mee als argument (`advisories`, `bans`,
+# `licenses`, `sources`, `all`); zonder argument draait `all`. De aanroepers
+# zijn `just audit` (deterministisch: bans, licenses, sources) en
+# `just audit-advisories` (tijdsafhankelijk), zie de Justfile.
+#
 # De aanroep verschilt per versie: 0.19 wil `check --config <pad>`, 0.20 wil
 # `--config <pad> check`. Eén aanroep die op beide werkt bestaat niet, dus wie
 # cargo-deny vers installeert kreeg `unexpected argument '--config' found` in
@@ -50,5 +55,10 @@ elif [ ! -x "$binary" ]; then
     install -m0755 "$tmp/cargo-deny" "$binary"
 fi
 
+checks=("$@")
+if [ "${#checks[@]}" -eq 0 ]; then
+    checks=(all)
+fi
+
 cd packages
-exec "$binary" check --config "${root}/deny.toml"
+exec "$binary" check --config "${root}/deny.toml" "${checks[@]}"

--- a/script/report-advisories.sh
+++ b/script/report-advisories.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Meldt de uitkomst van script/audit-advisories.sh als issue, en houdt die
+# melding actueel.
+#
+# Een advisory die geen pull request rood maakt, wordt door niemand opgepakt
+# zolang hij alleen in een runlog staat. De melding moet dus een eigen plek in
+# de repo hebben, en die plek moet vanzelf verdwijnen zodra de advisory weg is —
+# anders is een openstaand issue over een halfjaar niets meer waard.
+#
+# Drie regels bepalen dat gedrag:
+#
+#   Schoon        elk openstaand advisory-issue gaat dicht, met de reden erbij.
+#                 De controle draait ook op main na een bump, dus een fix sluit
+#                 het issue binnen minuten in plaats van bij de volgende nacht.
+#   Zelfde set    er gebeurt niets. De vingerafdruk (sha256 over de gevonden
+#                 advisory-ids) staat in het issuelichaam, dus een dagelijkse
+#                 run herhaalt zichzelf niet.
+#   Andere set    een nieuw issue, en het vorige gaat dicht met een verwijzing.
+#                 Zo is de titel altijd de stand van vandaag en staat er nooit
+#                 meer dan één open.
+#
+# Blijft dezelfde set langer dan NAG_DAYS staan, dan komt er één herinnering per
+# NAG_DAYS met de leeftijd erin. Dat is de bovengrens: geen dagelijkse ruis,
+# maar ook geen issue dat maanden onbesproken wegzakt.
+set -uo pipefail
+
+: "${REPO:?REPO is verplicht}"
+
+out="${ADVISORY_OUT:?ADVISORY_OUT is verplicht}"
+ids="$out/advisories.ids"
+body="$out/advisories.md"
+label="${LABEL:-security-advisory}"
+nag_days="${NAG_DAYS:-7}"
+run_url="${RUN_URL:-}"
+now_epoch=$(date -u -d "${NOW:-now}" +%s)
+
+for f in "$ids" "$body"; do
+    if [ ! -f "$f" ]; then
+        echo "FOUT: $f bestaat niet; draai eerst script/audit-advisories.sh" >&2
+        exit 1
+    fi
+done
+
+fout() {
+    echo "::error title=Advisory-melding::$1"
+    exit 1
+}
+
+vandaag=$(date -u -d "@$now_epoch" +%Y-%m-%d)
+
+dagen_sinds() { # ISO-8601 tijdstip -> hele dagen tot nu
+    local t
+    t=$(date -u -d "$1" +%s 2>/dev/null) || { echo 0; return; }
+    echo $(((now_epoch - t) / 86400))
+}
+
+# Nummer, aanmaakdatum en vingerafdruk van elk openstaand advisory-issue. Een
+# mislukte aanroep is niet hetzelfde als "er staat er geen": dat verschil
+# bepaalt of er zo meteen een tweede issue over dezelfde advisory bijkomt.
+if ! open_issues=$(gh issue list --repo "$REPO" --label "$label" --state open \
+    --limit 50 --json number,createdAt,body \
+    --jq '.[] | [.number, .createdAt, (((.body // "") | capture("<!-- advisories: (?<fp>[0-9a-f]+) -->") | .fp) // "geen")] | @tsv' 2>&1); then
+    fout "kon de openstaande issues met label ${label} niet opvragen: ${open_issues}"
+fi
+
+sluit() { # nummer, reden
+    gh issue close "$1" --repo "$REPO" --comment "$2" ||
+        fout "kon issue #$1 niet sluiten"
+}
+
+if [ ! -s "$ids" ]; then
+    if [ -z "$open_issues" ]; then
+        echo "Schoon, en er staat geen advisory-issue open."
+        exit 0
+    fi
+    while IFS=$'\t' read -r nummer _ _; do
+        [ -n "$nummer" ] || continue
+        echo "Schoon: issue #${nummer} gaat dicht."
+        sluit "$nummer" "De advisory-controle van ${vandaag} is schoon: geen van de gemelde advisories staat nog in de afhankelijkheden.${run_url:+ Zie ${run_url}.}"
+    done <<<"$open_issues"
+    exit 0
+fi
+
+fingerprint=$(sha256sum "$ids" | cut -c1-16)
+aantal=$(wc -l <"$ids")
+
+bestaand=""
+bestaand_datum=""
+while IFS=$'\t' read -r nummer datum fp; do
+    [ -n "$nummer" ] || continue
+    if [ "$fp" = "$fingerprint" ]; then
+        bestaand="$nummer"
+        bestaand_datum="$datum"
+    fi
+done <<<"$open_issues"
+
+if [ -n "$bestaand" ]; then
+    # De herinnering hangt aan de laatste herinnering, niet aan de leeftijd van
+    # het issue: anders zou hij vanaf dag NAG_DAYS elke dag opnieuw komen.
+    if ! laatste=$(gh issue view "$bestaand" --repo "$REPO" --json comments \
+        --jq '[.comments[] | select((.body // "") | contains("<!-- advisories-nag -->")) | .createdAt] | max // ""' 2>&1); then
+        fout "kon de reacties op issue #${bestaand} niet opvragen: ${laatste}"
+    fi
+
+    sinds=$(dagen_sinds "${laatste:-$bestaand_datum}")
+    leeftijd=$(dagen_sinds "$bestaand_datum")
+
+    if [ "$sinds" -lt "$nag_days" ]; then
+        echo "Zelfde advisories als in issue #${bestaand} (${leeftijd} dagen oud); geen nieuwe melding."
+        exit 0
+    fi
+
+    gh issue comment "$bestaand" --repo "$REPO" --body \
+        "Deze advisories staan nu ${leeftijd} dagen open en zijn er vandaag (${vandaag}) nog steeds. Ze blokkeren geen enkele pull request, dus er is niets dat ze vanzelf onder de aandacht brengt.${run_url:+ De run van vandaag: ${run_url}.}
+
+<!-- advisories-nag -->" ||
+        fout "kon geen herinnering op issue #${bestaand} plaatsen"
+    echo "Herinnering geplaatst op issue #${bestaand} (${leeftijd} dagen open)."
+    exit 0
+fi
+
+gh label create "$label" --repo "$REPO" --color B60205 \
+    --description "Openstaande advisory uit de periodieke security-controle" 2>/dev/null || true
+
+{
+    cat "$body"
+    echo
+    if [ -n "$run_url" ]; then
+        echo "De [run](${run_url}) heeft het volledige log."
+        echo
+    fi
+    echo "Dit issue gaat vanzelf dicht zodra \`just audit-advisories\` schoon is."
+    echo
+    echo "<!-- advisories: ${fingerprint} -->"
+} >"$out/issue-body.md"
+
+titel="Advisories in afhankelijkheden: ${aantal} openstaand (${vandaag})"
+if ! nieuw=$(gh issue create --repo "$REPO" --title "$titel" --label "$label" \
+    --body-file "$out/issue-body.md" 2>&1); then
+    fout "kon het issue niet aanmaken: ${nieuw}"
+fi
+echo "Aangemaakt: $nieuw"
+
+# Het vorige issue ging over een andere set advisories. Wat daarvan nog geldt,
+# staat opnieuw in het nieuwe issue; twee open issues over dezelfde controle
+# zouden alleen maar de vraag oproepen welke de stand is.
+while IFS=$'\t' read -r nummer _ _; do
+    [ -n "$nummer" ] || continue
+    [ "$nummer" = "${nieuw##*/}" ] && continue
+    sluit "$nummer" "Vervangen door de controle van ${vandaag}: ${nieuw}"
+done <<<"$open_issues"

--- a/script/report-advisories.test.sh
+++ b/script/report-advisories.test.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Dekt elk pad in script/report-advisories.sh dat beslist of er een melding
+# komt, met een `gh`-stub op PATH.
+#
+# Deze melding is het enige dat een advisory nog onder de aandacht brengt nu de
+# PR-poort er niet meer op omvalt. Een meldscript dat stilletjes niets doet is
+# van een werkend meldscript alleen te onderscheiden door het hier vast te
+# leggen: schoon sluit, dezelfde set zwijgt, een andere set opent, en oud wordt
+# herinnerd.
+set -uo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+script="$here/report-advisories.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+pass=0
+fail=0
+NU="2026-08-20T12:00:00Z"
+
+maak_stub() { # issue-list-tsv, laatste-nag-datum, list-faalt
+    cat >"$tmp/bin/gh" <<STUB
+#!/usr/bin/env bash
+echo "\$*" >>"$tmp/calls"
+case "\$1 \$2" in
+  "issue list")
+    if [ -n "${3:-}" ]; then echo "API-fout" >&2; exit 1; fi
+    printf '%s' "$1"
+    [ -n "$1" ] && echo
+    ;;
+  "issue view")   printf '%s\n' "$2" ;;
+  "issue create") echo "https://github.com/o/r/issues/77" ;;
+esac
+exit 0
+STUB
+    chmod +x "$tmp/bin/gh"
+}
+
+geval() { # naam, ids-inhoud, verwachte-exit, issue-list-tsv, laatste-nag, list-faalt, verwachte gh-aanroep (leeg = geen schrijfactie)
+    local naam="$1" ids="$2" want="$3" lijst="$4" nag="${5:-}" listfail="${6:-}" verwacht="${7:-}"
+    rm -rf "$tmp/out" "$tmp/bin" "$tmp/calls"
+    mkdir -p "$tmp/out" "$tmp/bin"
+    printf '%s' "$ids" >"$tmp/out/advisories.ids"
+    echo "melding" >"$tmp/out/advisories.md"
+    touch "$tmp/calls"
+    maak_stub "$lijst" "$nag" "$listfail"
+
+    local uit status
+    uit="$(PATH="$tmp/bin:$PATH" REPO=o/r ADVISORY_OUT="$tmp/out" NOW="$NU" \
+        bash "$script" 2>&1)"
+    status=$?
+
+    if [ "$status" -ne "$want" ]; then
+        echo "FAIL: $naam — exit $status, verwacht $want"
+        sed 's/^/    /' <<<"$uit"
+        fail=$((fail + 1))
+        return
+    fi
+
+    local schrijf
+    schrijf=$(grep -E '^(issue (create|close|comment))' "$tmp/calls" || true)
+    if [ -z "$verwacht" ]; then
+        if [ -n "$schrijf" ]; then
+            echo "FAIL: $naam — verwachtte geen schrijfactie, kreeg: $schrijf"
+            fail=$((fail + 1))
+            return
+        fi
+    elif ! grep -qF "$verwacht" <<<"$schrijf"; then
+        echo "FAIL: $naam — '$verwacht' niet aangeroepen; wel: ${schrijf:-niets}"
+        sed 's/^/    /' <<<"$uit"
+        fail=$((fail + 1))
+        return
+    fi
+    echo "ok: $naam"
+    pass=$((pass + 1))
+}
+
+# De vingerafdruk die het script van deze bevindingen maakt, zodat een
+# testgeval een issue kan opvoeren dat er al over gaat.
+fp_van() {
+    printf '%s' "$1" >"$tmp/fp.ids"
+    sha256sum "$tmp/fp.ids" | cut -c1-16
+}
+
+BEVINDING=$'cargo-deny RUSTSEC-2026-0066\n'
+ANDERS=$'npm GHSA-aaaa-bbbb-cccc\n'
+FP=$(fp_van "$BEVINDING")
+
+geval "schoon zonder openstaand issue laat alles met rust" "" 0 ""
+
+geval "schoon sluit het openstaande issue" "" 0 \
+    $'42\t2026-08-01T00:00:00Z\tdeadbeef' "" "" "issue close 42"
+
+geval "een nieuwe bevinding opent een issue" "$BEVINDING" 0 "" "" "" \
+    "issue create"
+
+geval "dezelfde bevinding meldt zich niet nog een keer" "$BEVINDING" 0 \
+    "42	2026-08-19T00:00:00Z	$FP"
+
+geval "een bevinding die blijft staan krijgt een herinnering" "$BEVINDING" 0 \
+    "42	2026-08-01T00:00:00Z	$FP" "" "" "issue comment 42"
+
+geval "na een verse herinnering blijft het stil" "$BEVINDING" 0 \
+    "42	2026-08-01T00:00:00Z	$FP" "2026-08-18T00:00:00Z"
+
+geval "een andere set advisories vervangt het issue" "$ANDERS" 0 \
+    "42	2026-08-01T00:00:00Z	$FP" "" "" "issue create"
+
+geval "en sluit het vorige" "$ANDERS" 0 \
+    "42	2026-08-01T00:00:00Z	$FP" "" "" "issue close 42"
+
+# Een mislukte lijst-aanroep is niet hetzelfde als "er staat geen issue open".
+# Zou het script dat verwarren, dan komt er bij elke storing een issue bij over
+# een advisory die er al een heeft.
+geval "een mislukte lijst-aanroep blokkeert in plaats van te verdubbelen" \
+    "$BEVINDING" 1 "" "" "faal"
+
+# Zonder uitslag van de audit valt er niets te melden; dan blijft een oud issue
+# ten onrechte open of komt er een lege melding.
+rm -rf "$tmp/out" "$tmp/bin"
+mkdir -p "$tmp/out" "$tmp/bin"
+if PATH="$tmp/bin:$PATH" REPO=o/r ADVISORY_OUT="$tmp/out" bash "$script" >/dev/null 2>&1; then
+    echo "FAIL: ontbrekende uitslag hoort te blokkeren"
+    fail=$((fail + 1))
+else
+    echo "ok: ontbrekende uitslag blokkeert"
+    pass=$((pass + 1))
+fi
+
+echo
+echo "$pass geslaagd, $fail mislukt"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
De verplichte check `Security Audit` draaide cargo-deny met alle checks plus `npm audit`, waardoor een advisory die buiten de repo verscheen elke openstaande pull request rood maakte zonder dat er iets aan die pull request veranderd was; op 7 augustus gebeurde dat twee keer op één dag. Deze splitsing houdt in `just audit` wat deterministisch is (bans, licenses, sources en license-checker: dezelfde commit geeft altijd dezelfde uitslag) en verhuist de advisory-controle naar `just audit-advisories`, die dagelijks draait in de nieuwe workflow `security-advisories.yml` en ook op main zodra een lockfile of deny.toml verandert. De uitkomst gaat naar een issue met het label `security-advisory`: schoon sluit het issue, dezelfde set advisories meldt zich niet nog een keer, een andere set vervangt het issue, en blijft dezelfde set langer dan een week staan dan komt er één herinnering per week met de leeftijd erin. Omdat die melding het enige is wat een advisory nog onder de aandacht brengt, valt de run zelf daarnaast om bij bevindingen, zodat GitHub erover mailt en Actions het rood zet. `script/report-advisories.test.sh` legt met een `gh`-stub elk pad vast dat beslist of er een melding komt, aangesloten op pre-commit en `just check`.