### PR TITLE
chore(github): labels onder een voorvoegsel per herkomst

### DIFF
--- a/.claude/skills/merge-train/SKILL.md
+++ b/.claude/skills/merge-train/SKILL.md
@@ -104,7 +104,7 @@ Test, Validate PR title, Claude review completed
 
 Wacht op precies deze zeven en op niets anders.
 
-- `Build and Deploy` is `skipped` zonder het `preview`-label. Dat is geen fout.
+- `Build and Deploy` is `skipped` zonder het `deploy:preview`-label. Dat is geen fout.
 - `CodeQL` en `Analyze (…)` rapporteren niet op een PR die alleen docs raakt.
   Nooit op wachten; ze zijn niet verplicht.
 - `Mutation Testing (diff)` draait alleen bij een wijziging in

--- a/.claude/skills/mutation-cleanup/SKILL.md
+++ b/.claude/skills/mutation-cleanup/SKILL.md
@@ -24,7 +24,7 @@ behaviour the tests actually pin down.
 Two workflows produce them:
 
 - `.github/workflows/mutation-testing.yml` runs the full set every Monday and
-  opens an issue labelled `mutation-testing` with the counts and a report.
+  opens an issue labelled `mbot:survivors` with the counts and a report.
 - `.github/workflows/mutation-diff.yml` runs on every pull request that touches
   `packages/engine/**`, over the changed lines only. That gate is why new gaps
   should not reach this backlog.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,8 +23,8 @@ updates:
       prefix: chore(deps)
       prefix-development: chore(deps)
     labels:
-      - dependencies
-      - rust
+      - dbot:deps
+      - dbot:cargo
     groups:
       opentelemetry:
         patterns:
@@ -82,8 +82,8 @@ updates:
       prefix: chore(deps)
       prefix-development: chore(deps)
     labels:
-      - dependencies
-      - javascript
+      - dbot:deps
+      - dbot:npm
     groups:
       npm-minor-patch:
         update-types:
@@ -101,8 +101,8 @@ updates:
     cooldown:
       default-days: 5
     labels:
-      - dependencies
-      - docker
+      - dbot:deps
+      - dbot:docker
     ignore:
       - dependency-name: node
         versions:
@@ -127,8 +127,8 @@ updates:
     cooldown:
       default-days: 5
     labels:
-      - dependencies
-      - docker
+      - dbot:deps
+      - dbot:docker
     ignore:
       - dependency-name: node
         versions:
@@ -152,8 +152,8 @@ updates:
     cooldown:
       default-days: 5
     labels:
-      - dependencies
-      - docker
+      - dbot:deps
+      - dbot:docker
     ignore:
       # The Rust image version must match rust-toolchain.toml (source of
       # truth); bump it manually together with the toolchain.
@@ -174,8 +174,8 @@ updates:
       prefix: chore(deps)
       prefix-development: chore(deps)
     labels:
-      - dependencies
-      - javascript
+      - dbot:deps
+      - dbot:npm
     groups:
       npm-minor-patch:
         update-types:
@@ -196,8 +196,8 @@ updates:
       prefix: chore(deps)
       prefix-development: chore(deps)
     labels:
-      - dependencies
-      - javascript
+      - dbot:deps
+      - dbot:npm
     groups:
       npm-minor-patch:
         update-types:
@@ -212,8 +212,8 @@ updates:
     cooldown:
       default-days: 5
     labels:
-      - dependencies
-      - github-actions
+      - dbot:deps
+      - dbot:actions
     groups:
       actions-minor-patch:
         update-types:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
   # Deze job is de poort van de hele keten: alles wat bouwt of deployt hangt er
   # via `needs: changes` aan, dus wat hier niet doorkomt kost geen runner.
   #
-  # Een PR bouwt alleen met het label `preview` erop. Getoetst op aanwezigheid
+  # Een PR bouwt alleen met het label `deploy:preview` erop. Getoetst op aanwezigheid
   # van het label, niet op het soort gebeurtenis, zodat dezelfde regel geldt bij
   # openen, bij elke volgende commit en op het moment dat het label erbij komt.
   # Bij `unlabeled` bouwt de keten nooit; dat event bestaat hier alleen om
