### PR TITLE
fix(github): het opruimen van previews mag productie niet raken

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -488,9 +488,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # Het label eraf halen ruimt op, net als het sluiten van de PR: een preview
-    # waar niemand meer naar kijkt hoort niet te blijven draaien. Sluiten ruimt
-    # ook op zonder dat het label er ooit op zat, want dan valt er niets te
-    # verwijderen en prunet deze job alsnog de verweesde sha-images.
+    # waar niemand meer naar kijkt hoort niet te blijven draaien. Zat het label
+    # er nooit op, dan valt er niets te verwijderen en doet deze job niets.
     #
     # Een fork-PR heeft nooit gebouwd of gedeployd, dus er valt niets op te
     # ruimen en de GHCR-aanroepen zouden alleen maar op rechten stuklopen.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -530,22 +530,5 @@ jobs:
           github-admin-token: ${{ secrets.ADMIN_TOKEN }}
           comment-header: '## Preview Deployment'
 
-      - name: Prune orphaned SHA-tagged images
-        env:
-          GH_TOKEN: ${{ secrets.ADMIN_TOKEN }}
-        run: |
-          for PACKAGE in regelrecht-editor regelrecht-admin regelrecht-harvester-worker regelrecht-enrich-worker regelrecht-pipeline-api regelrecht-grafana regelrecht-lawmaking regelrecht-docs; do
-            echo "Pruning sha-only images for $PACKAGE..."
-            gh api --paginate \
-              "/orgs/${{ github.repository_owner }}/packages/container/${PACKAGE}/versions" \
-              --jq '.[] | select(
-                (.metadata.container.tags | length == 0) or
-                (.metadata.container.tags | all(startswith("sha-")))
-              ) | .id' \
-            2>/dev/null | while read -r VERSION_ID; do
-              echo "Deleting $PACKAGE version $VERSION_ID"
-              gh api --method DELETE \
-                "/orgs/${{ github.repository_owner }}/packages/container/${PACKAGE}/versions/${VERSION_ID}" \
-              2>/dev/null || true
-            done
-          done
+      # De sha-opruiming die hier stond kon het image onder productie vandaan
+      # halen en draait nu in scheduled-cleanup.yml.

--- a/.github/workflows/scheduled-cleanup.yml
+++ b/.github/workflows/scheduled-cleanup.yml
@@ -13,6 +13,9 @@ on:
 
 env:
   ZAD_PROJECT: regel-k4c
+  # Dezelfde basis-URL die zad-actions zelf als default hanteert; hier expliciet
+  # omdat de scripts hieronder er rechtstreeks naartoe praten.
+  ZAD_API_BASE: https://operations-manager.rig.prd1.gn2.quattro.rijksapps.nl/api
 
 jobs:
   cleanup-stale-previews:
@@ -26,8 +29,7 @@ jobs:
       pull-requests: read
 
     steps:
-      # Voor script/check-preview-environments.sh onderaan; de opruimactie zelf
-      # heeft de boom niet nodig.
+      # Voor de scripts hieronder; de opruimactie zelf heeft de boom niet nodig.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 1
@@ -45,21 +47,33 @@ jobs:
           dry-run: ${{ inputs.dry-run || false }}
           github-admin-token: ${{ secrets.ADMIN_TOKEN }}
 
-      # De opruimactie hierboven meldt succes op basis van alleen de ZAD-kant:
-      # in zad-actions zet stap 1 `ENV_SUCCESS`, en de stappen die de
-      # GitHub-environment, de deployments en de images verwijderen raken die
-      # variabele nergens aan. Op 7 augustus 2026 sloot de run af met
-      # "Successfully cleaned 773 environment(s)" terwijl alle 773 met 404
-      # faalden. Deze stap telt de uitkomst in plaats van de melding.
-      #
-      # Op een dry-run overslaan: die verwijdert per definitie niets, dus zou
-      # hij hier altijd omvallen.
-      - name: Controleer wat er is achtergebleven
-        if: ${{ !(inputs.dry-run || false) }}
+      # De opruimactie hierboven inventariseert GitHub-environments en mist
+      # daarmee elk ZAD-deployment waarvan de environment al weg is.
+      - name: Ruim verweesde ZAD-deployments op
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-        run: script/check-preview-environments.sh
+          ZAD_API_KEY: ${{ secrets.RIG_API_KEY }}
+          ZAD_API_BASE: ${{ env.ZAD_API_BASE }}
+          ZAD_PROJECT: ${{ env.ZAD_PROJECT }}
+          DRY_RUN: ${{ inputs.dry-run || false }}
+        run: script/prune-orphaned-deployments.sh
+
+      # Draaide in cleanup-preview bij elke gesloten PR. Hier draait hij één
+      # keer per nacht, en staat een rode uitkomst in een run die iemand leest.
+      - name: Ruim image-versies op die nergens meer bij horen
+        env:
+          GH_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+          ORG: ${{ github.repository_owner }}
+          PACKAGES: >-
+            regelrecht-editor regelrecht-admin regelrecht-harvester-worker
+            regelrecht-enrich-worker regelrecht-pipeline-api regelrecht-grafana
+            regelrecht-lawmaking regelrecht-docs
+          ZAD_API_KEY: ${{ secrets.RIG_API_KEY }}
+          ZAD_API_BASE: ${{ env.ZAD_API_BASE }}
+          ZAD_PROJECT: ${{ env.ZAD_PROJECT }}
+          DRY_RUN: ${{ inputs.dry-run || false }}
+        run: script/prune-preview-images.sh
 
       - name: Cleanup stale container images
         env:
