### PR TITLE
feat(ci): merk het op als een workflowbestand niet draait

### DIFF
--- a/.github/workflows/scheduled-cleanup.yml
+++ b/.github/workflows/scheduled-cleanup.yml
@@ -90,3 +90,21 @@ jobs:
                 fi
               done
           done
+
+  # Wordt dit bestand zelf afgekeurd, dan draait ook deze baan niet.
+  afgekeurde-workflows:
+    name: Afgekeurde workflows
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 1
+
+      - name: Zoek workflows die niet draaien
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: script/check-rejected-workflows.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -119,6 +119,13 @@ repos:
         pass_filenames: false
         files: ^(script/check-preview-environments(\.test)?\.sh|\.github/workflows/scheduled-cleanup\.yml)$
 
+      - id: rejected-workflows-tests
+        name: Detector op afgekeurde workflows doet wat hij belooft
+        entry: script/check-rejected-workflows.test.sh
+        language: system
+        pass_filenames: false
+        files: ^(script/check-rejected-workflows(\.test)?\.sh|\.github/workflows/scheduled-cleanup\.yml)$
+
       - id: advisories-report-tests
         name: Advisory-melding komt aan en niet dubbel
         entry: script/report-advisories.test.sh

--- a/Justfile
+++ b/Justfile
@@ -132,11 +132,17 @@ deployed-urls-test:
 preview-environments-test:
     script/check-preview-environments.test.sh
 
+# De controle die afgekeurde workflowbestanden opspoort. `gh` staat in de test
+# als stub op PATH, dus er gaat geen verkeer naar GitHub.
+[doc("Check the detector for workflow files Actions rejected")]
+rejected-workflows-test:
+    script/check-rejected-workflows.test.sh
+
 # Run all quality checks, exactly what CI runs. Needs Docker for the
 # container-backed suites; on a machine without a daemon, swap `test` for
 # `test-no-docker`.
 [doc("Run all quality checks, exactly what CI runs (needs Docker)")]
-check: format lint build-check validate validate-annotations deploy-filters-test precompress-test security-headers-test first-load-test ci-gate-test dockerfile-consistency-test deploy-gate-test deployed-urls-test preview-environments-test advisories-report-test test
+check: format lint build-check validate validate-annotations deploy-filters-test precompress-test security-headers-test first-load-test ci-gate-test dockerfile-consistency-test deploy-gate-test deployed-urls-test preview-environments-test rejected-workflows-test advisories-report-test test
 
 # --- Tests ---
 

--- a/script/check-rejected-workflows.sh
+++ b/script/check-rejected-workflows.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Zoekt workflowbestanden die niet draaien: afgekeurd door Actions, of
+# uitgeschakeld. Een afgekeurd bestand heet naar zijn pad, want er valt geen
+# `name:` te lezen uit iets dat niet is ingelezen. Zie issue #1281.
+set -uo pipefail
+
+: "${REPO:?REPO is verplicht}"
+
+antwoord=$(gh api "repos/${REPO}/actions/workflows" --paginate \
+    --jq '.workflows[] | [.name, .path, .state, .html_url] | @tsv' 2>&1)
+status=$?
+
+# Zonder lijst zegt deze controle niets, en dan is doorlaten de verkeerde
+# uitkomst.
+if [ "$status" -ne 0 ]; then
+    echo "::error title=Workflows::kon de workflows niet opvragen, dus deze controle zegt niets: ${antwoord}"
+    exit 1
+fi
+
+stil=()
+while IFS=$'\t' read -r naam pad staat url; do
+    [ -z "$pad" ] && continue
+    if [ "$naam" = "$pad" ]; then
+        stil+=("${pad} — afgekeurd door Actions — ${url}")
+    elif [ "$staat" != "active" ]; then
+        stil+=("${pad} — staat op ${staat} — ${url}")
+    fi
+done <<< "$antwoord"
+
+if [ "${#stil[@]}" -gt 0 ]; then
+    echo "::error title=Workflows::${#stil[@]} workflowbestand(en) draaien niet. Zie issue #1281."
+    printf '  %s\n' "${stil[@]}"
+    exit 1
+fi
+
+echo "Alle workflows zijn ingelezen en actief."