@@ -34,7 +34,7 @@ jobs:
       github.event.pull_request.head.repo.fork != true &&
       (
         github.event_name == 'push' ||
-        contains(github.event.pull_request.labels.*.name, 'preview')
+        contains(github.event.pull_request.labels.*.name, 'deploy:preview')
       )
     permissions:
       contents: read
@@ -499,7 +499,7 @@ jobs:
       github.event.pull_request.head.repo.fork != true &&
       (
         github.event.action == 'closed' ||
-        (github.event.action == 'unlabeled' && github.event.label.name == 'preview')
+        (github.event.action == 'unlabeled' && github.event.label.name == 'deploy:preview')
       )
     permissions:
       packages: write

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -402,7 +402,7 @@ jobs:
           ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          gh label create mutation-testing \
+          gh label create mbot:survivors \
             --color FBCA04 \
             --description "Overlevende mutanten uit de wekelijkse mutatierun" \
             --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
@@ -451,13 +451,13 @@ jobs:
           new_issue=$(gh issue create \
             --repo "$GITHUB_REPOSITORY" \
             --title "Mutatietesten: ${MISSED} overlevende mutanten (${today})" \
-            --label mutation-testing \
+            --label mbot:survivors \
             --body-file body.md)
           echo "Aangemaakt: $new_issue"
 
           # Het vorige issue is een momentopname van dezelfde voorraad en wordt
           # door dit issue vervangen. Wat er nog in stond, staat er opnieuw in.
-          gh issue list --repo "$GITHUB_REPOSITORY" --label mutation-testing \
+          gh issue list --repo "$GITHUB_REPOSITORY" --label mbot:survivors \
             --state open --json number --jq '.[].number' \
             | while read -r n; do
                 if [ "${new_issue##*/}" != "$n" ]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,13 +382,13 @@ de job staat in het workflowbestand dat de PR meebrengt.
 
 ### How It Works
 
-1. **PR carrying the `preview` label, opened or pushed to**: Builds changed Docker images, pushes to GHCR, deploys `prN` to ZAD
-2. **`preview` label removed, or PR closed**: Deletes ZAD deployment and GHCR images
+1. **PR carrying the `deploy:preview` label, opened or pushed to**: Builds changed Docker images, pushes to GHCR, deploys `prN` to ZAD
+2. **`deploy:preview` label removed, or PR closed**: Deletes ZAD deployment and GHCR images
 3. **Push to main**: Deploys `regelrecht` (production) to ZAD
 
 ### Previews are opt-in
 