@@ -90,3 +104,24 @@ jobs:
                 fi
               done
           done
+
+      # De opruimactie meldt succes op basis van alleen de ZAD-kant, dus deze
+      # twee tellen de uitkomst. Achteraan en met !cancelled(), zodat een rode
+      # controle de opruiming erboven niet meesleept. Op een dry-run overslaan:
+      # die verwijdert niets, dus zouden ze altijd omvallen.
+      - name: Controleer wat er is achtergebleven
+        if: ${{ !cancelled() && !(inputs.dry-run || false) }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: script/check-preview-environments.sh
+
+      - name: Controleer of er ZAD-deployments zijn achtergebleven
+        if: ${{ !cancelled() && !(inputs.dry-run || false) }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ZAD_API_KEY: ${{ secrets.RIG_API_KEY }}
+          ZAD_API_BASE: ${{ env.ZAD_API_BASE }}
+          ZAD_PROJECT: ${{ env.ZAD_PROJECT }}
+        run: script/check-preview-deployments.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -126,6 +126,27 @@ repos:
         pass_filenames: false
         files: ^(script/check-preview-environments(\.test)?\.sh|\.github/workflows/scheduled-cleanup\.yml)$
 
+      - id: preview-deployments-tests
+        name: Controle op achtergebleven ZAD-deployments doet wat hij belooft
+        entry: script/check-preview-deployments.test.sh
+        language: system
+        pass_filenames: false
+        files: ^(script/check-preview-deployments(\.test)?\.sh|\.github/workflows/scheduled-cleanup\.yml)$
+
+      - id: orphaned-deployments-tests
+        name: Opruimen van verweesde deployments raakt niets van een open PR
+        entry: script/prune-orphaned-deployments.test.sh
+        language: system
+        pass_filenames: false
+        files: ^(script/prune-orphaned-deployments(\.test)?\.sh|\.github/workflows/scheduled-cleanup\.yml)$
+
+      - id: preview-images-tests
+        name: Opruimen van images laat draaiende versies staan
+        entry: script/prune-preview-images.test.sh
+        language: system
+        pass_filenames: false
+        files: ^(script/prune-preview-images(\.test)?\.sh|\.github/workflows/scheduled-cleanup\.yml)$
+
       - id: advisories-report-tests
         name: Advisory-melding komt aan en niet dubbel
         entry: script/report-advisories.test.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -482,6 +482,23 @@ and they do nothing on a PR without `deploy:preview`.
 Fork PRs stay out of the chain regardless of labels; they have no secrets and a
 read-only `GITHUB_TOKEN`, so the push to GHCR could never succeed.
 
+### Opruimen
+
+Productie draait op een `sha-`-tag, niet op `latest`. Een opruiming die op de
+tagvorm afgaat kan dus het image onder de draaiende deployment vandaan halen;
+`script/prune-preview-images.sh` toetst daarom aan wat ZAD op dat moment draait
+en verwijdert niets als het die lijst niet krijgt. Hij draait in
+`scheduled-cleanup.yml` en niet bij elke gesloten pull request.
+
+De opruiming inventariseert GitHub-environments, en mist daarmee elk
+ZAD-deployment waarvan de environment al weg is.
+`script/prune-orphaned-deployments.sh` inventariseert andersom;
+`check-preview-deployments.sh` en `check-preview-environments.sh` stellen daarna
+vast wat er werkelijk over is, want de melding van een opruiming zegt hier niets
+over de uitkomst.
+
+De redenering achter elke regel staat in de kop van het betreffende script.
+
 ### Debugging deploy-preview failures
 
 ZAD deploy timeouts ("Task did not complete within 300s") almost always indicate an **application error**, not a platform issue. When `deploy-preview` fails:

--- a/script/check-preview-deployments.sh
+++ b/script/check-preview-deployments.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Het spiegelbeeld van check-preview-environments.sh: geen `prN`-deployment in
+# ZAD mag nog bij een gesloten pull request horen. De opruiming inventariseert
+# GitHub-environments, dus wat geen environment meer heeft valt daar buiten
+# beeld en blijft draaien.
+#
+# Deze poort telt wat er staat, niet wat er is gemeld, en draait dus ná de
+# opruiming. Het verwijderen bij ZAD is asynchroon, vandaar de wachtlus.
+set -uo pipefail
+
+: "${REPO:?REPO is verplicht}"
+: "${ZAD_API_KEY:?ZAD_API_KEY is verplicht}"
+: "${ZAD_API_BASE:?ZAD_API_BASE is verplicht}"
+: "${ZAD_PROJECT:?ZAD_PROJECT is verplicht}"
+
+WAIT_SECONDS="${WAIT_SECONDS:-180}"
+POLL_INTERVAL="${POLL_INTERVAL:-15}"
+
+# Nul open PR's kan kloppen, maar het is ook wat een mislukte aanroep oplevert,
+# en dan zou elk deployment hieronder ten onrechte als achtergebleven gelden.
+mapfile -t open_prs < <(
+    gh pr list --repo "${REPO}" --state open --limit 1000 --json number \
+        --jq '.[] | "pr\(.number)"' 2>/dev/null | sort -u
+)
+
+if [ "${#open_prs[@]}" -eq 0 ]; then
+    echo "::error title=Preview-opruiming::kon de open pull requests niet opvragen; de controle zegt zonder die lijst niets."
+    exit 1
+fi
+
+seen=0
+stale=()
+
+# Vult `seen` en `stale`. Status 2: niet op te halen. Status 3: opgehaald maar
+# geen deployments-lijst, wat als lege lijst zou doorgaan voor "niets te doen".
+read_state() {
+    local json previews preview open keep
+    json="$(
+        curl -sS --fail-with-body --max-time 60 -H "X-API-Key: ${ZAD_API_KEY}" \
+            "${ZAD_API_BASE}/v2/projects/${ZAD_PROJECT}/deployments"
+    )" || return 2
+
+    # Een 200 met een foutlichaam levert een lege lijst op, en dat zou hier als
+    # "niets achtergebleven" gelden.
+    jq -e 'has("deployments")' <<<"$json" >/dev/null 2>&1 || return 3
+
+    mapfile -t previews < <(
+        jq -r '.deployments[]?.name // empty' <<<"$json" |
+            grep -E '^pr[0-9]+$' | sort -u
+    )
+
+    seen=${#previews[@]}
+    stale=()
+    for preview in "${previews[@]}"; do
+        keep=false
+        for open in "${open_prs[@]}"; do
+            [ "$preview" = "$open" ] && keep=true && break
+        done
+        [ "$keep" = false ] && stale+=("$preview")
+    done
+    # Zonder dit is de status die van de laatste `&&`, en dat leest de
+    # aanroeper als een mislukte opvraging.
+    return 0
+}
+
+deadline=$((SECONDS + WAIT_SECONDS))
+while true; do
+    read_state
+    case $? in
+        0) ;;
+        3)
+            echo "::error title=Preview-opruiming::het antwoord van ZAD bevat geen deployments-lijst; zonder die lijst zegt deze controle niets."
+            exit 1
+            ;;
+        *)
+            echo "::error title=Preview-opruiming::kon de deployments niet opvragen bij ZAD; zonder die lijst zegt deze controle niets."
+            exit 1
+            ;;
+    esac
+
+    [ "${#stale[@]}" -eq 0 ] && break
+    [ "$SECONDS" -ge "$deadline" ] && break
+
+    echo "nog ${#stale[@]} te gaan (${stale[*]}); opnieuw over ${POLL_INTERVAL}s"
+    sleep "$POLL_INTERVAL"
+done
+
+echo "prN-deployments in ZAD: ${seen}, waarvan bij een open PR: $((seen - ${#stale[@]}))"
+
+if [ "${#stale[@]}" -gt 0 ]; then
+    echo "::error title=Preview-opruiming::${#stale[@]} ZAD-deployment(s) horen bij een gesloten pull request en draaien nog na ${WAIT_SECONDS}s. De opruiming kan hier succes voor gemeld hebben; die melding komt uit de ZAD-API en niet uit de uitkomst."
+    printf '  %s\n' "${stale[@]}"
+    exit 1
+fi
+
+echo "Niets achtergebleven."