--- a/script/check-rejected-workflows.test.sh
+++ b/script/check-rejected-workflows.test.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Dekt elk pad dat groen of rood beslist in script/check-rejected-workflows.sh,
+# met een `gh`-stub op PATH. Een controle die altijd doorlaat is anders niet te
+# onderscheiden van een die werkt.
+set -uo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+gate="$here/check-rejected-workflows.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+pass=0
+fail=0
+
+# $1 = regels "naam<TAB>pad<TAB>staat<TAB>url", $2 = exitcode van gh.
+stub_gh() {
+    printf '%s' "$1" >"$tmp/regels"
+    cat >"$tmp/gh" <<STUB
+#!/usr/bin/env bash
+cat "$tmp/regels"
+exit $2
+STUB
+    chmod +x "$tmp/gh"
+}
+
+check() { # naam, verwachte exit, regels, gh-exit, patroon
+    local name="$1" want="$2" regels="$3" ghexit="$4" needle="${5:-}"
+    stub_gh "$regels" "$ghexit"
+    local out status
+    out="$(PATH="$tmp:$PATH" REPO=o/r bash "$gate" 2>&1)"
+    status=$?
+
+    if [ "$status" -ne "$want" ]; then
+        echo "FAIL: $name — exit $status, verwacht $want"
+        echo "$out" | sed 's/^/    /'
+        fail=$((fail + 1))
+        return
+    fi
+    if [ -n "$needle" ] && ! grep -qF "$needle" <<<"$out"; then
+        echo "FAIL: $name — '$needle' niet in de uitvoer"
+        echo "$out" | sed 's/^/    /'
+        fail=$((fail + 1))
+        return
+    fi
+    echo "ok: $name"
+    pass=$((pass + 1))
+}
+
+goed="CI	.github/workflows/ci.yml	active	https://x/1
+Scheduled Cleanup	.github/workflows/scheduled-cleanup.yml	active	https://x/2
+"
+afgekeurd="CI	.github/workflows/ci.yml	active	https://x/1
+.github/workflows/security-advisories.yml	.github/workflows/security-advisories.yml	active	https://x/2
+"
+uit="CI	.github/workflows/ci.yml	disabled_inactivity	https://x/1
+"
+
+check "alles ingelezen en actief is schoon" 0 "$goed" 0 "Alle workflows zijn ingelezen en actief"
+
+check "een naam gelijk aan het pad is rood" 1 "$afgekeurd" 0 "afgekeurd door Actions"
+
+check "de url staat erbij, anders is hij niet op te zoeken" 1 "$afgekeurd" 0 "https://x/2"
+
+# GitHub zet een geplande workflow na zestig dagen inactiviteit uit. Dezelfde
+# faalvorm: hij draait niet en zegt dat nergens.
+check "een uitgeschakelde workflow is rood" 1 "$uit" 0 "disabled_inactivity"
+
+check "een lege lijst is schoon" 0 "" 0 "Alle workflows zijn ingelezen en actief"
+
+# Een gefaalde aanroep en een lege uitkomst zien er hetzelfde uit; zonder lijst
+# zegt de controle niets en is doorlaten fout.
+check "een gefaalde gh-aanroep blokkeert met een eigen reden" 1 "" 1 \
+    "kon de workflows niet opvragen"
+
+echo
+echo "$pass geslaagd, $fail mislukt"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Sluit #1281.

Keurt Actions een workflowbestand af, dan draait het niet en verschijnt er geen gefaalde baan: de run heeft nul jobs en nul check-runs. Dat is hier twee keer gebeurd, met twee verschillende oorzaken, en beide keren stond er iets stil zonder dat iemand het zag.

Eén API-aanroep is genoeg om dat vast te stellen. De workflows-endpoint geeft van een afgekeurd bestand het pad als `name`, want er valt geen `name:` te lezen uit iets dat niet is ingelezen. Dat signaal hangt niet af van de reden van afkeuring en niet van of er die dag gepusht is. `state` komt uit dezelfde aanroep en vangt de workflow die GitHub na zestig dagen inactiviteit uitzet, wat dezelfde faalvorm is.

De baan hangt aan de nachtelijke opruiming. Vóór de merge zou eerder zijn, maar zo`n poort staat dan in het workflowbestand dat de pull request zelf meebrengt, en dat is precies de constructie die CLAUDE.md elders als ontoereikend beschrijft.

Twee grenzen die blijven staan. Wordt dit bestand zelf afgekeurd, dan draait de controle niet; dat is niet op te lossen binnen Actions. En dit meldt dat een bestand is afgekeurd, niet waarom.