### PR TITLE
fix(github): een ingetrokken goedkeuring opent de security-poort niet meer

### DIFF
--- a/script/require-security-approval.sh
+++ b/script/require-security-approval.sh
@@ -122,7 +122,12 @@ output 'dependency' "$dependency"
 # geciteerde changelog.
 own_text=${body%%<details>*}
 
-advisories=$(grep -oiE 'GHSA-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}|CVE-[0-9]{4}-[0-9]+' <<<"$body" |
+# Uit de aanhef en niet uit de hele body, om dezelfde reden als bij signaal 3:
+# achter het eerste `<details>` staan geciteerde changelogs die een advisory van
+# een heel ander pakket kunnen noemen. Die zou hier in de blokkeermelding komen
+# als de advisory van déze update, terwijl de goedkeurder er juist naar moet
+# kijken.
+advisories=$(grep -oiE 'GHSA-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}|CVE-[0-9]{4}-[0-9]+' <<<"$own_text" |
     tr '[:lower:]' '[:upper:]' | sort -u | paste -sd, -)
 output 'advisories' "$advisories"
 
@@ -133,7 +138,7 @@ signal=''
 # formulering kan veranderen. Mislukt de aanroep — een door Dependabot gestarte
 # run krijgt een token met minder rechten — dan is dat geen "geen alert": de
 # poort zegt het en valt terug op de twee tekstsignalen.
-if alerts=$(gh api "repos/${REPO}/dependabot/alerts?state=open&per_page=100" \
+if alerts=$(gh api "repos/${REPO}/dependabot/alerts?state=open&per_page=100" --paginate \
     --jq '.[].security_vulnerability.package.name' 2>"$gh_stderr"); then
     if [ -n "$dependency" ] && grep -qixF "$dependency" <<<"$alerts"; then
         is_security=true
@@ -172,15 +177,26 @@ fi
 # Een goedkeuring van een bot is geen menselijke blik, en een goedkeuring van
 # een willekeurige buitenstaander evenmin: iedereen met een account kan een
 # review achterlaten, dus alleen wie schrijfrechten heeft telt.
+#
+# Eerst de laatste review per persoon, dan pas filteren op APPROVED. De API
+# geeft elke ingediende review als eigen object terug en herschrijft een
+# eerdere niet: keurt iemand goed en vraagt hij daarna op dezelfde commit
+# wijzigingen aan, dan staat die APPROVED er nog steeds. Filteren-dan-laatste
+# pakt hem dus alsnog op, en een ingetrokken goedkeuring zou de poort openen.
 approver=$(jq -r --arg sha "$head_sha" '
     [ .[]
-      | select(.state == "APPROVED")
       | select(.commit_id == $sha)
       | select(.user.login | endswith("[bot]") | not)
       | select(.author_association == "OWNER"
                or .author_association == "MEMBER"
                or .author_association == "COLLABORATOR")
-    ] | last | .user.login // ""' <<<"$reviews")
+      # COMMENTED laat het oordeel ongemoeid; alleen wat een standpunt is telt
+      # mee bij het bepalen van iemands laatste woord.
+      | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")
+    ]
+    | group_by(.user.login) | map(max_by(.id))
+    | map(select(.state == "APPROVED"))
+    | last | .user.login // ""' <<<"$reviews")
 
 if [ -n "$approver" ]; then
     output 'approved' 'true'

--- a/script/require-security-approval.test.sh
+++ b/script/require-security-approval.test.sh
@@ -54,9 +54,14 @@ pr_json() { # $1 = auteur, $2 = titel, $3 = body
         '{head: {sha: "cafebabe1234567"}, user: {login: $u}, title: $t, body: $b}'
 }
 
+# Elke review krijgt een oplopend id, zoals de API ze ook geeft: de poort
+# bepaalt daarmee wiens laatste woord telt. Aanroepvolgorde is dus de volgorde
+# waarin er gereviewd is.
+review_id=0
 review() { # $1 = login, $2 = state, $3 = commit, $4 = association
-    jq -n --arg l "$1" --arg s "$2" --arg c "$3" --arg a "$4" \
-        '{user: {login: $l}, state: $s, commit_id: $c, author_association: $a}'
+    review_id=$((review_id + 1))
+    jq -n --arg l "$1" --arg s "$2" --arg c "$3" --arg a "$4" --argjson i "$review_id" \
+        '{id: $i, user: {login: $l}, state: $s, commit_id: $c, author_association: $a}'
 }
 
 # $1 = naam, $2 = verwachte exitcode, $3 = pr.json, $4 = alerts.json,
@@ -172,6 +177,30 @@ check "een ingetrokken goedkeuring telt niet" 1 \
     "$(pr_json 'dependabot[bot]' 'chore(deps): bump serde from 1.0.1 to 1.0.2' "$marker")" \
     "$no_alerts" "[$(review eelco DISMISSED cafebabe1234567 MEMBER)]" \
     'moet deze PR goedkeuren' 'approved=false'
+
+# De API herschrijft een eerdere review niet: wie goedkeurt en zich daarna
+# bedenkt, laat dat APPROVED-object gewoon staan. Filteren op APPROVED en dan de
+# laatste pakken vindt hem alsnog, en dan opent een ingetrokken goedkeuring de
+# poort.
+check "wie zich na zijn goedkeuring bedenkt, keurt niet meer goed" 1 \
+    "$(pr_json 'dependabot[bot]' 'chore(deps): bump serde from 1.0.1 to 1.0.2' "$marker")" \
+    "$no_alerts" \
+    "[$(review eelco APPROVED cafebabe1234567 MEMBER),$(review eelco CHANGES_REQUESTED cafebabe1234567 MEMBER)]" \
+    'moet deze PR goedkeuren' 'approved=false'
+
+# En andersom: wie eerst wijzigingen vroeg en daarna alsnog goedkeurt, telt wel.
+check "wie na wijzigingen alsnog goedkeurt, telt wel" 0 \
+    "$(pr_json 'dependabot[bot]' 'chore(deps): bump serde from 1.0.1 to 1.0.2' "$marker")" \
+    "$no_alerts" \
+    "[$(review eelco CHANGES_REQUESTED cafebabe1234567 MEMBER),$(review eelco APPROVED cafebabe1234567 MEMBER)]" \
+    'goedgekeurd door @eelco' 'approved=true'
+
+# Iemand anders die zich bedenkt mag een geldige goedkeuring niet wegnemen.
+check "de intrekking van de een raakt de goedkeuring van de ander niet" 0 \
+    "$(pr_json 'dependabot[bot]' 'chore(deps): bump serde from 1.0.1 to 1.0.2' "$marker")" \
+    "$no_alerts" \
+    "[$(review anne APPROVED cafebabe1234567 MEMBER),$(review eelco APPROVED cafebabe1234567 MEMBER),$(review eelco CHANGES_REQUESTED cafebabe1234567 MEMBER)]" \
+    'goedgekeurd door @anne' 'approved=true'
 
 check "onbereikbare alerts blokkeren niet, maar worden wel gemeld" 1 \
     "$(pr_json 'dependabot[bot]' 'chore(deps): bump serde from 1.0.1 to 1.0.2' "$marker")" \


### PR DESCRIPTION
De reviews-API herschrijft een eerdere review niet. Wie een security-update goedkeurt en daarna op dezelfde commit wijzigingen aanvraagt, laat dat `APPROVED`-object gewoon staan; de poort filterde op `APPROVED` en pakte daarna de laatste, en vond hem dus alsnog. Een ingetrokken goedkeuring liet de merge door, wat precies is wat #1234 moest voorkomen. Nu eerst de laatste review per persoon, dan pas filteren.

Twee kleinere dingen uit dezelfde review. De advisory-nummers voor de melding kwamen uit de hele body in plaats van uit de aanhef, terwijl de detectie die scheiding wel maakt, dus een geciteerde changelog kon een advisory van een ander pakket tonen aan degene die moet goedkeuren. En de alerts-aanroep miste `--paginate`.

Gevonden door de review op #1234, drieëntwintig seconden voor de merge. De poort bewijst dat er gereviewd is, niet wat er gevonden is; dat staat als #1248.