--- a/script/check-preview-deployments.test.sh
+++ b/script/check-preview-deployments.test.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Dekt elk pad dat groen of rood beslist in script/check-preview-deployments.sh,
+# met stubs voor `gh` en `curl` op PATH. Een controle die altijd doorlaat is
+# zonder deze test niet te onderscheiden van een die werkt, en dat is precies de
+# fout die deze controle bij de opruiming zelf blootlegt.
+set -uo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+gate="$here/check-preview-deployments.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+pass=0
+fail=0
+
+# $1 = deploymentnamen (spatiegescheiden), $2 = curl-exitcode.
+stub_curl() {
+    local names="$1" rc="${2:-0}" body="" n
+    if [ "$names" = "__ERROR_BODY__" ]; then
+        cat >"$tmp/curl" <<'STUB'
+#!/usr/bin/env bash
+echo '{"detail":"Not Found"}'
+STUB
+        chmod +x "$tmp/curl"
+        return
+    fi
+    for n in $names; do
+        [ -n "$body" ] && body+=","
+        body+="{\"name\":\"$n\"}"
+    done
+    cat >"$tmp/curl" <<STUB
+#!/usr/bin/env bash
+[ $rc -ne 0 ] && exit $rc
+cat <<'JSON'
+{"deployments":[$body]}
+JSON
+STUB
+    chmod +x "$tmp/curl"
+}
+
+# $1 = open PR-nummers.
+stub_gh() {
+    cat >"$tmp/gh" <<STUB
+#!/usr/bin/env bash
+# Toetst de vraag die gesteld wordt. Zonder deze controle overleeft een mutatie
+# van --state open naar --state closed elke test, terwijl dat precies de regel
+# is die bepaalt wat behouden blijft.
+case " \$* " in
+    *" --state open "*) ;;
+    *) echo "stub: onverwachte gh-aanroep: \$*" >&2; exit 64 ;;
+esac
+case " \$* " in
+    *" --repo o/r "*) ;;
+    *) echo "stub: verkeerde repo: \$*" >&2; exit 64 ;;
+esac
+for n in $1; do echo "pr\$n"; done
+STUB
+    chmod +x "$tmp/gh"
+}
+
+check() { # naam, verwachte exit, deployments, open-prs, curl-rc, patroon
+    local name="$1" want="$2" deps="$3" prs="$4" rc="$5" needle="${6:-}"
+    stub_curl "$deps" "$rc"
+    stub_gh "$prs"
+    local out status
+    out="$(
+        PATH="$tmp:$PATH" REPO=o/r ZAD_API_KEY=k ZAD_API_BASE=http://x \
+            ZAD_PROJECT=p WAIT_SECONDS=0 POLL_INTERVAL=0 bash "$gate" 2>&1
+    )"
+    status=$?
+
+    if [ "$status" -ne "$want" ]; then
+        echo "FAIL: $name — exit $status, verwacht $want"
+        echo "$out" | sed 's/^/    /'
+        fail=$((fail + 1))
+        return
+    fi
+    if [ -n "$needle" ] && ! grep -qF "$needle" <<<"$out"; then
+        echo "FAIL: $name — '$needle' niet in de uitvoer"
+        echo "$out" | sed 's/^/    /'
+        fail=$((fail + 1))
+        return
+    fi
+    echo "ok: $name"
+    pass=$((pass + 1))
+}
+
+check "alleen deployments van open PR's is schoon" 0 \
+    "pr10 pr11" "10 11" 0 "Niets achtergebleven"
+
+check "een deployment van een gesloten PR is rood" 1 \
+    "pr10 pr99" "10" 0 "pr99"
+
+check "productie en upload tellen niet mee" 0 \
+    "regelrecht upload pr10" "10" 0 "Niets achtergebleven"
+
+# Namen die op "pr" lijken maar geen preview zijn; zonder deze zou een te ruime
+# grep ongemerkt doorglippen.
+check "prod en preview-shared zijn geen previews" 0 \
+    "prod preview-shared pr10-db PR10 pr10" "10" 0 "Niets achtergebleven"
+
+check "geen enkel deployment is schoon" 0 \
+    "regelrecht" "10" 0 "Niets achtergebleven"
+
+check "een onbereikbare ZAD-API is rood, niet groen" 1 \
+    "pr10" "10" 7 "kon de deployments niet opvragen"
+
+# Een 200 met een foutlichaam gaf voorheen een lege lijst en dus "niets
+# achtergebleven": een poort die altijd doorlaat.
+check "een 200 zonder deployments-lijst is rood" 1 \
+    "__ERROR_BODY__" "10" 0 "bevat geen deployments-lijst"
+
+# Zonder de lijst met open PR's zou elk deployment als achtergebleven gelden;
+# dat moet een fout zijn en geen lawine van valse meldingen.
+check "geen open PR's opgehaald is rood" 1 \
+    "pr10" "" 0 "kon de open pull requests niet opvragen"
+
+echo
+echo "geslaagd: $pass, gefaald: $fail"
+[ "$fail" -eq 0 ]