-A pull request builds and deploys nothing unless someone puts the **`preview`**
+A pull request builds and deploys nothing unless someone puts the **`deploy:preview`**
 label on it. Seven images plus a preview environment per PR was about half of
 the repository's runner consumption, and it held up no merge: none of those
 checks is required and nothing tests against the preview (`E2E (mocked)` runs
@@ -403,7 +403,7 @@ preview keeps running that nobody is looking at.
 The gate is the *presence* of the label on the PR, checked on every event, not
 the kind of event. The `deploy:<component>` labels are a separate, additive
 thing: they force a component to build that the change-detection did not flag,
-and they do nothing on a PR without `preview`.
+and they do nothing on a PR without `deploy:preview`.
 
 Fork PRs stay out of the chain regardless of labels; they have no secrets and a
 read-only `GITHUB_TOKEN`, so the push to GHCR could never succeed.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ editor sessions; they are not meant to be read directly.
 
 The pipeline API and the harvester and enrich workers deploy alongside these but have no web UI of their own.
 
-A PR gets a preview environment once it carries the `preview` label; taking the label off, or closing the PR, cleans it up again.
+A PR gets a preview environment once it carries the `deploy:preview` label; taking the label off, or closing the PR, cleans it up again.
 
 ## Getting started
 

--- a/docs/src/content/docs/components/frontend.md
+++ b/docs/src/content/docs/components/frontend.md
@@ -108,7 +108,7 @@ just dev             # Starts everything with hot reload
 The editor ships as a single Docker image (`regelrecht-editor`) that bundles the built Vue frontend together with the [editor-api](./editor-api) Rust binary, which serves the static assets and the REST API. It is deployed to RIG/ZAD:
 
 - **Production**: `editor.regelrecht.rijks.app`
-- **PR previews**: deployed for a pull request that carries the `preview` label
+- **PR previews**: deployed for a pull request that carries the `deploy:preview` label
 
 ## Admin Dashboard
 

--- a/docs/src/content/docs/operations/adding-a-law.md
+++ b/docs/src/content/docs/operations/adding-a-law.md
@@ -74,7 +74,7 @@ just bdd
 
 ## Step 6: Open a pull request
 
-Commit the new law file, any BDD scenarios, and open a PR. CI will run schema validation, BDD tests, and all other checks automatically. Add the `preview` label to the PR if reviewers should be able to try the law in a running editor.
+Commit the new law file, any BDD scenarios, and open a PR. CI will run schema validation, BDD tests, and all other checks automatically. Add the `deploy:preview` label to the PR if reviewers should be able to try the law in a running editor.
 
 ## Further reading
 

--- a/docs/src/content/docs/operations/contributing.md
+++ b/docs/src/content/docs/operations/contributing.md
@@ -51,7 +51,7 @@ Do not bypass hooks with `--no-verify`. If a hook fails, fix the underlying prob
 
 1. Create a feature branch and push your changes
 2. Open a PR - CI runs all relevant checks automatically
-3. Add the `preview` label if reviewers need a running preview (see [Deployment](./deployment))
+3. Add the `deploy:preview` label if reviewers need a running preview (see [Deployment](./deployment))
 4. Get a code review
 5. Merge to main - production deploys automatically
 

--- a/docs/src/content/docs/operations/deployment.md
+++ b/docs/src/content/docs/operations/deployment.md
@@ -9,7 +9,7 @@ All components are deployed to ZAD (RIG/Quattro/rijksapps) via GitHub Actions. D
 
 ### On pull request
 
-A PR only builds and deploys when it carries the `preview` label. Without that label nothing is built, because a preview costs about half of the repository's runner budget and no required check depends on it. Add the label and the build starts, whether the PR was opened a minute or a month ago:
+A PR only builds and deploys when it carries the `deploy:preview` label. Without that label nothing is built, because a preview costs about half of the repository's runner budget and no required check depends on it. Add the label and the build starts, whether the PR was opened a minute or a month ago:
 
 1. Changed components are detected automatically
 2. Docker images are built and pushed to `ghcr.io/minbzk/regelrecht-{component}:sha-{commit}`
@@ -18,7 +18,7 @@ A PR only builds and deploys when it carries the `preview` label. Without that l
 
 Every later commit on a labelled PR repeats this. Remove the label and the preview and its images are cleaned up.
 
-Only changed components are rebuilt. Any component can also be forced to build by adding its `deploy:<component>` label to the PR (for example `deploy:editor`); those labels are additive and do nothing on their own, since `preview` is what opens the gate.
+Only changed components are rebuilt. Any component can also be forced to build by adding its `deploy:<component>` label to the PR (for example `deploy:editor`); those labels are additive and do nothing on their own, since `deploy:preview` is what opens the gate.
 
 ### On merge to main
 


### PR DESCRIPTION
De labels zijn hernoemd naar een vorm met voorvoegsel, en de configuratie moet mee: `dependabot.yml` noemde nog `dependencies`, `rust`, `docker`, `github-actions` en `javascript`, `deploy.yml` toetste nog op `preview`, en `mutation-testing.yml` maakte en zocht nog `mutation-testing`.

Zonder deze wijziging maken beide bots de oude labels bij hun volgende run opnieuw aan, en werkt het aanzetten van een preview niet meer, want het label waar `deploy.yml` op wacht bestaat niet meer.

De verwijzingen in `CLAUDE.md`, `README.md`, vier docs-pagina's en twee skills gaan mee.