--- a/script/prune-orphaned-deployments.sh
+++ b/script/prune-orphaned-deployments.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Verwijdert `prN`-deployments in ZAD die bij een gesloten pull request horen.
+# De bestaande opruiming inventariseert GitHub-environments en mist daarmee
+# alles waarvan de environment al weg is; dit script kijkt andersom.
+#
+# check-preview-deployments.sh stelt daarna vast wat er werkelijk overblijft.
+set -uo pipefail
+
+: "${REPO:?REPO is verplicht}"
+: "${ZAD_API_KEY:?ZAD_API_KEY is verplicht}"
+: "${ZAD_API_BASE:?ZAD_API_BASE is verplicht}"
+: "${ZAD_PROJECT:?ZAD_PROJECT is verplicht}"
+
+DRY_RUN="${DRY_RUN:-false}"
+
+deployments_json="$(
+    curl -sS --fail-with-body --max-time 60 -H "X-API-Key: ${ZAD_API_KEY}" \
+        "${ZAD_API_BASE}/v2/projects/${ZAD_PROJECT}/deployments"
+)" || {
+    echo "::error title=Preview-opruiming::kon de deployments niet opvragen bij ZAD."
+    exit 1
+}
+
+# Een 200 met een foutlichaam levert een lege lijst op, en dat zou hier als
+# "niets te doen" gelden.
+if ! jq -e 'has("deployments")' <<<"$deployments_json" >/dev/null 2>&1; then
+    echo "::error title=Preview-opruiming::het antwoord van ZAD bevat geen deployments-lijst."
+    exit 1
+fi
+
+mapfile -t previews < <(
+    jq -r '.deployments[]?.name // empty' <<<"$deployments_json" |
+        grep -E '^pr[0-9]+$' | sort -u
+)
+
+if [ "${#previews[@]}" -eq 0 ]; then
+    echo "Geen prN-deployments in ZAD."
+    exit 0
+fi
+
+# Nul open PR's kan kloppen, maar het is ook wat een mislukte aanroep oplevert.
+# Zonder die lijst zou dit script elk preview-deployment verwijderen, inclusief
+# die van pull requests waar iemand op dat moment naar kijkt.
+mapfile -t open_prs < <(
+    gh pr list --repo "${REPO}" --state open --limit 1000 --json number \
+        --jq '.[] | "pr\(.number)"' 2>/dev/null | sort -u
+)
+
+if [ "${#open_prs[@]}" -eq 0 ]; then
+    echo "::error title=Preview-opruiming::kon de open pull requests niet opvragen; er wordt niets verwijderd."
+    exit 1
+fi
+
+removed=0
+for preview in "${previews[@]}"; do
+    keep=false
+    for open in "${open_prs[@]}"; do
+        [ "$preview" = "$open" ] && keep=true && break
+    done
+    [ "$keep" = true ] && continue
+
+    if [ "$DRY_RUN" = true ]; then
+        echo "  zou verwijderen: ${preview}"
+        removed=$((removed + 1))
+        continue
+    fi
+
+    # De padvorm wijkt af van die bij het lezen: geen `/deployments/` ertussen.
+    # Overgenomen uit `ZadClient.delete_deployment` in zad-cli 0.9.1.
+    if curl -sS --fail-with-body --max-time 120 -X DELETE \
+        -H "X-API-Key: ${ZAD_API_KEY}" \
+        "${ZAD_API_BASE}/v2/projects/${ZAD_PROJECT}/${preview}" >/dev/null; then
+        echo "  verwijdering aangevraagd: ${preview}"
+        removed=$((removed + 1))
+    else
+        echo "::warning title=Preview-opruiming::${preview} kon niet worden verwijderd."
+    fi
+done
+
+echo "Verweesde deployments opgeruimd: ${removed}."

--- a/script/prune-orphaned-deployments.test.sh
+++ b/script/prune-orphaned-deployments.test.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Dekt elk pad dat bepaalt of er een deployment verdwijnt. De curl-stub schrijft
+# elke DELETE weg, zodat de test afgaat op wat er werkelijk zou zijn verwijderd
+# en niet op wat het script erover meldt.
+set -uo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+script="$here/prune-orphaned-deployments.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+pass=0
+fail=0
+
+# $1 = deploymentnamen (spatiegescheiden), $2 = exitcode voor de GET.
+stub_curl() {
+    local names="$1" rc="${2:-0}" body="" n
+    for n in $names; do
+        [ -n "$body" ] && body+=","
+        body+="{\"name\":\"$n\"}"
+    done
+    cat >"$tmp/curl" <<STUB
+#!/usr/bin/env bash
+for arg in "\$@"; do
+    if [ "\$arg" = "DELETE" ]; then
+        echo "\${@: -1}" >>"$tmp/deleted"
+        exit 0
+    fi
+done
+[ $rc -ne 0 ] && exit $rc
+cat <<'JSON'
+{"deployments":[$body]}
+JSON
+STUB
+    chmod +x "$tmp/curl"
+}
+
+# $1 = open PR-nummers.
+stub_gh() {
+    cat >"$tmp/gh" <<STUB
+#!/usr/bin/env bash
+# Toetst de vraag die gesteld wordt. Zonder deze controle overleeft een mutatie
+# van --state open naar --state closed elke test, terwijl dat precies de regel
+# is die bepaalt wat behouden blijft.
+case " \$* " in
+    *" --state open "*) ;;
+    *) echo "stub: onverwachte gh-aanroep: \$*" >&2; exit 64 ;;
+esac
+case " \$* " in
+    *" --repo o/r "*) ;;
+    *) echo "stub: verkeerde repo: \$*" >&2; exit 64 ;;
+esac
+for n in $1; do echo "pr\$n"; done
+STUB
+    chmod +x "$tmp/gh"
+}
+
+check() { # naam, verwachte exit, deployments, open-prs, verwachte-deletes, curl-rc
+    local name="$1" want="$2" deps="$3" prs="$4" want_del="$5" crc="${6:-0}"
+    : >"$tmp/deleted"
+    stub_curl "$deps" "$crc"
+    stub_gh "$prs"
+
+    local out status actual
+    out="$(
+        PATH="$tmp:$PATH" REPO=o/r ZAD_API_KEY=k ZAD_API_BASE=http://x \
+            ZAD_PROJECT=proj bash "$script" 2>&1
+    )"
+    status=$?
+    actual="$(tr '\n' ' ' <"$tmp/deleted" | sed 's/ *$//')"
+
+    if [ "$status" -ne "$want" ]; then
+        echo "FAIL: $name — exit $status, verwacht $want"
+        echo "$out" | sed 's/^/    /'
+        fail=$((fail + 1))
+        return
+    fi
+    if [ "$actual" != "$want_del" ]; then
+        echo "FAIL: $name — verwijderd '[$actual]', verwacht '[$want_del]'"
+        echo "$out" | sed 's/^/    /'
+        fail=$((fail + 1))
+        return
+    fi
+    echo "ok: $name"
+    pass=$((pass + 1))
+}
+
+check "een preview van een gesloten PR gaat weg" 0 \
+    "pr99" "10" "http://x/v2/projects/proj/pr99"
+
+check "een preview van een open PR blijft staan" 0 \
+    "pr10" "10" ""
+
+check "productie en upload blijven altijd staan" 0 \
+    "regelrecht upload" "10" ""
+
+check "geen prN-deployments is niets te doen" 0 \
+    "regelrecht" "10" ""
+
+# Zonder de lijst met open PR's zou elk preview-deployment weggaan, ook die van
+# pull requests waar op dat moment iemand naar kijkt.
+check "geen open PR's opgehaald verwijdert niets" 1 \
+    "pr10 pr99" "" ""
+
+check "een onbereikbare ZAD-API verwijdert niets" 1 \
+    "pr99" "10" "" 7
+
+echo
+echo "geslaagd: $pass, gefaald: $fail"
+[ "$fail" -eq 0 ]

--- a/script/prune-preview-images.sh
+++ b/script/prune-preview-images.sh
@@ -40,10 +40,11 @@ fi
 # zou een registry met poort of een digest-pin een niet-bestaande "tag"
 # opleveren, en geen match betekent hier: mag weg.
 #
-# jq faalt hard (`-e`) omdat een half gelezen lijst gevaarlijker is dan een
-# lege: de leegte-controle hieronder vangt hem niet.
+# Zonder `-e`, anders geeft jq ook status non-zero als er domweg geen images
+# in staan en meldt dit pad "onleesbaar" terwijl de leegte-controle hieronder
+# de juiste diagnose heeft. Een echte jq-fout blijft wel non-zero.
 images_raw="$(
-    jq -re '.deployments[]?.components[]?.image // empty' <<<"$deployments_json"
+    jq -r '.deployments[]?.components[]?.image // empty' <<<"$deployments_json"
 )" || {
     echo "::error title=Image-opruiming::het antwoord van ZAD is niet te lezen als een lijst draaiende images; er wordt niets verwijderd."
     exit 1

--- a/script/prune-preview-images.sh
+++ b/script/prune-preview-images.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Verwijdert een image-versie alleen als alle drie gelden: elke tag heeft de
+# `sha-`-vorm, geen tag draait in ZAD, en de versie is ouder dan
+# RETENTION_DAYS. Die laatste dekt de race met een deploy die doorschuift
+# tussen het opvragen en het verwijderen.
+#
+# Productie draait op een sha-tag, dus alleen op de tagvorm afgaan zou het image
+# onder de draaiende deployment vandaan halen. Lukt het opvragen van die lijst
+# niet, dan verwijdert dit script niets.
+#
+# Versies zonder tags blijven staan: single-arch builds, dus dat is buildcache.
+set -uo pipefail
+
+: "${ORG:?ORG is verplicht}"
+: "${PACKAGES:?PACKAGES is verplicht (spatiegescheiden)}"
+: "${ZAD_API_KEY:?ZAD_API_KEY is verplicht}"
+: "${ZAD_API_BASE:?ZAD_API_BASE is verplicht}"
+: "${ZAD_PROJECT:?ZAD_PROJECT is verplicht}"
+
+RETENTION_DAYS="${RETENTION_DAYS:-7}"
+DRY_RUN="${DRY_RUN:-false}"
+
+# Een lege lijst is niet "er draait niets"; het is ook wat een verlopen sleutel
+# of een foutpagina oplevert, en dan zou elke sha-tag als ongebruikt gelden.
+# Vandaar --fail-with-body en de vormcontrole hieronder.
+deployments_json="$(
+    curl -sS --fail-with-body --max-time 60 -H "X-API-Key: ${ZAD_API_KEY}" \
+        "${ZAD_API_BASE}/v2/projects/${ZAD_PROJECT}/deployments"
+)" || {
+    echo "::error title=Image-opruiming::kon de draaiende deployments niet opvragen bij ZAD; er wordt niets verwijderd."
+    exit 1
+}
+
+if ! jq -e 'has("deployments")' <<<"$deployments_json" >/dev/null 2>&1; then
+    echo "::error title=Image-opruiming::het antwoord van ZAD bevat geen deployments-lijst; er wordt niets verwijderd."
+    exit 1
+fi
+
+# De tag staat na de laatste `:` in het laatste padsegment. Op de hele URL
+# zou een registry met poort of een digest-pin een niet-bestaande "tag"
+# opleveren, en geen match betekent hier: mag weg.
+#
+# jq faalt hard (`-e`) omdat een half gelezen lijst gevaarlijker is dan een
+# lege: de leegte-controle hieronder vangt hem niet.
+images_raw="$(
+    jq -re '.deployments[]?.components[]?.image // empty' <<<"$deployments_json"
+)" || {
+    echo "::error title=Image-opruiming::het antwoord van ZAD is niet te lezen als een lijst draaiende images; er wordt niets verwijderd."
+    exit 1
+}
+
+in_use=()
+while IFS= read -r image; do
+    [ -z "$image" ] && continue
+    last="${image##*/}"
+    case "$last" in
+        *@*)
+            # Digest-gepind: de tag is niet af te leiden, dus stoppen.
+            echo "::error title=Image-opruiming::ZAD rapporteert een digest-gepinde image (${image}); dit script kan dan niet vaststellen welke tag draait."
+            exit 1
+            ;;
+        *:*) in_use+=("${last##*:}") ;;
+        # Geen tag betekent latest, en die is al beschermd: niet sha-only.
+        *) in_use+=("latest") ;;
+    esac
+done <<<"$images_raw"
+
+if [ "${#in_use[@]}" -eq 0 ]; then
+    echo "::error title=Image-opruiming::ZAD gaf geen enkele draaiende image terug. Zonder die lijst is niet vast te stellen wat veilig weg kan."
+    exit 1
+fi
+
+mapfile -t in_use < <(printf '%s\n' "${in_use[@]}" | sort -u)
+
+echo "In gebruik volgens ZAD (${#in_use[@]}): ${in_use[*]}"
+
+is_in_use() {
+    local tag="$1" used
+    for used in "${in_use[@]}"; do
+        [ "$tag" = "$used" ] && return 0
+    done
+    return 1
+}
+
+cutoff="$(date -u -d "${RETENTION_DAYS} days ago" +%s)"
+deleted=0
+kept_in_use=0
+
+# --- 2. Per package langs de versies ---
+for package in ${PACKAGES}; do
+    versions="$(
+        gh api --paginate -F per_page=100 "/orgs/${ORG}/packages/container/${package}/versions"
+    )" || {
+        echo "::error title=Image-opruiming::kon de versies van ${package} niet opvragen; er wordt niets verwijderd."
+        exit 1
+    }
+
+    while read -r id updated tags; do
+        [ -z "$id" ] && continue
+
+        skip=false
+        for tag in $tags; do
+            if is_in_use "$tag"; then
+                echo "  behoud ${package} ${tag} (draait in ZAD)"
+                kept_in_use=$((kept_in_use + 1))
+                skip=true
+                break
+            fi
+        done
+        [ "$skip" = true ] && continue
+
+        # Een onleesbaar tijdstempel is een reden om over te slaan, niet om
+        # de leeftijdstoets stil te laten wegvallen.
+        if ! age="$(date -u -d "$updated" +%s 2>/dev/null)" || [ -z "$age" ]; then
+            echo "::warning title=Image-opruiming::${package} versie ${id} heeft een onleesbare datum (${updated}); overgeslagen."
+            continue
+        fi
+        [ "$age" -gt "$cutoff" ] && continue
+
+        if [ "$DRY_RUN" = true ]; then
+            echo "  zou verwijderen: ${package} ${tags} (${updated})"
+            deleted=$((deleted + 1))
+            continue
+        fi
+
+        if gh api --method DELETE \
+            "/orgs/${ORG}/packages/container/${package}/versions/${id}"; then
+            echo "  verwijderd: ${package} ${tags}"
+            deleted=$((deleted + 1))
+        else
+            echo "::warning title=Image-opruiming::${package} versie ${id} (${tags}) kon niet worden verwijderd."
+        fi
+    done < <(
+        jq -r '
+            .[]
+            | select((.metadata.container.tags | length) > 0)
+            | select(.metadata.container.tags | all(startswith("sha-")))
+            | "\(.id) \(.updated_at) \(.metadata.container.tags | join(" "))"
+        ' <<<"$versions"
+    )
+done
+
+echo "Opgeruimd: ${deleted}. Overgeslagen omdat ze draaien: ${kept_in_use}."

--- a/script/prune-preview-images.test.sh
+++ b/script/prune-preview-images.test.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Dekt elk pad dat bepaalt of er een image-versie verdwijnt, met stubs voor
+# `curl` en `gh` op PATH. De stub schrijft elke DELETE weg, zodat de test niet
+# op de melding afgaat maar op wat er werkelijk zou zijn verwijderd.
+#
+# Het geval dat er echt toe doet staat bovenaan: een versie waarvan alle tags de
+# `sha-`-vorm hebben en die op dat moment in ZAD draait. Dat is de vorm waarin
+# productie draait, en de vorige versie van dit script zou hem hebben verwijderd.
+set -uo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+script="$here/prune-preview-images.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+pass=0
+fail=0
+
+old="$(date -u -d '30 days ago' +%Y-%m-%dT%H:%M:%SZ)"
+recent="$(date -u -d '1 day ago' +%Y-%m-%dT%H:%M:%SZ)"
+
+# $1 = images die ZAD draait (spatiegescheiden), $2 = curl-exitcode.
+stub_curl() {
+    local images="$1" rc="${2:-0}" body="" i
+    for i in $images; do
+        [ -n "$body" ] && body+=","
+        # Een waarde met een `/` erin is een volledige image-URL; anders is het
+        # alleen de tag en plakken we er een gewone URL omheen.
+        case "$i" in
+            */*) body+="{\"image\":\"$i\"}" ;;
+            *) body+="{\"image\":\"ghcr.io/o/p:$i\"}" ;;
+        esac
+    done
+    cat >"$tmp/curl" <<STUB
+#!/usr/bin/env bash
+[ $rc -ne 0 ] && exit $rc
+cat <<'JSON'
+{"deployments":[{"name":"regelrecht","components":[$body]}]}
+JSON
+STUB
+    chmod +x "$tmp/curl"
+}
+
+# $1 = versies als "id|updated|tag,tag" (spatiegescheiden), $2 = exitcode voor
+# de lijst-aanroep. Het scheidingsteken is `|` en geen `:`, want de tijdstempel
+# bevat zelf dubbele punten.
+stub_gh() {
+    local versions="$1" rc="${2:-0}" body="" v id updated tags taglist t
+    for v in $versions; do
+        IFS='|' read -r id updated tags <<<"$v"
+        taglist=""
+        if [ -n "$tags" ]; then
+            for t in ${tags//,/ }; do
+                [ -n "$taglist" ] && taglist+=","
+                taglist+="\"$t\""
+            done
+        fi
+        [ -n "$body" ] && body+=","
+        body+="{\"id\":$id,\"updated_at\":\"$updated\",\"metadata\":{\"container\":{\"tags\":[$taglist]}}}"
+    done
+    cat >"$tmp/gh" <<STUB
+#!/usr/bin/env bash
+if [ "\$1" = "api" ] && [ "\$2" = "--method" ]; then
+    echo "\$4" >>"$tmp/deleted"
+    exit 0
+fi
+[ $rc -ne 0 ] && exit $rc
+cat <<'JSON'
+[$body]
+JSON
+STUB
+    chmod +x "$tmp/gh"
+}
+
+check() { # naam, verwachte exit, in-gebruik, versies, verwachte-deletes, curl-rc, gh-rc
+    local name="$1" want="$2" used="$3" versions="$4" want_del="$5"
+    local crc="${6:-0}" grc="${7:-0}"
+    : >"$tmp/deleted"
+    stub_curl "$used" "$crc"
+    stub_gh "$versions" "$grc"
+
+    local out status actual
+    out="$(
+        PATH="$tmp:$PATH" ORG=o PACKAGES=p ZAD_API_KEY=k \
+            ZAD_API_BASE=http://x ZAD_PROJECT=proj bash "$script" 2>&1
+    )"
+    status=$?
+    actual="$(tr '\n' ' ' <"$tmp/deleted" | sed 's/ *$//')"
+
+    if [ "$status" -ne "$want" ]; then
+        echo "FAIL: $name — exit $status, verwacht $want"
+        echo "$out" | sed 's/^/    /'
+        fail=$((fail + 1))
+        return
+    fi
+    if [ "$actual" != "$want_del" ]; then
+        echo "FAIL: $name — verwijderd '[$actual]', verwacht '[$want_del]'"
+        echo "$out" | sed 's/^/    /'
+        fail=$((fail + 1))
+        return
+    fi
+    echo "ok: $name"
+    pass=$((pass + 1))
+}
+
+# De kern: dit is de vorm waarin productie draait.
+check "een sha-only image die in ZAD draait blijft staan" 0 \
+    "sha-abc" "1|$old|sha-abc" ""
+
+check "een sha-only image dat nergens draait en oud is gaat weg" 0 \
+    "sha-abc" "2|$old|sha-def" "/orgs/o/packages/container/p/versions/2"
+
+check "een sha-only image dat te jong is blijft staan" 0 \
+    "sha-abc" "3|$recent|sha-def" ""
+
+check "latest beschermt de versie" 0 \
+    "sha-abc" "4|$old|sha-def,latest" ""
+
+check "een pr-tag beschermt de versie" 0 \
+    "sha-abc" "5|$old|pr-123" ""
+
+# Single-arch builds: een versie zonder tags is de buildcache in GHCR, geen
+# onderdeel van een multi-arch manifest.
+check "een versie zonder tags blijft staan" 0 \
+    "sha-abc" "6|$old|" ""
+
+check "meerdere sha-tags waarvan er één draait beschermt de versie" 0 \
+    "sha-abc" "7|$old|sha-def,sha-abc" ""
+
+# Zonder te weten wat er draait mag er niets weg; dat was de fout van de
+# vorige versie, die de 403 in /dev/null gooide en gewoon doorging.
+check "een onbereikbare ZAD-API verwijdert niets" 1 \
+    "sha-abc" "8|$old|sha-def" "" 7
+
+check "een lege lijst draaiende images verwijdert niets" 1 \
+    "" "9|$old|sha-def" ""
+
+check "een mislukte versie-opvraag verwijdert niets" 1 \
+    "sha-abc" "10|$old|sha-def" "" 0 1
+
+# De tag zit in het laatste padsegment. Op de hele URL zou de poort als tag
+# gelezen worden en beschermt de lijst niets meer.
+check "een registry met een poort verandert niets aan de bescherming" 0 \
+    "registry.internal:5000/o/p:sha-abc" "11|$old|sha-abc" ""
+
+# Bij een digest is de draaiende tag niet af te leiden; doorgaan zou de
+# bescherming stil uitschakelen.
+check "een digest-gepinde image stopt het script" 1 \
+    "ghcr.io/o/p@sha256:deadbeef" "12|$old|sha-abc" ""
+
+check "een onleesbare datum slaat de versie over" 0 \
+    "sha-abc" "13|null|sha-def" ""
+
+echo
+echo "geslaagd: $pass, gefaald: $fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
De sha-opruiming in `cleanup-preview` verwijderde elke image-versie waarvan alle tags met `sha-` beginnen, over acht packages heen. Productie draait op zo'n tag en niet op `latest`, dus zodra een main-build `latest` doorschuift houdt de draaiende image alleen zijn sha-tag over en voldoet hij aan dat criterium. De eerstvolgende gesloten pull request had het image dan onder productie vandaan gehaald. Dat het nooit gebeurde komt doordat het token `read:packages` mist en de 403 in `/dev/null` verdween; het repareren van dat token (#1213) zou de stap voor het eerst echt laten lopen.

Wat er nu weg mag, toetst het script aan wat ZAD op dat moment draait: alleen versies die sha-only zijn, nergens in gebruik, en ouder dan een week. Lukt het opvragen van die lijst niet, dan gaat er niets weg. De stap verhuist naar de nachtelijke run, waar hij een keer per nacht draait in plaats van bij elke merge, het script van main komt in plaats van uit de pull request, en een rode uitkomst in een run staat die iemand leest.

Daarnaast bleven op 10 augustus negentien preview-deployments draaien, waarvan acht van pull requests die drie dagen eerder waren gemerged — met een `cleanup-preview` die voor elk van die acht `deleted successfully` had gelogd. De opruiming inventariseert GitHub-environments en zoekt daar het ZAD-deployment bij, dus wat geen environment meer heeft komt in geen enkele lijst voor. De nachtelijke run kijkt nu ook andersom, vanuit ZAD, en de twee controles staan achteraan zodat een rode de opruiming erboven niet meesleept.

Drie scripts met tests ernaast, in dezelfde vorm als de bestaande poorten. De `gh`-stub toetst de argumenten die het script meegeeft: zonder dat overleefde een mutatie van `--state open` naar `--state closed` alle tests, terwijl dat de regel is die bepaalt wat behouden blijft.